### PR TITLE
tui: Add watchlist stock search and symbol not-found error

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -159,6 +159,10 @@ SwitchCurrency.title: Choose Currency
 SwitchWatchlist.title: Choose Watchlist group
 SearchStock:
   title: "Open Quote (e.g. AAPL.US)"
+StockDetail.not_found: "Symbol not found"
+WatchlistSearch:
+  title: "Search Watchlist (code / name)"
+  invalid_format: "Invalid format, try AAPL.US"
 TextInput:
   placeholder: "What are you searching for?"
 TradeToken.title: Trade Password

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -159,6 +159,10 @@ SwitchCurrency.title: 选择币种
 SwitchWatchlist.title: 选择自选列表分组
 SearchStock:
   title: "查看股票（例如 AAPL.US）"
+StockDetail.not_found: "股票代码不存在"
+WatchlistSearch:
+  title: "搜索自选股票（代码 / 名称）"
+  invalid_format: "格式无效，请输入如 AAPL.US 的 symbol"
 TextInput:
   placeholder: "输入想搜索的内容"
 TradeToken.title: 交易密码

--- a/locales/zh-HK.yml
+++ b/locales/zh-HK.yml
@@ -159,6 +159,10 @@ SwitchCurrency.title: 選擇幣種
 SwitchWatchlist.title: 選擇自選列表分組
 SearchStock:
   title: "查看股票（例如 AAPL.US）"
+StockDetail.not_found: "股票代碼不存在"
+WatchlistSearch:
+  title: "搜尋自選股票（代碼 / 名稱）"
+  invalid_format: "格式無效，請輸入如 AAPL.US 的 symbol"
 TextInput:
   placeholder: "輸入想搜索的內容"
 TradeToken.title: 交易密碼

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -15,6 +15,7 @@ use crate::tui::widgets::{Carousel, Loading, LocalSearch, Search, Terminal};
 use crate::{openapi, tui::systems};
 
 pub static RT: OnceLock<tokio::runtime::Handle> = OnceLock::new();
+pub static UPDATE_TX: OnceLock<mpsc::UnboundedSender<CommandQueue>> = OnceLock::new();
 pub static POPUP: AtomicU8 = AtomicU8::new(0);
 pub static LAST_STATE: Atomic<AppState> = Atomic::new(AppState::Watchlist);
 pub static QUOTE_BMP: Atomic<bool> = Atomic::new(false);
@@ -28,6 +29,7 @@ pub const POPUP_SEARCH: u8 = 0b10;
 pub const POPUP_ACCOUNT: u8 = 0b100;
 pub const POPUP_CURRENCY: u8 = 0b1000;
 pub const POPUP_WATCHLIST: u8 = 0b10000;
+pub const POPUP_WATCHLIST_SEARCH: u8 = 0b10_0000;
 
 #[derive(
     Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States, strum::EnumIter, bytemuck::NoUninit,
@@ -50,6 +52,7 @@ pub async fn run(
     mut quote_receiver: impl tokio_stream::Stream<Item = longbridge::quote::PushEvent> + Unpin,
 ) {
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
+    UPDATE_TX.set(update_tx.clone()).ok();
 
     // Initialize index subscriptions
     let indexes: Vec<[Counter; 3]> = vec![
@@ -114,6 +117,18 @@ pub async fn run(
         })
     });
     let search_watchlist = LocalSearch::new(Vec::<WatchlistGroup>::new(), |_keyword, _group| false);
+    let watchlist_search = LocalSearch::new(
+        Vec::<crate::data::Counter>::new(),
+        |keyword: &str, counter: &crate::data::Counter| {
+            let kw = keyword.to_ascii_lowercase();
+            if counter.as_str().to_ascii_lowercase().contains(&kw) {
+                return true;
+            }
+            crate::data::STOCKS
+                .get(counter)
+                .is_some_and(|s| s.name.to_ascii_lowercase().contains(&kw))
+        },
+    );
 
     RT.set(tokio::runtime::Handle::current()).unwrap();
     let mut app = bevy_app::App::new();
@@ -124,6 +139,7 @@ pub async fn run(
         .init_resource::<Loading>()
         .insert_resource(search_stock)
         .insert_resource(search_watchlist)
+        .insert_resource(watchlist_search)
         .insert_resource(systems::Command(update_tx.clone()))
         .insert_resource(Carousel::new(indexes, Duration::from_secs(5)))
         .insert_resource(systems::WsState(crate::data::ReadyState::Open))
@@ -571,7 +587,91 @@ fn handle_popup_input(
         }
     } else if popup == POPUP_HELP {
         POPUP.store(0, Ordering::Relaxed);
+    } else if popup == POPUP_WATCHLIST_SEARCH {
+        handle_watchlist_search_input(app, event);
     }
+}
+
+fn handle_watchlist_search_input(app: &mut bevy_app::App, event: crossterm::event::KeyEvent) {
+    // First check for direct Enter (typed input, no dropdown selection)
+    let direct_query = {
+        let mut search = app
+            .world
+            .resource_mut::<LocalSearch<crate::data::Counter>>();
+        search.consume_direct_enter(event)
+    };
+
+    if let Some(query) = direct_query {
+        if let Some(symbol) = normalize_counter(&query) {
+            POPUP.store(0, Ordering::Relaxed);
+            let counter = crate::data::Counter::new(&symbol);
+            {
+                app.world
+                    .resource_mut::<LocalSearch<crate::data::Counter>>()
+                    .close();
+            }
+            navigate_to_counter(app, counter);
+        } else {
+            app.world
+                .resource_mut::<LocalSearch<crate::data::Counter>>()
+                .set_error(t!("WatchlistSearch.invalid_format").to_string());
+        }
+    } else {
+        let (hidden, selected) = {
+            let mut search = app
+                .world
+                .resource_mut::<LocalSearch<crate::data::Counter>>();
+            let (hidden, selected) = search.handle_key(event);
+            if hidden {
+                POPUP.store(0, Ordering::Relaxed);
+            }
+            (hidden, selected)
+        };
+        let _ = hidden;
+        if let Some(counter) = selected {
+            navigate_to_counter(app, counter);
+        }
+    }
+}
+
+/// Normalizes user input into a full `CODE.MARKET` symbol string.
+/// - Input with a dot (e.g. `AAPL.US`, `700.hk`) → validates market, returns uppercased.
+/// - All-letter input (e.g. `AAPL`, `tsla`) → appends `.US`.
+/// - All-digit input (e.g. `700`, `09988`) → appends `.HK`.
+/// - Anything else → `None` (invalid).
+fn normalize_counter(query: &str) -> Option<String> {
+    let q = query.trim();
+    if q.is_empty() {
+        return None;
+    }
+    if q.contains('.') {
+        let mut parts = q.splitn(2, '.');
+        let code = parts.next().unwrap_or("").trim();
+        let market = parts.next().unwrap_or("").trim().to_uppercase();
+        if code.is_empty()
+            || !matches!(market.as_str(), "HK" | "US" | "SH" | "SZ" | "SG" | "HAS")
+        {
+            return None;
+        }
+        Some(format!("{}.{}", code.to_uppercase(), market))
+    } else if q.chars().all(|c| c.is_ascii_alphabetic()) {
+        Some(format!("{}.US", q.to_uppercase()))
+    } else if q.chars().all(|c| c.is_ascii_digit()) {
+        Some(format!("{q}.HK"))
+    } else {
+        None
+    }
+}
+
+fn navigate_to_counter(app: &mut bevy_app::App, counter: crate::data::Counter) {
+    app.world.insert_resource(systems::StockDetail(counter));
+    let state = *app.world.resource::<State<AppState>>().get();
+    let next_state = if state == AppState::Stock {
+        AppState::Stock
+    } else {
+        AppState::WatchlistStock
+    };
+    app.world.insert_resource(NextState(Some(next_state)));
 }
 
 #[allow(clippy::too_many_lines)]
@@ -719,14 +819,21 @@ fn handle_global_keys(
             _ => {}
         },
         key!('/') => {
-            {
+            if state == AppState::Watchlist || state == AppState::WatchlistStock {
+                let mut ws = app
+                    .world
+                    .resource_mut::<LocalSearch<crate::data::Counter>>();
+                ws.visible();
+                POPUP.store(POPUP_WATCHLIST_SEARCH, Ordering::Relaxed);
+                render_state.mark_dirty(DirtyFlags::ALL);
+            } else {
                 let mut search = app
                     .world
                     .resource_mut::<Search<openapi::search::StockItem>>();
                 search.visible();
+                POPUP.store(POPUP_SEARCH, Ordering::Relaxed);
+                render_state.mark_dirty(DirtyFlags::POPUP_SEARCH);
             }
-            POPUP.store(POPUP_SEARCH, Ordering::Relaxed);
-            render_state.mark_dirty(DirtyFlags::POPUP_SEARCH);
         }
         key!('?') => {
             POPUP.store(POPUP_HELP, Ordering::Relaxed);

--- a/src/tui/render/dirty_flags.rs
+++ b/src/tui/render/dirty_flags.rs
@@ -96,6 +96,9 @@ impl DirtyFlags {
         if popup & crate::tui::app::POPUP_WATCHLIST != 0 {
             self.insert(Self::POPUP_WATCHLIST);
         }
+        if popup & crate::tui::app::POPUP_WATCHLIST_SEARCH != 0 {
+            self.insert(Self::POPUP_WATCHLIST);
+        }
         self
     }
 }

--- a/src/tui/systems/mod.rs
+++ b/src/tui/systems/mod.rs
@@ -130,6 +130,7 @@ pub(crate) type PopUp<'w> = (
     ResMut<'w, LocalSearch<openapi::account::CurrencyInfo>>,
     ResMut<'w, Search<openapi::search::StockItem>>,
     ResMut<'w, LocalSearch<WatchlistGroup>>,
+    ResMut<'w, LocalSearch<Counter>>,
 );
 
 // Shared event types

--- a/src/tui/systems/portfolio.rs
+++ b/src/tui/systems/portfolio.rs
@@ -38,7 +38,7 @@ pub fn render_portfolio(
     _accounts: Res<crate::tui::widgets::Select<Account>>,
     _command: Res<super::Command>,
     (state, indexes, ws): NavFooter,
-    (mut account, mut currency, mut search, mut watchgroup): PopUp,
+    (mut account, mut currency, mut search, mut watchgroup, mut watchlist_search): PopUp,
     _table_state: Local<ratatui::widgets::TableState>,
     mut log_panel: Local<crate::tui::widgets::LogPanel>,
 ) {
@@ -85,6 +85,7 @@ pub fn render_portfolio(
                 &mut currency,
                 &mut search,
                 &mut watchgroup,
+                &mut watchlist_search,
             );
             return;
         };
@@ -396,6 +397,7 @@ pub fn render_portfolio(
             &mut currency,
             &mut search,
             &mut watchgroup,
+            &mut watchlist_search,
         );
 
         // Render floating log panel if visible

--- a/src/tui/systems/stock_detail.rs
+++ b/src/tui/systems/stock_detail.rs
@@ -32,6 +32,8 @@ static REFRESH_STOCK_TASK: std::sync::LazyLock<Mutex<Option<JoinHandle<()>>>> =
     std::sync::LazyLock::new(|| Mutex::new(None));
 // Flag to track if a refresh is currently executing
 static REFRESH_EXECUTING: Atomic<bool> = Atomic::new(false);
+// Flag set when the API returns no data for the current symbol
+static STOCK_NOT_FOUND: Atomic<bool> = Atomic::new(false);
 
 // RAII guard to ensure REFRESH_EXECUTING is always cleared
 struct RefreshGuard;
@@ -57,7 +59,7 @@ pub fn render_stock(
     mut events: EventReader<Key>,
     stock: Res<StockDetail>,
     (state, indexes, ws): NavFooter,
-    (mut account, mut currency, mut search, mut watchgroup): PopUp,
+    (mut account, mut currency, mut search, mut watchgroup, mut watchlist_search): PopUp,
     mut last_choose: Local<Counter>,
     mut log_panel: Local<crate::tui::widgets::LogPanel>,
 ) {
@@ -133,6 +135,7 @@ pub fn render_stock(
             &mut currency,
             &mut search,
             &mut watchgroup,
+            &mut watchlist_search,
         );
 
         // Render floating log panel if visible
@@ -206,6 +209,26 @@ pub(crate) fn stock_detail(
     }
 
     let Some(stock) = STOCKS.get(counter) else {
+        if STOCK_NOT_FOUND.load(Ordering::Relaxed) {
+            let content_height = 2u16;
+            let y_offset = rect.height.saturating_sub(content_height) / 2;
+            let centered_rect = Rect {
+                y: rect.y + y_offset,
+                height: content_height,
+                ..rect
+            };
+            let text = ratatui::text::Text::from(vec![
+                Line::from(Span::styled(counter.to_string(), styles::primary())),
+                Line::from(Span::styled(
+                    t!("StockDetail.not_found").to_string(),
+                    styles::dark_gray(),
+                )),
+            ]);
+            frame.render_widget(
+                Paragraph::new(text).alignment(Alignment::Center),
+                centered_rect,
+            );
+        }
         return;
     };
 
@@ -863,10 +886,13 @@ pub fn refresh_stock_debounced(counter: Counter) {
             task.abort();
         }
 
+        // Reset not-found flag whenever a new refresh starts
+        STOCK_NOT_FOUND.store(false, Ordering::Relaxed);
+
         // Spawn a new debounced task
         let handle = RT.get().unwrap().spawn(async move {
-            // Wait 50ms before executing
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            // Wait 150ms before executing to avoid firing on every stock passed during navigation
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
 
             // Try to acquire the execution lock (RAII guard)
             let Some(_guard) = RefreshGuard::try_acquire() else {
@@ -894,6 +920,12 @@ pub fn refresh_stock_debounced(counter: Counter) {
                     STOCKS.modify(counter.clone(), |stock| {
                         stock.update_from_security_quote(quote);
                     });
+                } else {
+                    // API returned no data — symbol does not exist
+                    STOCK_NOT_FOUND.store(true, Ordering::Relaxed);
+                    if let Some(tx) = crate::tui::app::UPDATE_TX.get() {
+                        let _ = tx.send(bevy_ecs::system::CommandQueue::default());
+                    }
                 }
             }
 
@@ -934,6 +966,7 @@ pub fn enter_stock(counter: Res<StockDetail>) {
 }
 
 pub fn exit_stock() {
+    STOCK_NOT_FOUND.store(false, Ordering::Relaxed);
     crate::tui::systems::stock_news::reset_news_view();
     RT.get().unwrap().spawn(async move {
         _ = WS.unmount("stock_detail").await;

--- a/src/tui/systems/watchlist.rs
+++ b/src/tui/systems/watchlist.rs
@@ -31,7 +31,7 @@ pub fn render_watchlist(
     mut events: EventReader<Key>,
     command: Res<Command>,
     (state, indexes, ws): NavFooter,
-    (mut account, mut currency, mut search, mut watchgroup): PopUp,
+    (mut account, mut currency, mut search, mut watchgroup, mut watchlist_search): PopUp,
     mut log_panel: Local<crate::tui::widgets::LogPanel>,
 ) {
     for event in &mut events {
@@ -115,6 +115,7 @@ pub fn render_watchlist(
             &mut currency,
             &mut search,
             &mut watchgroup,
+            &mut watchlist_search,
         );
 
         // Render floating log panel if visible
@@ -540,6 +541,7 @@ pub fn refresh_watchlist(update_tx: mpsc::UnboundedSender<CommandQueue>) {
         // counter order maybe change, reset table highlight
         WATCHLIST_TABLE.lock().expect("poison").select(None);
 
+        let final_counters = WATCHLIST.read().expect("poison").counters().to_vec();
         let local_search = LocalSearch::new(
             WATCHLIST.read().expect("poison").groups().to_vec(),
             |keyword: &str, group: &crate::data::WatchlistGroup| {
@@ -547,9 +549,22 @@ pub fn refresh_watchlist(update_tx: mpsc::UnboundedSender<CommandQueue>) {
                 group.name.to_ascii_lowercase().contains(keyword)
             },
         );
+        let watchlist_search =
+            LocalSearch::new(final_counters, |keyword: &str, counter: &Counter| {
+                let kw = keyword.to_ascii_lowercase();
+                if counter.as_str().to_ascii_lowercase().contains(&kw) {
+                    return true;
+                }
+                crate::data::STOCKS
+                    .get(counter)
+                    .is_some_and(|s| s.name.to_ascii_lowercase().contains(&kw))
+            });
         let mut queue = CommandQueue::default();
         queue.push(InsertResource {
             resource: local_search,
+        });
+        queue.push(InsertResource {
+            resource: watchlist_search,
         });
         _ = update_tx.send(queue);
     });

--- a/src/tui/systems/watchlist_stock.rs
+++ b/src/tui/systems/watchlist_stock.rs
@@ -34,7 +34,7 @@ pub fn render_watchlist_stock(
     stock: Res<StockDetail>,
     command: Res<Command>,
     (state, indexes, ws): NavFooter,
-    (mut account, mut currency, mut search, mut watchgroup): PopUp,
+    (mut account, mut currency, mut search, mut watchgroup, mut watchlist_search): PopUp,
     mut last_choose: Local<Counter>,
     mut log_panel: Local<crate::tui::widgets::LogPanel>,
 ) {
@@ -272,6 +272,7 @@ pub fn render_watchlist_stock(
             &mut currency,
             &mut search,
             &mut watchgroup,
+            &mut watchlist_search,
         );
 
         // Render floating log panel if visible

--- a/src/tui/views/popup.rs
+++ b/src/tui/views/popup.rs
@@ -1,4 +1,5 @@
 use crate::{
+    data::Counter,
     openapi,
     tui::ui::styles,
     tui::widgets::{LocalSearch, Search},
@@ -6,7 +7,7 @@ use crate::{
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::Span,
     widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table},
     Frame,
@@ -19,6 +20,7 @@ pub fn render(
     currency: &mut LocalSearch<openapi::account::CurrencyInfo>,
     search: &mut Search<openapi::search::StockItem>,
     watchlist: &mut LocalSearch<crate::data::WatchlistGroup>,
+    watchlist_search: &mut LocalSearch<Counter>,
 ) {
     let popup = crate::tui::app::POPUP.load(std::sync::atomic::Ordering::Relaxed);
     if popup == crate::tui::app::POPUP_ACCOUNT {
@@ -31,6 +33,8 @@ pub fn render(
         crate::tui::views::help::render(frame, rect);
     } else if popup == crate::tui::app::POPUP_SEARCH {
         searching(frame, rect, search);
+    } else if popup == crate::tui::app::POPUP_WATCHLIST_SEARCH {
+        search_watchlist(frame, rect, watchlist_search);
     }
 }
 
@@ -221,4 +225,69 @@ fn searching(frame: &mut Frame, rect: Rect, search: &mut Search<openapi::search:
         rect.x + u16::try_from(input.visual_cursor()).unwrap() + 1,
         rect.y + 1,
     ));
+}
+
+fn search_watchlist(frame: &mut Frame, rect: Rect, search: &mut LocalSearch<Counter>) {
+    const MAX_SIZE: (u16, u16) = (60, 25);
+    const COLUMN_WIDTHS: [Constraint; 3] = [
+        Constraint::Length(4),
+        Constraint::Length(12),
+        Constraint::Min(10),
+    ];
+    let rect = crate::tui::ui::rect::centered(MAX_SIZE.0, MAX_SIZE.1, rect);
+    frame.render_widget(Clear, rect);
+
+    let chunks = Layout::default()
+        .margin(1)
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(1)].as_ref())
+        .split(rect);
+
+    let input = &search.input;
+    let (title, border_style) = if let Some(err) = search.error() {
+        (format!(" {err} "), Style::default().fg(Color::LightRed))
+    } else {
+        (t!("WatchlistSearch.title").to_string(), styles::border())
+    };
+    let paragraph = Paragraph::new(input.value()).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(border_style)
+            .title(title),
+    );
+    frame.render_widget(paragraph, chunks[0]);
+    frame.set_cursor_position((
+        chunks[0].x + u16::try_from(input.visual_cursor()).unwrap() + 1,
+        chunks[0].y + 1,
+    ));
+
+    let rows = search
+        .options()
+        .iter()
+        .map(|counter| {
+            let name = crate::data::STOCKS
+                .get(counter)
+                .map(|s| s.display_name().to_string())
+                .unwrap_or_default();
+            Row::new(vec![
+                Cell::from(Span::styled(
+                    counter.market().to_string(),
+                    styles::market(counter.region()),
+                )),
+                Cell::from(counter.code().to_string()),
+                Cell::from(name),
+            ])
+        })
+        .collect::<Vec<_>>();
+
+    let table = Table::new(rows, COLUMN_WIDTHS)
+        .block(
+            Block::default()
+                .borders(Borders::all())
+                .border_style(styles::border()),
+        )
+        .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .column_spacing(1);
+
+    frame.render_stateful_widget(table, chunks[1], &mut search.table);
 }

--- a/src/tui/widgets/search.rs
+++ b/src/tui/widgets/search.rs
@@ -20,6 +20,7 @@ pub struct LocalSearch<T> {
     items: Vec<T>,
     options: Vec<T>,
     func: fn(&str, &T) -> bool,
+    error_msg: Option<String>,
 }
 
 impl<T> std::fmt::Debug for LocalSearch<T>
@@ -47,6 +48,7 @@ where
             options: items.clone(),
             items,
             func,
+            error_msg: None,
         }
     }
 
@@ -62,6 +64,7 @@ where
         match event {
             key!(Esc) => {
                 self.visible = false;
+                self.error_msg = None;
                 return (true, None);
             }
             key!(Enter) => {
@@ -71,6 +74,7 @@ where
                     self.input.reset();
                     self.options = self.items.clone();
                     self.visible = false;
+                    self.error_msg = None;
                     return (true, Some(selected));
                 }
             }
@@ -83,6 +87,7 @@ where
                 self.table.select(idx);
             }
             _ => {
+                self.error_msg = None;
                 let evt = crossterm::event::Event::Key(event);
                 if self.input.handle_event(&evt).is_some() {
                     let keyword = self.input.value();
@@ -92,10 +97,54 @@ where
                         .filter(|v| keyword.is_empty() || (self.func)(keyword, v))
                         .cloned()
                         .collect();
+                    // Auto-select first match so Enter works immediately
+                    self.table.select(if self.options.is_empty() {
+                        None
+                    } else {
+                        Some(0)
+                    });
                 }
             }
         }
         (false, None)
+    }
+
+    pub fn set_error(&mut self, msg: String) {
+        self.error_msg = Some(msg);
+    }
+
+    pub fn error(&self) -> Option<&str> {
+        self.error_msg.as_deref()
+    }
+
+    /// When Enter is pressed with a non-empty input and no dropdown item selected,
+    /// returns the raw typed query for direct navigation. Leaves the popup open so
+    /// the caller can decide whether to close it or show an error.
+    pub fn consume_direct_enter(&mut self, event: KeyEvent) -> Option<String> {
+        if matches!(event, key!(Enter))
+            && self.table.selected().is_none()
+            && !self.input.value().is_empty()
+        {
+            Some(self.input.value().to_string())
+        } else {
+            None
+        }
+    }
+
+    pub fn close(&mut self) {
+        self.visible = false;
+        self.error_msg = None;
+        self.input.reset();
+        self.options = self.items.clone();
+        self.table.select(None);
+    }
+
+    pub fn reset_items(&mut self, items: Vec<T>) {
+        self.items = items.clone();
+        self.options = items;
+        self.input.reset();
+        self.table.select(None);
+        self.error_msg = None;
     }
 
     pub fn items(&self) -> &[T] {


### PR DESCRIPTION
## Summary

- Press `/` in Watchlist or WatchlistStock to open a local search popup that filters the current watchlist by code or stock name in real time
- First match is auto-selected so Enter navigates immediately without extra keystrokes
- Typing a raw symbol (`AAPL` → `.US`, `700` → `.HK`, `AAPL.US` verbatim) and pressing Enter infers the market and navigates directly; invalid formats show a red error border
- When the Longbridge API returns no data for a symbol, the stock detail view now shows the requested symbol and a localised "not found" hint centred in the viewport instead of silently rendering nothing
- Rendering performance fix: added `POPUP_WATCHLIST_SEARCH` to `mark_popup_change()` so keystrokes mark the dirty flag and re-render immediately

## Test plan

- [ ] Press `/` on Watchlist screen — search popup opens
- [ ] Type partial code or name — list filters in real time, first match highlighted
- [ ] Press Enter with a match selected — navigates to that stock
- [ ] Type `AAPL` (no market suffix) + Enter — opens `AAPL.US`
- [ ] Type `700` (digits only) + Enter — opens `700.HK`
- [ ] Type `AAPL.HK` + Enter (valid format, non-existent stock) — stock detail shows symbol + "not found" centred
- [ ] Type `???` + Enter — red error border appears, popup stays open
- [ ] Press Esc — popup closes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)