### PR TITLE
fix: simplify create-topic response to only parse topic id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,7 +2038,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#ed0b1e79108702c85cb2361e3983e19f7922d7a6"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2073,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#ed0b1e79108702c85cb2361e3983e19f7922d7a6"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#ed0b1e79108702c85cb2361e3983e19f7922d7a6"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2093,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#ed0b1e79108702c85cb2361e3983e19f7922d7a6"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#ed0b1e79108702c85cb2361e3983e19f7922d7a6"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#ed0b1e79108702c85cb2361e3983e19f7922d7a6"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2195,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#ed0b1e79108702c85cb2361e3983e19f7922d7a6"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
 dependencies = [
  "byteorder",
  "flate2",

--- a/src/cli/topic.rs
+++ b/src/cli/topic.rs
@@ -139,19 +139,18 @@ pub async fn cmd_create_topic(
         hashtags: None,
         license: None,
     };
-    let item = crate::openapi::content().create_topic(opts).await?;
+    let id = crate::openapi::content().create_topic(opts).await?;
 
     if matches!(format, OutputFormat::Json) {
         println!(
             "{}",
-            serde_json::to_string_pretty(&owned_topic_to_json(&item)).unwrap_or_default()
+            serde_json::to_string_pretty(&serde_json::json!({ "id": id })).unwrap_or_default()
         );
         return Ok(());
     }
 
     println!("Topic created successfully.");
-    println!("  ID:   {}", item.id);
-    println!("  URL:  https://longbridge.com/topics/{}", item.id);
-    println!("  Type: {}", item.topic_type);
+    println!("  ID:   {id}");
+    println!("  URL:  https://longbridge.com/topics/{id}");
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Updated `longbridge` SDK dependency to latest `main` (which includes the `fix/create-topic-return-id` merge)
- Adapted `cmd_create_topic` to the new SDK API: `create_topic` now returns `String` (topic id only) instead of `OwnedTopic`
- Removed complex response parsing that was failing due to missing `license` field in the API response

## Test plan

- [x] Tested with `longbridge create-topic --type article` — successfully creates topic and returns ID and URL