### PR TITLE
cli: Show release notes URL instead of full content on version change

### DIFF
--- a/.github/workflows/test-update.yml
+++ b/.github/workflows/test-update.yml
@@ -64,7 +64,7 @@ jobs:
           # Run with no subcommand (prints help, no auth needed) and capture output
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "Release notes" || { echo "FAIL: release notes not shown after version change"; exit 1; }
+          echo "$output" | grep -q "Updated to" || { echo "FAIL: release notes not shown after version change"; exit 1; }
           # Verify marker was updated so it won't show again
           version=$(cat ~/.longbridge/.terminal-last-run-version)
           [ "$version" = "0.14.0" ] || { echo "FAIL: last-run-version not updated (got: $version)"; exit 1; }
@@ -73,7 +73,7 @@ jobs:
         run: |
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          if echo "$output" | grep -q "Release notes"; then
+          if echo "$output" | grep -q "Updated to"; then
             echo "FAIL: release notes shown again on second run"
             exit 1
           fi
@@ -126,7 +126,7 @@ jobs:
           echo "0.0.1" > ~/.longbridge/.terminal-last-run-version
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "Release notes" || { echo "FAIL: release notes not shown after version change"; exit 1; }
+          echo "$output" | grep -q "Updated to" || { echo "FAIL: release notes not shown after version change"; exit 1; }
           version=$(cat ~/.longbridge/.terminal-last-run-version)
           [ "$version" = "0.14.0" ] || { echo "FAIL: last-run-version not updated (got: $version)"; exit 1; }
 
@@ -134,7 +134,7 @@ jobs:
         run: |
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          if echo "$output" | grep -q "Release notes"; then
+          if echo "$output" | grep -q "Updated to"; then
             echo "FAIL: release notes shown again on second run"
             exit 1
           fi
@@ -193,7 +193,7 @@ jobs:
           Set-Content -Path "$dir\.terminal-last-run-version" -Value "0.0.1" -NoNewline
           $output = cargo run 2>&1 | Out-String
           Write-Host $output
-          if ($output -notmatch "Release notes") {
+          if ($output -notmatch "Updated to") {
             throw "FAIL: release notes not shown after version change"
           }
           $version = (Get-Content "$dir\.terminal-last-run-version").Trim()
@@ -206,7 +206,7 @@ jobs:
         run: |
           $output = cargo run 2>&1 | Out-String
           Write-Host $output
-          if ($output -match "Release notes") {
+          if ($output -match "Updated to") {
             throw "FAIL: release notes shown again on second run"
           }
 

--- a/.github/workflows/test-update.yml
+++ b/.github/workflows/test-update.yml
@@ -64,7 +64,7 @@ jobs:
           # Run with no subcommand (prints help, no auth needed) and capture output
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "What's new" || { echo "FAIL: release notes not shown after version change"; exit 1; }
+          echo "$output" | grep -q "Release notes" || { echo "FAIL: release notes not shown after version change"; exit 1; }
           # Verify marker was updated so it won't show again
           version=$(cat ~/.longbridge/.terminal-last-run-version)
           [ "$version" = "0.14.0" ] || { echo "FAIL: last-run-version not updated (got: $version)"; exit 1; }
@@ -73,7 +73,7 @@ jobs:
         run: |
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          if echo "$output" | grep -q "What's new"; then
+          if echo "$output" | grep -q "Release notes"; then
             echo "FAIL: release notes shown again on second run"
             exit 1
           fi
@@ -126,7 +126,7 @@ jobs:
           echo "0.0.1" > ~/.longbridge/.terminal-last-run-version
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          echo "$output" | grep -q "What's new" || { echo "FAIL: release notes not shown after version change"; exit 1; }
+          echo "$output" | grep -q "Release notes" || { echo "FAIL: release notes not shown after version change"; exit 1; }
           version=$(cat ~/.longbridge/.terminal-last-run-version)
           [ "$version" = "0.14.0" ] || { echo "FAIL: last-run-version not updated (got: $version)"; exit 1; }
 
@@ -134,7 +134,7 @@ jobs:
         run: |
           output=$(cargo run 2>&1 || true)
           echo "$output"
-          if echo "$output" | grep -q "What's new"; then
+          if echo "$output" | grep -q "Release notes"; then
             echo "FAIL: release notes shown again on second run"
             exit 1
           fi
@@ -193,7 +193,7 @@ jobs:
           Set-Content -Path "$dir\.terminal-last-run-version" -Value "0.0.1" -NoNewline
           $output = cargo run 2>&1 | Out-String
           Write-Host $output
-          if ($output -notmatch "What's new") {
+          if ($output -notmatch "Release notes") {
             throw "FAIL: release notes not shown after version change"
           }
           $version = (Get-Content "$dir\.terminal-last-run-version").Trim()
@@ -206,7 +206,7 @@ jobs:
         run: |
           $output = cargo run 2>&1 | Out-String
           Write-Host $output
-          if ($output -match "What's new") {
+          if ($output -match "Release notes") {
             throw "FAIL: release notes shown again on second run"
           }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,8 +106,8 @@ async fn main() {
     // Kick off background version check to refresh the update cache for the next run.
     update::spawn_version_check();
 
-    // Show release notes once after a version change (e.g. brew upgrade, manual install).
-    update::check_and_show_release_notes().await;
+    // Show release notes URL once after a version change (e.g. brew upgrade, manual install).
+    update::check_and_show_release_notes();
 
     match cli.command {
         None => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -102,7 +102,11 @@ pub fn notify_if_update_available() {
     if is_newer(CURRENT_VERSION, &latest) {
         let green = "\x1b[32m";
         let reset = "\x1b[0m";
-        eprintln!("\nNew version {latest} is available, run `{green}longbridge update{reset}` to update.\n");
+        let url = release_notes_url();
+        eprintln!(
+            "\nNew version {latest} is available, run `{green}longbridge update{reset}` to update."
+        );
+        eprintln!("Release notes: {url}\n");
     }
 }
 
@@ -466,9 +470,9 @@ pub async fn cmd_release_notes() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Check if the binary version changed since the last run. If so, fetch and
-/// display release notes once, then update the marker file.
-pub async fn check_and_show_release_notes() {
+/// Check if the binary version changed since the last run. If so, print a
+/// one-line notice with the release notes URL (no network request).
+pub fn check_and_show_release_notes() {
     let last = read_last_run_version();
 
     // Always update the marker so we only show once.
@@ -483,19 +487,12 @@ pub async fn check_and_show_release_notes() {
         return;
     }
 
-    // Version changed — fetch and display release notes.
-    match fetch_release_notes().await {
-        Ok(md) => {
-            let green = "\x1b[32m";
-            let reset = "\x1b[0m";
-            eprintln!("\n{green}Updated to v{CURRENT_VERSION} (was v{last}). What's new:{reset}\n");
-            render_release_notes(&md);
-            eprintln!();
-        }
-        Err(e) => {
-            tracing::debug!("Failed to fetch release notes: {e}");
-        }
-    }
+    let green = "\x1b[32m";
+    let reset = "\x1b[0m";
+    let url = release_notes_url();
+    eprintln!(
+        "\n{green}Updated to v{CURRENT_VERSION} (was v{last}). Release notes: {url}{reset}\n"
+    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- On first run after update (any method: brew, manual install, etc.), print a one-line notice with release notes URL instead of fetching full markdown — no network request, non-blocking
- Add release notes URL to the "new version available" notice
- Users can run `longbridge update --release-notes` for full content

## Test plan

- [x] `cargo fmt && cargo clippy` — clean
- [x] `cargo test -- update::tests` — 4 tests pass
- [ ] CI `test-update.yml` verifies on Linux/macOS/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)