### PR TITLE
fix: improve install script robustness and temp dir handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "longbridge-terminal"
-version = "0.8.2"
+version = "0.8.3"
 
 [[bin]]
 name = "longbridge"

--- a/install
+++ b/install
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -u
+set -eu
 type curl > /dev/null || { echo "curl: not found"; exit 1; }
 
 repo='longbridge/longbridge-terminal'
@@ -51,16 +51,17 @@ fi
 download_url=https://github.com/longbridge/longbridge-terminal/releases/download/$version/$package_name-$platform$libc-$arch.tar.gz
 echo $download_url
 
-curl -Lo $bin_name.tar.gz $download_url
-tar zxf $bin_name.tar.gz
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+curl -Lo "$tmp_dir/$bin_name.tar.gz" $download_url
+tar zxf "$tmp_dir/$bin_name.tar.gz" -C "$tmp_dir"
 
 if test $(id -u) -eq 0; then
-  mv $bin_name /usr/local/bin/$bin_name
+  mv "$tmp_dir/$bin_name" /usr/local/bin/$bin_name
 else
-  sudo mv $bin_name /usr/local/bin/$bin_name
+  sudo mv "$tmp_dir/$bin_name" /usr/local/bin/$bin_name
 fi
-
-rm $bin_name.tar.gz
 echo "Longbridge CLI $version has installed successfully."
 echo ""
 echo "You can use \`longbridge -h\` to get help."


### PR DESCRIPTION
## Summary

- Add `-e` to `set -eu` so any command failure (curl, tar, mv, etc.) exits immediately — prevents printing "installed successfully" after a failed step
- Download and extract to a temp dir (`mktemp -d`) instead of the current directory, avoiding permission errors when CWD is `/` or other restricted paths
- Use `trap 'rm -rf "$tmp_dir"' EXIT` for automatic cleanup on both success and failure

## Test plan

- [ ] Run install script from `/` to verify no permission error during download
- [ ] Simulate a failed download (bad URL) and verify script exits without printing success message