### PR TITLE
refactor: replace duplicate local types with SDK re-exports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,25 @@ cargo fmt
 cargo fmt && cargo clippy
 ```
 
+### Verifying Changes
+
+After any data-layer or CLI output change, verify correctness by comparing the installed release binary against the local build using the same command and `--format json`:
+
+```bash
+# Run both and compare — output should be identical (timestamps may differ for live data)
+longbridge <command> <args> --format json
+cargo run -- <command> <args> --format json
+```
+
+Pick commands that exercise the modified code paths. Common ones:
+
+| Changed area | Verification command |
+|---|---|
+| Trade direction / trades | `longbridge trades 700.HK --format json` |
+| Kline / AdjustType | `longbridge kline 700.HK --format json` |
+| Quote / calc-index | `longbridge calc-index 700.HK --format json` |
+| Static info | `longbridge static 700.HK --format json` |
+
 ### Configuration
 
 **Authentication Method: OAuth 2.0 (longbridge SDK)**

--- a/src/cli/topic.rs
+++ b/src/cli/topic.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use longbridge::content::{
-    CreateTopicOptions, CreateReplyOptions, ListTopicRepliesOptions, MyTopicsOptions,
-    OwnedTopic, TopicReply,
+    CreateReplyOptions, CreateTopicOptions, ListTopicRepliesOptions, MyTopicsOptions, OwnedTopic,
+    TopicReply,
 };
 use regex::Regex;
 use time::OffsetDateTime;

--- a/src/data/stock.rs
+++ b/src/data/stock.rs
@@ -115,13 +115,7 @@ impl Stock {
                 volume: t.volume,
                 timestamp: t.timestamp.unix_timestamp(),
                 trade_type: t.trade_type.clone(),
-                direction: match t.direction {
-                    longbridge::quote::TradeDirection::Neutral => {
-                        super::types::TradeDirection::Neutral
-                    }
-                    longbridge::quote::TradeDirection::Down => super::types::TradeDirection::Down,
-                    longbridge::quote::TradeDirection::Up => super::types::TradeDirection::Up,
-                },
+                direction: t.direction,
             })
             .collect();
     }

--- a/src/data/types.rs
+++ b/src/data/types.rs
@@ -227,13 +227,8 @@ impl KlineType {
     }
 }
 
-/// Adjustment type
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum AdjustType {
-    #[default]
-    NoAdjust,
-    ForwardAdjust,
-}
+/// Re-export `AdjustType` from Longbridge SDK
+pub use longbridge::quote::AdjustType;
 
 /// Candlestick data (detailed version with adjustment factors)
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -513,18 +508,6 @@ pub struct QuoteData {
     pub timestamp: i64,              // Timestamp
 }
 
-/// Candlestick data
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Candlestick {
-    pub timestamp: i64,
-    pub open: Decimal,
-    pub high: Decimal,
-    pub low: Decimal,
-    pub close: Decimal,
-    pub volume: u64,
-    pub turnover: Decimal,
-}
-
 /// Depth data
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Depth {
@@ -541,13 +524,8 @@ pub struct DepthData {
     pub bids: Vec<Depth>, // Bid orders
 }
 
-/// Trade direction
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum TradeDirection {
-    Neutral,
-    Up,
-    Down,
-}
+/// Re-export `TradeDirection` from Longbridge SDK
+pub use longbridge::quote::TradeDirection;
 
 /// Single trade record
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/kline.rs
+++ b/src/kline.rs
@@ -161,11 +161,7 @@ impl KlineStore {
             KlineType::PerYear => longbridge::quote::Period::Year,
         };
 
-        // Convert AdjustType to Longbridge AdjustType
-        let adjust = match adjust_type {
-            AdjustType::NoAdjust => longbridge::quote::AdjustType::NoAdjust,
-            AdjustType::ForwardAdjust => longbridge::quote::AdjustType::ForwardAdjust,
-        };
+        let adjust = adjust_type;
 
         // Select appropriate trading session based on period type
         // For all periods, use All to get complete data


### PR DESCRIPTION
## Summary

- Replace local `AdjustType` and `TradeDirection` enums with `pub use longbridge::quote::*` re-exports, eliminating manual identity conversions in `stock.rs` and `kline.rs`
- Remove unused local `Candlestick` struct (no callers found)
- Add verification guide to `CLAUDE.md`: compare `longbridge <cmd> --format json` vs `cargo run -- <cmd> --format json` after data-layer changes

## Test plan

- [ ] `cargo fmt && cargo clippy` — clean
- [ ] `longbridge trades 700.HK --format json` vs `cargo run -- trades 700.HK --format json` — identical output (TradeDirection)
- [ ] `longbridge kline 700.HK --format json` vs `cargo run -- kline 700.HK --format json` — identical output (AdjustType)

🤖 Generated with [Claude Code](https://claude.com/claude-code)