### PR TITLE
chore: update brew install command to use --cask flag

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -87,7 +87,7 @@ jobs:
           python3 - <<'PYEOF'
           import re, os
 
-          formula_path = "homebrew-tap/Formula/longbridge-terminal.rb"
+          formula_path = "homebrew-tap/Casks/longbridge-terminal.rb"
           version  = os.environ["VERSION"]
           tag      = os.environ["TAG"]
           repo     = os.environ["REPO"]
@@ -128,7 +128,7 @@ jobs:
           PYEOF
 
           echo "--- Updated formula ---"
-          cat homebrew-tap/Formula/longbridge-terminal.rb
+          cat homebrew-tap/Casks/longbridge-terminal.rb
 
       - name: Create pull request
         env:
@@ -144,7 +144,7 @@ jobs:
 
           BRANCH="bump/longbridge-terminal-${VERSION}"
           git checkout -b "$BRANCH"
-          git add Formula/longbridge-terminal.rb
+          git add Casks/longbridge-terminal.rb
 
           if git diff --cached --quiet; then
             echo "No changes detected — formula is already up to date"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Also ships a full-screen TUI for interactive monitoring.
 **Homebrew (macOS / Linux)**
 
 ```bash
-brew install longbridge/tap/longbridge-terminal
+brew install --cask longbridge/tap/longbridge-terminal
 ```
 
 **Install script**


### PR DESCRIPTION
## Summary

- Update `README.md` brew install command to `brew install --cask`
- Update `update-homebrew.yml` workflow to reference `Casks/` directory instead of `Formula/`

Follows the migration of longbridge/homebrew-tap from Formula to Cask.