### PR TITLE
cli: Add release notes display after update

### DIFF
--- a/.github/workflows/test-update.yml
+++ b/.github/workflows/test-update.yml
@@ -64,7 +64,7 @@ jobs:
           # Run with no subcommand (prints help, no auth needed) and capture output
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "What's new" || { echo "FAIL: release notes not shown after version change"; exit 1; }
+          echo "$output" | grep -q "Release notes" || { echo "FAIL: release notes not shown after version change"; exit 1; }
           # Verify marker was updated so it won't show again
           version=$(cat ~/.longbridge/.terminal-last-run-version)
           [ "$version" = "0.14.0" ] || { echo "FAIL: last-run-version not updated (got: $version)"; exit 1; }
@@ -73,7 +73,7 @@ jobs:
         run: |
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          if echo "$output" | grep -q "What's new"; then
+          if echo "$output" | grep -q "Release notes"; then
             echo "FAIL: release notes shown again on second run"
             exit 1
           fi
@@ -126,7 +126,7 @@ jobs:
           echo "0.0.1" > ~/.longbridge/.terminal-last-run-version
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "What's new" || { echo "FAIL: release notes not shown after version change"; exit 1; }
+          echo "$output" | grep -q "Release notes" || { echo "FAIL: release notes not shown after version change"; exit 1; }
           version=$(cat ~/.longbridge/.terminal-last-run-version)
           [ "$version" = "0.14.0" ] || { echo "FAIL: last-run-version not updated (got: $version)"; exit 1; }
 
@@ -134,7 +134,7 @@ jobs:
         run: |
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          if echo "$output" | grep -q "What's new"; then
+          if echo "$output" | grep -q "Release notes"; then
             echo "FAIL: release notes shown again on second run"
             exit 1
           fi
@@ -193,7 +193,7 @@ jobs:
           Set-Content -Path "$dir\.terminal-last-run-version" -Value "0.0.1" -NoNewline
           $output = cargo run 2>&1 | Out-String
           Write-Host $output
-          if ($output -notmatch "What's new") {
+          if ($output -notmatch "Release notes") {
             throw "FAIL: release notes not shown after version change"
           }
           $version = (Get-Content "$dir\.terminal-last-run-version").Trim()
@@ -206,7 +206,7 @@ jobs:
         run: |
           $output = cargo run 2>&1 | Out-String
           Write-Host $output
-          if ($output -match "What's new") {
+          if ($output -match "Release notes") {
             throw "FAIL: release notes shown again on second run"
           }
 

--- a/.github/workflows/test-update.yml
+++ b/.github/workflows/test-update.yml
@@ -50,6 +50,34 @@ jobs:
       - name: Build
         run: cargo build
 
+      - name: Test --release-notes flag fetches content
+        run: |
+          output=$(cargo run -- update --release-notes 2>&1)
+          echo "$output"
+          [ -n "$output" ] || { echo "FAIL: --release-notes returned empty output"; exit 1; }
+
+      - name: Test first-run version detection
+        run: |
+          # Write a fake old version to trigger release notes on next run
+          mkdir -p ~/.longbridge
+          echo "0.0.1" > ~/.longbridge/.terminal-last-run-version
+          # Run any command (--help is fine, no auth needed) and capture stderr
+          output=$(cargo run -- --help 2>&1 >/dev/null || true)
+          echo "$output"
+          echo "$output" | grep -q "What's new" || { echo "FAIL: release notes not shown after version change"; exit 1; }
+          # Verify marker was updated so it won't show again
+          version=$(cat ~/.longbridge/.terminal-last-run-version)
+          [ "$version" = "0.14.0" ] || { echo "FAIL: last-run-version not updated (got: $version)"; exit 1; }
+
+      - name: Test release notes not shown on subsequent run
+        run: |
+          output=$(cargo run -- --help 2>&1 >/dev/null || true)
+          echo "$output"
+          if echo "$output" | grep -q "What's new"; then
+            echo "FAIL: release notes shown again on second run"
+            exit 1
+          fi
+
       - name: Run update
         run: cargo run -- update --verbose
 
@@ -85,6 +113,31 @@ jobs:
 
       - name: Build
         run: cargo build
+
+      - name: Test --release-notes flag fetches content
+        run: |
+          output=$(cargo run -- update --release-notes 2>&1)
+          echo "$output"
+          [ -n "$output" ] || { echo "FAIL: --release-notes returned empty output"; exit 1; }
+
+      - name: Test first-run version detection
+        run: |
+          mkdir -p ~/.longbridge
+          echo "0.0.1" > ~/.longbridge/.terminal-last-run-version
+          output=$(cargo run -- --help 2>&1 >/dev/null || true)
+          echo "$output"
+          echo "$output" | grep -q "What's new" || { echo "FAIL: release notes not shown after version change"; exit 1; }
+          version=$(cat ~/.longbridge/.terminal-last-run-version)
+          [ "$version" = "0.14.0" ] || { echo "FAIL: last-run-version not updated (got: $version)"; exit 1; }
+
+      - name: Test release notes not shown on subsequent run
+        run: |
+          output=$(cargo run -- --help 2>&1 >/dev/null || true)
+          echo "$output"
+          if echo "$output" | grep -q "What's new"; then
+            echo "FAIL: release notes shown again on second run"
+            exit 1
+          fi
 
       - name: Run update
         run: cargo run -- update --verbose
@@ -122,6 +175,40 @@ jobs:
 
       - name: Build
         run: cargo build
+
+      - name: Test --release-notes flag fetches content
+        shell: pwsh
+        run: |
+          $output = cargo run -- update --release-notes 2>&1 | Out-String
+          Write-Host $output
+          if ([string]::IsNullOrWhiteSpace($output)) {
+            throw "FAIL: --release-notes returned empty output"
+          }
+
+      - name: Test first-run version detection
+        shell: pwsh
+        run: |
+          $dir = "$env:USERPROFILE\.longbridge"
+          New-Item -ItemType Directory -Path $dir -Force | Out-Null
+          Set-Content -Path "$dir\.terminal-last-run-version" -Value "0.0.1" -NoNewline
+          $output = cargo run -- --help 2>&1 | Out-String
+          Write-Host $output
+          if ($output -notmatch "What's new") {
+            throw "FAIL: release notes not shown after version change"
+          }
+          $version = (Get-Content "$dir\.terminal-last-run-version").Trim()
+          if ($version -ne "0.14.0") {
+            throw "FAIL: last-run-version not updated (got: $version)"
+          }
+
+      - name: Test release notes not shown on subsequent run
+        shell: pwsh
+        run: |
+          $output = cargo run -- --help 2>&1 | Out-String
+          Write-Host $output
+          if ($output -match "What's new") {
+            throw "FAIL: release notes shown again on second run"
+          }
 
       - name: Run update
         shell: pwsh

--- a/.github/workflows/test-update.yml
+++ b/.github/workflows/test-update.yml
@@ -61,8 +61,8 @@ jobs:
           # Write a fake old version to trigger release notes on next run
           mkdir -p ~/.longbridge
           echo "0.0.1" > ~/.longbridge/.terminal-last-run-version
-          # Run any command (--help is fine, no auth needed) and capture stderr
-          output=$(cargo run -- --help 2>&1 >/dev/null || true)
+          # Run with no subcommand (prints help, no auth needed) and capture output
+          output=$(cargo run 2>&1 || true)
           echo "$output"
           echo "$output" | grep -q "What's new" || { echo "FAIL: release notes not shown after version change"; exit 1; }
           # Verify marker was updated so it won't show again
@@ -71,7 +71,7 @@ jobs:
 
       - name: Test release notes not shown on subsequent run
         run: |
-          output=$(cargo run -- --help 2>&1 >/dev/null || true)
+          output=$(cargo run 2>&1 || true)
           echo "$output"
           if echo "$output" | grep -q "What's new"; then
             echo "FAIL: release notes shown again on second run"
@@ -124,7 +124,7 @@ jobs:
         run: |
           mkdir -p ~/.longbridge
           echo "0.0.1" > ~/.longbridge/.terminal-last-run-version
-          output=$(cargo run -- --help 2>&1 >/dev/null || true)
+          output=$(cargo run 2>&1 || true)
           echo "$output"
           echo "$output" | grep -q "What's new" || { echo "FAIL: release notes not shown after version change"; exit 1; }
           version=$(cat ~/.longbridge/.terminal-last-run-version)
@@ -132,7 +132,7 @@ jobs:
 
       - name: Test release notes not shown on subsequent run
         run: |
-          output=$(cargo run -- --help 2>&1 >/dev/null || true)
+          output=$(cargo run 2>&1 || true)
           echo "$output"
           if echo "$output" | grep -q "What's new"; then
             echo "FAIL: release notes shown again on second run"
@@ -191,7 +191,7 @@ jobs:
           $dir = "$env:USERPROFILE\.longbridge"
           New-Item -ItemType Directory -Path $dir -Force | Out-Null
           Set-Content -Path "$dir\.terminal-last-run-version" -Value "0.0.1" -NoNewline
-          $output = cargo run -- --help 2>&1 | Out-String
+          $output = cargo run 2>&1 | Out-String
           Write-Host $output
           if ($output -notmatch "What's new") {
             throw "FAIL: release notes not shown after version change"
@@ -204,7 +204,7 @@ jobs:
       - name: Test release notes not shown on subsequent run
         shell: pwsh
         run: |
-          $output = cargo run -- --help 2>&1 | Out-String
+          $output = cargo run 2>&1 | Out-String
           Write-Host $output
           if ($output -match "What's new") {
             throw "FAIL: release notes shown again on second run"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+dependencies = [
+ "crossterm",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +814,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "crokey"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
+dependencies = [
+ "crossterm",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +876,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2130,6 +2187,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,6 +2441,7 @@ dependencies = [
  "tabled",
  "tar",
  "tempfile",
+ "termimad",
  "time",
  "tokio",
  "tokio-stream",
@@ -2483,6 +2564,15 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimad"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c5d708226d186590a7b6d4a9780e2bdda5f689e0d58cd17012a298efd745d2"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -4188,6 +4278,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4420,6 +4516,22 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "termimad"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22117210909e9dfff30a558f554c7fb3edb198ef614e7691386785fb7679677c"
+dependencies = [
+ "coolor",
+ "crokey",
+ "crossbeam",
+ "lazy-regex",
+ "minimad",
+ "serde",
+ "thiserror 1.0.69",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 strum = { version = "0.26", features = ["derive"] }
 tempfile = "3"
+termimad = "0.30"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
 tokio = { version = "1.33.0", features = ["full"] }
 tokio-stream = "0.1"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -113,7 +113,12 @@ pub enum Commands {
     ///
     /// Downloads and runs the official install script to replace the current binary.
     /// Example: longbridge update
-    Update,
+    /// Example: longbridge update --release-notes
+    Update {
+        /// Show release notes instead of updating
+        #[arg(long)]
+        release_notes: bool,
+    },
 
     /// Launch the interactive full-screen TUI (terminal UI)
     ///
@@ -1735,7 +1740,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
         | Commands::Logout
         | Commands::Tui
         | Commands::Check
-        | Commands::Update => {
+        | Commands::Update { .. } => {
             unreachable!()
         }
     }

--- a/src/data/types.rs
+++ b/src/data/types.rs
@@ -135,8 +135,9 @@ impl TradeStatusExt for TradeStatus {
             TradeStatus::SplitStockHalts => t!("TradeStatus.SplitStockHalts"),
             TradeStatus::Expired => t!("TradeStatus.Expired"),
             TradeStatus::WarrantPrepareList => t!("TradeStatus.WarrantPrepareList"),
-           TradeStatus::SuspendTrade => t!("TradeStatus.SuspendTrade"),
-        }.to_string()
+            TradeStatus::SuspendTrade => t!("TradeStatus.SuspendTrade"),
+        }
+        .to_string()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,9 @@ async fn main() {
     // Kick off background version check to refresh the update cache for the next run.
     update::spawn_version_check();
 
+    // Show release notes once after a version change (e.g. brew upgrade, manual install).
+    update::check_and_show_release_notes().await;
+
     match cli.command {
         None => {
             // No subcommand: print help and exit
@@ -151,8 +154,13 @@ async fn main() {
             }
         }
 
-        Some(cli::Commands::Update) => {
-            if let Err(e) = update::cmd_update(verbose).await {
+        Some(cli::Commands::Update { release_notes }) => {
+            if release_notes {
+                if let Err(e) = update::cmd_release_notes().await {
+                    eprintln!("Error: {e}");
+                    std::process::exit(1);
+                }
+            } else if let Err(e) = update::cmd_update(verbose).await {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,8 +106,8 @@ async fn main() {
     // Kick off background version check to refresh the update cache for the next run.
     update::spawn_version_check();
 
-    // Show release notes once after a version change (e.g. brew upgrade, manual install).
-    update::check_and_show_release_notes().await;
+    // Show release notes URL once after a version change (e.g. brew upgrade, manual install).
+    update::check_and_show_release_notes();
 
     match cli.command {
         None => {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -648,9 +648,7 @@ fn normalize_counter(query: &str) -> Option<String> {
         let mut parts = q.splitn(2, '.');
         let code = parts.next().unwrap_or("").trim();
         let market = parts.next().unwrap_or("").trim().to_uppercase();
-        if code.is_empty()
-            || !matches!(market.as_str(), "HK" | "US" | "SH" | "SZ" | "SG" | "HAS")
-        {
+        if code.is_empty() || !matches!(market.as_str(), "HK" | "US" | "SH" | "SZ" | "SG" | "HAS") {
             return None;
         }
         Some(format!("{}.{}", code.to_uppercase(), market))

--- a/src/update.rs
+++ b/src/update.rs
@@ -102,7 +102,11 @@ pub fn notify_if_update_available() {
     if is_newer(CURRENT_VERSION, &latest) {
         let green = "\x1b[32m";
         let reset = "\x1b[0m";
-        eprintln!("\nNew version {latest} is available, run `{green}longbridge update{reset}` to update.\n");
+        let url = release_notes_url();
+        eprintln!(
+            "\nNew version {latest} is available, run `{green}longbridge update{reset}` to update."
+        );
+        eprintln!("Release notes: {url}\n");
     }
 }
 
@@ -466,9 +470,9 @@ pub async fn cmd_release_notes() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Check if the binary version changed since the last run. If so, fetch and
-/// display release notes once, then update the marker file.
-pub async fn check_and_show_release_notes() {
+/// Check if the binary version changed since the last run. If so, print a
+/// one-line notice with the release notes URL (no network request).
+pub fn check_and_show_release_notes() {
     let last = read_last_run_version();
 
     // Always update the marker so we only show once.
@@ -483,19 +487,12 @@ pub async fn check_and_show_release_notes() {
         return;
     }
 
-    // Version changed — fetch and display release notes.
-    match fetch_release_notes().await {
-        Ok(md) => {
-            let green = "\x1b[32m";
-            let reset = "\x1b[0m";
-            eprintln!("\n{green}Updated to v{CURRENT_VERSION} (was v{last}). What's new:{reset}\n");
-            render_release_notes(&md);
-            eprintln!();
-        }
-        Err(e) => {
-            tracing::debug!("Failed to fetch release notes: {e}");
-        }
-    }
+    let green = "\x1b[32m";
+    let reset = "\x1b[0m";
+    let url = release_notes_url();
+    eprintln!(
+        "\n{green}Updated to v{CURRENT_VERSION} (was v{last}). Release notes: {url}{reset}\n"
+    );
 }
 
 #[cfg(test)]

--- a/src/update.rs
+++ b/src/update.rs
@@ -9,16 +9,18 @@
 use std::{path::PathBuf, time::Duration};
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-const RELEASES_LATEST_URL: &str =
-    "https://github.com/longbridge/longbridge-terminal/releases/latest";
 const CHECK_INTERVAL_SECS: u64 = 86400; // 24 hours
 const FETCH_TIMEOUT_SECS: u64 = 5;
-
 const DOWNLOAD_TIMEOUT_SECS: u64 = 300;
-const PACKAGE_NAME: &str = "longbridge-terminal";
 
-const BASE_URL_GLOBAL: &str = "https://open.longbridge.com/github/release/longbridge-terminal";
-const BASE_URL_CN: &str = "https://open.longbridge.cn/github/release/longbridge-terminal";
+const HOST_GLOBAL: &str = "https://open.longbridge.com";
+const HOST_CN: &str = "https://open.longbridge.cn";
+const RELEASE_PATH: &str = "/github/release/longbridge-terminal";
+const RELEASE_NOTES_PATH: &str = "/docs/cli/release-notes.md";
+
+const RELEASES_LATEST_URL: &str =
+    "https://github.com/longbridge/longbridge-terminal/releases/latest";
+const PACKAGE_NAME: &str = "longbridge-terminal";
 
 #[cfg(target_os = "macos")]
 const PLATFORM: &str = "darwin";
@@ -150,19 +152,19 @@ async fn fetch_latest_version() -> Option<String> {
     Some(version.to_string())
 }
 
-fn get_base_url() -> &'static str {
+fn get_host() -> &'static str {
     if crate::region::is_cn_cached() {
-        BASE_URL_CN
+        HOST_CN
     } else {
-        BASE_URL_GLOBAL
+        HOST_GLOBAL
     }
 }
 
 async fn fetch_latest_version_for_update() -> anyhow::Result<String> {
-    let base = get_base_url();
+    let host = get_host();
 
-    // Both Global and CN CDN: GET {base}/latest returns plain text like "v0.15.0"
-    let url = format!("{base}/latest");
+    // Both Global and CN CDN: GET {host}{RELEASE_PATH}/latest returns plain text like "v0.15.0"
+    let url = format!("{host}{RELEASE_PATH}/latest");
     let resp = reqwest::Client::builder()
         .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS))
         .build()?
@@ -199,7 +201,13 @@ async fn download_to_file(url: &str, dest: &std::path::Path) -> anyhow::Result<(
         .build()?;
 
     eprint!("Downloading...");
-    let bytes = client.get(url).send().await?.error_for_status()?.bytes().await?;
+    let bytes = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
 
     #[allow(clippy::cast_precision_loss)]
     {
@@ -350,8 +358,9 @@ pub async fn cmd_update(verbose: bool) -> anyhow::Result<()> {
     eprintln!("Updating v{CURRENT_VERSION} → v{latest} ...");
 
     // 4. Build download URL
-    let base = get_base_url();
-    let url = build_download_url(base, &latest);
+    let host = get_host();
+    let base = format!("{host}{RELEASE_PATH}");
+    let url = build_download_url(&base, &latest);
 
     if verbose {
         eprintln!("* Download: {url}");
@@ -374,13 +383,113 @@ pub async fn cmd_update(verbose: bool) -> anyhow::Result<()> {
         let _ = std::fs::remove_file(path);
     }
 
-    eprintln!("Updated to v{latest} successfully.");
+    eprintln!("Updated to v{latest} successfully.\n");
+
+    // 8. Show release notes and update the last-run marker so the next
+    //    startup won't show them again.
+    write_last_run_version();
+    match fetch_release_notes().await {
+        Ok(md) => render_release_notes(&md),
+        Err(e) => tracing::debug!("Failed to fetch release notes: {e}"),
+    }
+
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Release notes
+// ---------------------------------------------------------------------------
+
+fn last_run_version_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".longbridge").join(".terminal-last-run-version"))
+}
+
+fn read_last_run_version() -> Option<String> {
+    let path = last_run_version_path()?;
+    let s = std::fs::read_to_string(&path).ok()?;
+    let v = s.trim().to_string();
+    if v.is_empty() {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+fn write_last_run_version() {
+    let Some(path) = last_run_version_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, CURRENT_VERSION);
+}
+
+fn release_notes_url() -> String {
+    format!("{}{RELEASE_NOTES_PATH}", get_host())
+}
+
+async fn fetch_release_notes() -> anyhow::Result<String> {
+    let url = release_notes_url();
+    let body = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()?
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    Ok(body)
+}
+
+fn render_release_notes(markdown: &str) {
+    let skin = termimad::MadSkin::default();
+    skin.print_text(markdown);
+}
+
+/// Show release notes for the `longbridge update --release-notes` command.
+pub async fn cmd_release_notes() -> anyhow::Result<()> {
+    let markdown = fetch_release_notes().await?;
+    render_release_notes(&markdown);
+    Ok(())
+}
+
+/// Check if the binary version changed since the last run. If so, fetch and
+/// display release notes once, then update the marker file.
+pub async fn check_and_show_release_notes() {
+    let last = read_last_run_version();
+
+    // Always update the marker so we only show once.
+    write_last_run_version();
+
+    let Some(last) = last else {
+        // First-ever run — no previous version recorded, skip.
+        return;
+    };
+
+    if last == CURRENT_VERSION {
+        return;
+    }
+
+    // Version changed — fetch and display release notes.
+    match fetch_release_notes().await {
+        Ok(md) => {
+            let green = "\x1b[32m";
+            let reset = "\x1b[0m";
+            eprintln!("\n{green}Updated to v{CURRENT_VERSION} (was v{last}). What's new:{reset}\n");
+            render_release_notes(&md);
+            eprintln!();
+        }
+        Err(e) => {
+            tracing::debug!("Failed to fetch release notes: {e}");
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::is_newer;
+    use super::*;
 
     #[test]
     fn test_is_newer() {
@@ -389,5 +498,45 @@ mod tests {
         assert!(!is_newer("0.9.0", "0.9.0"));
         assert!(!is_newer("0.10.0", "0.9.0"));
         assert!(is_newer("0.9.0", "v0.9.1"));
+    }
+
+    #[test]
+    fn test_release_notes_url_respects_region() {
+        // Force global
+        std::env::set_var("LONGBRIDGE_REGION", "global");
+        let url_global = release_notes_url();
+        assert_eq!(
+            url_global,
+            "https://open.longbridge.com/docs/cli/release-notes.md"
+        );
+
+        // Force CN
+        std::env::set_var("LONGBRIDGE_REGION", "cn");
+        let url_cn = release_notes_url();
+        assert_eq!(
+            url_cn,
+            "https://open.longbridge.cn/docs/cli/release-notes.md"
+        );
+
+        std::env::remove_var("LONGBRIDGE_REGION");
+    }
+
+    #[test]
+    fn test_last_run_version_roundtrip() {
+        let path = last_run_version_path().expect("home dir should exist");
+        let backup = std::fs::read_to_string(&path).ok();
+
+        // Write and read back
+        write_last_run_version();
+        let v = read_last_run_version().expect("should read back");
+        assert_eq!(v, CURRENT_VERSION);
+
+        // Restore original state
+        match backup {
+            Some(original) => std::fs::write(&path, original).unwrap(),
+            None => {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -429,6 +429,17 @@ fn release_notes_url() -> String {
     format!("{}{RELEASE_NOTES_PATH}", get_host())
 }
 
+/// Strip YAML front matter (leading `---` … `---` block) from markdown.
+fn strip_frontmatter(s: &str) -> &str {
+    let trimmed = s.trim_start();
+    if let Some(rest) = trimmed.strip_prefix("---") {
+        if let Some(end) = rest.find("\n---") {
+            return rest[end + 4..].trim_start_matches('\n');
+        }
+    }
+    s
+}
+
 async fn fetch_release_notes() -> anyhow::Result<String> {
     let url = release_notes_url();
     let body = reqwest::Client::builder()
@@ -440,7 +451,7 @@ async fn fetch_release_notes() -> anyhow::Result<String> {
         .error_for_status()?
         .text()
         .await?;
-    Ok(body)
+    Ok(strip_frontmatter(&body).to_string())
 }
 
 fn render_release_notes(markdown: &str) {
@@ -498,6 +509,18 @@ mod tests {
         assert!(!is_newer("0.9.0", "0.9.0"));
         assert!(!is_newer("0.10.0", "0.9.0"));
         assert!(is_newer("0.9.0", "v0.9.1"));
+    }
+
+    #[test]
+    fn test_strip_frontmatter() {
+        let with_fm = "---\ntitle: Release Notes\nsidebar: 100\n---\n# Heading\nbody";
+        assert_eq!(strip_frontmatter(with_fm), "# Heading\nbody");
+
+        let no_fm = "# Heading\nbody";
+        assert_eq!(strip_frontmatter(no_fm), no_fm);
+
+        let incomplete = "---\ntitle: x\nno closing";
+        assert_eq!(strip_frontmatter(incomplete), incomplete);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- After `longbridge update` succeeds, fetch and render full release notes from `open.longbridge.com/docs/cli/release-notes.md` (supports `.cn`)
- On first run after any update method (brew, manual install), detect version change via `~/.longbridge/.terminal-last-run-version` and print a one-line notice with release notes URL (no network request, non-blocking)
- When a new version is available (`notify_if_update_available`), also show the release notes URL
- Add `longbridge update --release-notes` to view full release notes on demand
- Strip YAML frontmatter from fetched markdown before rendering
- Refactor URL constants: `HOST_GLOBAL`/`HOST_CN` + path constants to eliminate duplication
- Add `termimad` dependency for terminal markdown rendering
- Add unit tests and CI integration tests on Linux/macOS/Windows

## Test plan

- [x] `cargo fmt && cargo clippy` — clean
- [x] `cargo test -- update::tests` — 4 tests pass
- [x] `cargo run -- update --release-notes` — fetches and renders markdown (frontmatter stripped)
- [ ] CI `test-update.yml` verifies on all 3 platforms:
  - `--release-notes` flag returns content
  - First-run version detection prints release notes URL
  - Subsequent runs do not repeat the notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)