### PR TITLE
cli: Support BROWSER env var for custom browser selection

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -53,7 +53,23 @@ fn token_file_path() -> Result<PathBuf> {
 
 /// Try to open a URL in the system browser. Returns `true` if the command was
 /// launched successfully (the browser may still fail to load the page).
+///
+/// Checks the `BROWSER` environment variable first; falls back to the
+/// platform default (`open` on macOS, `cmd /c start` on Windows, `xdg-open`
+/// on Linux).
 pub fn open_browser(url: &str) -> bool {
+    // Honor the BROWSER environment variable if set.
+    if let Ok(browser) = std::env::var("BROWSER") {
+        if !browser.is_empty() {
+            return std::process::Command::new(&browser)
+                .arg(url)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .is_ok();
+        }
+    }
+
     #[cfg(target_os = "macos")]
     let mut cmd = std::process::Command::new("open");
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
Honor the BROWSER environment variable in open_browser() before falling back to the platform default (open/cmd/xdg-open).

## Usage

```bash
BROWSER=firefox longbridge login
BROWSER="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" longbridge login
```

## Test plan
   - [x] BROWSER=firefox longbridge login opens Firefox
   - [x] BROWSER="" longbridge login falls back to system default
   - [x] Unset BROWSER falls back to system default
   - [x] BROWSER=/nonexistent longbridge login gracefully falls back to printing the URL