### PR TITLE
fix: update my-topics API names and parse stock tags in descriptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Longbridge CLI
+# Contributing to Longbridge Terminal
 
-Thank you for your interest in contributing to Longbridge CLI! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to Longbridge Terminal! This document provides guidelines and instructions for contributing.
 
 ## Getting Started
 
@@ -15,15 +15,8 @@ Thank you for your interest in contributing to Longbridge CLI! This document pro
 1. **Clone the repository**:
 
    ```bash
-   git clone https://github.com/longbridge/longbridge-cli.git
-   cd longbridge-cli
-   ```
-
-2. **Configure API credentials**:
-
-   ```bash
-   cp .env.example .env
-   # Edit .env with your Longbridge OpenAPI credentials
+   git clone https://github.com/longbridge/longbridge-terminal.git
+   cd longbridge-terminal
    ```
 
 3. **Build and run**:
@@ -184,11 +177,6 @@ This project uses [Ratatui](https://ratatui.rs/) for the TUI. For Ratatui-specif
 - **Rust SDK**: [SDK Documentation](https://longbridge.github.io/openapi/rust/longbridge/)
 
 ### Debugging
-
-Logs are written to:
-
-- macOS: `~/Library/Logs/longbridge-cli/`
-- Linux: `~/.local/share/longbridge-cli/logs/`
 
 Enable debug logging:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1074,7 +1074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2038,7 +2038,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#c538b8b342f5aae3c89a43c48d6830c59d5234e8"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2073,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#c538b8b342f5aae3c89a43c48d6830c59d5234e8"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#c538b8b342f5aae3c89a43c48d6830c59d5234e8"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2093,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#c538b8b342f5aae3c89a43c48d6830c59d5234e8"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#c538b8b342f5aae3c89a43c48d6830c59d5234e8"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#c538b8b342f5aae3c89a43c48d6830c59d5234e8"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2195,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.0.5"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#fb37a062e9cb500de8d95d0f08ee104b81745706"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#c538b8b342f5aae3c89a43c48d6830c59d5234e8"
 dependencies = [
  "byteorder",
  "flate2",
@@ -2415,7 +2415,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2835,7 +2835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -2922,7 +2922,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3339,7 +3339,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3919,7 +3919,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4666,7 +4666,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src/cli/news.rs
+++ b/src/cli/news.rs
@@ -271,7 +271,7 @@ pub async fn cmd_topics(symbol: String, count: usize, format: &OutputFormat) -> 
                 serde_json::json!({
                     "id": item.id,
                     "title": item.title,
-                    "description": item.description,
+                    "description": crate::cli::topic::replace_stock_tags(&item.description),
                     "url": item.url,
                     "published_at": item.published_at.unix_timestamp(),
                     "likes_count": item.likes_count,

--- a/src/cli/topic.rs
+++ b/src/cli/topic.rs
@@ -1,9 +1,37 @@
 use anyhow::Result;
-use longbridge::content::{CreateTopicOptions, ListMyTopicsOptions, OwnedTopic};
+use longbridge::content::{CreateTopicOptions, MyTopicsOptions, OwnedTopic};
 use regex::Regex;
 use time::OffsetDateTime;
 
 use super::{output::print_table, OutputFormat};
+
+/// Replace `[st]ST/MARKET/SYMBOL#...[/st]` tags in topic text with ticker symbols like `TSLA.US`.
+pub fn replace_stock_tags(text: &str) -> String {
+    let mut result = String::new();
+    let mut remaining = text;
+    while let Some(start) = remaining.find("[st]") {
+        result.push_str(&remaining[..start]);
+        let after_open = &remaining[start + 4..];
+        let Some(end) = after_open.find("[/st]") else {
+            result.push_str("[st]");
+            result.push_str(after_open);
+            return result;
+        };
+        let inner = &after_open[..end];
+        // Format: ST/MARKET/SYMBOL#DisplayName or ST/MARKET/SYMBOL
+        let code = inner.split('#').next().unwrap_or(inner);
+        let parts: Vec<&str> = code.split('/').collect();
+        if parts.len() >= 3 {
+            let ticker = format!("{}.{}", parts[2].to_uppercase(), parts[1].to_uppercase());
+            result.push_str(&ticker);
+        } else {
+            result.push_str(inner);
+        }
+        remaining = &after_open[end + 5..];
+    }
+    result.push_str(remaining);
+    result
+}
 
 fn format_datetime(dt: OffsetDateTime) -> String {
     format!(
@@ -27,7 +55,6 @@ fn owned_topic_to_json(item: &OwnedTopic) -> serde_json::Value {
         "comments_count": item.comments_count,
         "views_count": item.views_count,
         "shares_count": item.shares_count,
-        "license": item.license,
         "url": format!("https://longbridge.com/topics/{}", item.id),
         "created_at": item.created_at.unix_timestamp(),
         "updated_at": item.updated_at.unix_timestamp(),
@@ -41,12 +68,12 @@ pub async fn cmd_topics_mine(
     post_type: Option<String>,
     format: &OutputFormat,
 ) -> Result<()> {
-    let opts = ListMyTopicsOptions {
+    let opts = MyTopicsOptions {
         page: Some(page),
         size: Some(size),
         topic_type: post_type,
     };
-    let items = crate::openapi::content().topics_mine(opts).await?;
+    let items = crate::openapi::content().my_topics(opts).await?;
 
     if items.is_empty() {
         println!("No topics found.");
@@ -74,14 +101,15 @@ pub async fn cmd_topics_mine(
     let rows = items
         .iter()
         .map(|item| {
+            let desc = replace_stock_tags(&item.description);
             let display = if item.title.is_empty() {
-                &item.description
+                desc.clone()
             } else {
-                &item.title
+                item.title.clone()
             };
             vec![
                 item.id.clone(),
-                display.clone(),
+                display,
                 item.topic_type.clone(),
                 format_datetime(item.created_at),
                 item.likes_count.to_string(),
@@ -137,7 +165,6 @@ pub async fn cmd_create_topic(
             Some(tickers)
         },
         hashtags: None,
-        license: None,
     };
     let id = crate::openapi::content().create_topic(opts).await?;
 


### PR DESCRIPTION
## Summary

- Rename `ListMyTopicsOptions` → `MyTopicsOptions` and `topics_mine()` → `my_topics()` to match updated longbridge SDK
- Remove `license` field from `OwnedTopic` JSON output and `CreateTopicOptions` (field no longer exists in SDK)
- Add `replace_stock_tags()` helper that converts `[st]ST/US/TSLA#Tesla.US[/st]` tags in topic descriptions to clean ticker format (`TSLA.US`)

## Test plan

- [ ] `longbridge my-topics` returns topic list without compile errors
- [ ] `longbridge topics <symbol>` JSON output has descriptions with `[st]` tags replaced by tickers
- [ ] `longbridge create-topic` still works without `license` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)