### PR TITLE
fix: use /health endpoint for connectivity probing in check command

### DIFF
--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -9,8 +9,8 @@ use crate::region;
 const CONNECT_TIMEOUT_SECS: u64 = 5;
 const PROBE_COUNT: usize = 10;
 const GLOBAL_HTTP_URL: &str = "https://openapi.longbridge.com";
-const GLOBAL_PROBE_URL: &str = "https://openapi.longbridge.com";
-const CN_PROBE_URL: &str = "https://openapi.longbridge.cn";
+const GLOBAL_PROBE_URL: &str = "https://openapi.longbridge.com/health";
+const CN_PROBE_URL: &str = "https://openapi.longbridge.cn/health";
 
 // ANSI colors
 const GREEN: &str = "\x1b[32m";
@@ -35,14 +35,20 @@ async fn probe(url: &str) -> ProbeStats {
         return ProbeStats { ok: false, ms: 0 };
     };
     // Warm-up: establish connection, result not counted
-    if client.head(url).send().await.is_err() {
+    if client.get(url).send().await.is_err() {
         return ProbeStats { ok: false, ms: 0 };
     }
     let mut samples = Vec::with_capacity(PROBE_COUNT);
     for _ in 0..PROBE_COUNT {
         let start = Instant::now();
-        if client.head(url).send().await.is_err() {
-            return ProbeStats { ok: false, ms: 0 };
+        match client.get(url).send().await {
+            Ok(resp) => {
+                let body = resp.text().await.unwrap_or_default();
+                if body.trim() != "success" {
+                    return ProbeStats { ok: false, ms: 0 };
+                }
+            }
+            Err(_) => return ProbeStats { ok: false, ms: 0 },
         }
         samples.push(start.elapsed().as_millis() as u64);
     }


### PR DESCRIPTION
## Summary

- Replace HEAD requests to root URL with GET requests to `/health` endpoint for both global and CN regions
- Verify response body equals `"success"` to confirm the service is healthy

## Test plan

- [ ] Run `longbridge check` and verify connectivity results are shown correctly
- [ ] Run `longbridge check --format json` and verify JSON output is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)