### PR TITLE
cli: Standardize command and parameter naming for consistency with industry conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AI-native CLI for the [Longbridge](https://longbridge.com) trading platform — 
 Covers every Longbridge OpenAPI endpoint: real-time quotes, depth, K-lines, options, and warrants for market data; account balances, stock and fund positions for portfolio management; and order submission, modification, cancellation, and execution history for trading. Designed for scripting, AI-agent tool-calling, and daily trading workflows from the terminal.
 
 ```bash
-$ longbridge static NVDA.US
+$ longbridge overview NVDA.US
 | Symbol  | Last    | Prev Close | Open    | High    | Low     | Volume    | Turnover        | Status |
 |---------|---------|------------|---------|---------|---------|-----------|-----------------|--------|
 | TSLA.US | 395.560 | 391.200    | 396.220 | 403.730 | 394.420 | 58068343  | 23138752546.000 | Normal |
@@ -113,12 +113,12 @@ longbridge depth TSLA.US                            # Level 2 order book depth (
 longbridge brokers 700.HK                           # Broker queue at each price level (HK market)
 longbridge trades TSLA.US [--count 50]              # Recent tick-by-tick trades
 longbridge intraday TSLA.US                         # Intraday minute-by-minute price and volume lines for today
-longbridge kline TSLA.US [--period day]             # OHLCV candlestick (K-line) data
+longbridge kline TSLA.US [--period day]             # OHLCV candlestick (K-line) data [--adjust none|forward]
 longbridge kline history TSLA.US --start 2024-01-01 # Historical OHLCV candlestick data within a date range
-longbridge static TSLA.US                           # Static reference info for one or more symbols
-longbridge calc-index TSLA.US --index pe,pb,eps     # Calculated financial indexes (PE, PB, EPS, turnover rate, etc.)
-longbridge capital flow TSLA.US                     # Intraday capital flow time series (large/medium/small money in vs out)
-longbridge capital dist TSLA.US                     # Capital distribution snapshot (large/medium/small inflow and outflow)
+longbridge overview TSLA.US                       # Static reference info for one or more symbols
+longbridge metrics TSLA.US --fields pe,pb,eps       # Calculated financial metrics (PE, PB, EPS, turnover rate, etc.)
+longbridge capital TSLA.US                          # Capital distribution snapshot (large/medium/small inflow and outflow)
+longbridge capital TSLA.US --flow                   # Intraday capital flow time series (large/medium/small money in vs out)
 longbridge market-temp [HK|US|CN|SG]                # Market sentiment temperature index (0–100, higher = more bullish)
 longbridge trading session                          # Trading session schedule (open/close times) for all markets
 longbridge trading days HK                          # Trading days and half-trading days for a market
@@ -149,7 +149,7 @@ longbridge option quote AAPL240119C190000          # Real-time quotes for option
 longbridge option chain AAPL.US                   # Option chain: list all expiry dates
 longbridge option chain AAPL.US --date 2024-01-19 # Option chain: strike prices for a given expiry
 longbridge warrant quote 12345.HK                 # Real-time quotes for warrant contracts
-longbridge warrant list 700.HK                    # Warrants linked to an underlying security
+longbridge warrant 700.HK                         # Warrants linked to an underlying security
 longbridge warrant issuers                        # Warrant issuer list (HK market)
 ```
 
@@ -197,20 +197,20 @@ longbridge watchlist pin --remove 700.HK           # Unpin securities
 ### Trading
 
 ```bash
-longbridge orders                                      # Today's orders, or historical orders with --history
-longbridge orders --history [--start 2024-01-01]       # Historical orders (use --symbol to filter)
-longbridge order <order_id>                            # Full detail for a single order including charges and history
-longbridge executions                                  # Today's trade executions (fills), or historical with --history
-longbridge buy TSLA.US 100 --price 250.00              # Submit a buy order (prompts for confirmation)
-longbridge sell TSLA.US 100 --price 260.00             # Submit a sell order (prompts for confirmation)
-longbridge cancel <order_id>                           # Cancel a pending order (prompts for confirmation)
-longbridge replace <order_id> --qty 200 --price 255.00 # Modify quantity or price of a pending order
-longbridge assets [--currency USD]                     # Asset overview: net assets, cash, buy power, margins, and per-currency breakdown
-longbridge cash-flow [--start 2024-01-01]              # Cash flow records (deposits, withdrawals, dividends, settlements)
-longbridge positions                                   # Current stock (equity) positions across all sub-accounts
-longbridge fund-positions                              # Current fund (mutual fund) positions across all sub-accounts
-longbridge margin-ratio TSLA.US                        # Margin ratio requirements for a symbol
-longbridge max-qty TSLA.US --side buy --price 250      # Estimate maximum buy or sell quantity given current account balance
+longbridge order                                           # Today's orders, or historical with --history
+longbridge order --history [--start 2024-01-01]            # Historical orders (use --symbol to filter)
+longbridge order detail <order_id>                         # Full detail for a single order including charges and history
+longbridge order executions                                # Today's trade executions (fills), or historical with --history
+longbridge order buy TSLA.US 100 --price 250.00            # Submit a buy order (prompts for confirmation)
+longbridge order sell TSLA.US 100 --price 260.00           # Submit a sell order (prompts for confirmation)
+longbridge order cancel <order_id>                         # Cancel a pending order (prompts for confirmation)
+longbridge order replace <order_id> --qty 200 --price 255.00 # Modify quantity or price of a pending order
+longbridge assets [--currency USD]                         # Asset overview: net assets, cash, buy power, margins, and per-currency breakdown
+longbridge cash-flow [--start 2024-01-01]                  # Cash flow records (deposits, withdrawals, dividends, settlements)
+longbridge positions                                       # Current stock (equity) positions across all sub-accounts
+longbridge fund-positions                                  # Current fund (mutual fund) positions across all sub-accounts
+longbridge margin-ratio TSLA.US                            # Margin ratio requirements for a symbol
+longbridge max-qty TSLA.US --side buy --price 250          # Estimate maximum buy or sell quantity given current account balance
 ```
 
 ### Profit Analysis

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -1067,8 +1067,8 @@ pub async fn cmd_finance_calendar(
     event_type: String,
     symbols: Vec<String>,
     markets: Vec<String>,
-    date: Option<String>,
-    date_end: Option<String>,
+    start: Option<String>,
+    end: Option<String>,
     count: u32,
     star: Vec<u32>,
     next: String,
@@ -1077,7 +1077,7 @@ pub async fn cmd_finance_calendar(
     verbose: bool,
 ) -> Result<()> {
     let today = time::OffsetDateTime::now_utc().date();
-    let start = date.unwrap_or_else(|| {
+    let start = start.unwrap_or_else(|| {
         if symbols.is_empty() {
             format!("{today}")
         } else {
@@ -1119,7 +1119,7 @@ pub async fn cmd_finance_calendar(
     for s in &star_strs {
         params.push(("star[]", s.as_str()));
     }
-    if let Some(ref end) = date_end {
+    if let Some(ref end) = end {
         params.push(("date_end", end.as_str()));
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -743,10 +743,10 @@ pub enum Commands {
         symbol: String,
     },
 
-    /// Corporate structure (subsidiary/parent companies)
+    /// Investment relations (subsidiary/parent companies)
     ///
-    /// Example: longbridge subsidiaries 700.HK
-    Subsidiaries {
+    /// Example: longbridge invest-relation 700.HK
+    InvestRelation {
         /// Symbol in <CODE>.<MARKET> format
         symbol: String,
     },
@@ -2066,7 +2066,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
         Commands::CorpAction { symbol } => {
             fundamental::cmd_corp_action(symbol, format, verbose).await
         }
-        Commands::Subsidiaries { symbol } => {
+        Commands::InvestRelation { symbol } => {
             fundamental::cmd_invest_relation(symbol, format, verbose).await
         }
         Commands::Constituent {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2793,7 +2793,7 @@ mod tests {
             assert_eq!(quantity, 100);
             assert_eq!(price, Some("250.00".to_string()));
             assert_eq!(order_type, "LO");
-            assert_eq!(tif, "Day");
+            assert_eq!(tif, "day");
         } else {
             panic!("expected Order Buy command");
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,7 +18,7 @@ pub mod watchlist;
 #[derive(ValueEnum, Clone, Default, Debug)]
 pub enum OutputFormat {
     #[default]
-    #[value(alias = "table")]
+    #[value(name = "table", alias = "pretty")]
     Pretty,
     Json,
 }
@@ -197,7 +197,7 @@ pub enum Commands {
     /// Use --session all to include pre/post-market candles (adds a Session column).
     /// Use the `history` subcommand to fetch a specific date range.
     /// Example: longbridge kline TSLA.US --period day --count 100
-    /// Example: longbridge kline TSLA.US --period 1h --adjust `forward_adjust`
+    /// Example: longbridge kline TSLA.US --period 1h --adjust forward
     /// Example: longbridge kline TSLA.US --period 1m --session all
     /// Example: longbridge kline history TSLA.US --start 2024-01-01 --end 2024-12-31
     Kline {
@@ -210,9 +210,8 @@ pub enum Commands {
         /// Number of candles to return (default: 100)
         #[arg(long, default_value = "100")]
         count: usize,
-        /// Price adjustment: `no_adjust` (default) | `forward_adjust`
-        /// Aliases: none=`no_adjust`, forward=`forward_adjust`
-        #[arg(long, default_value = "no_adjust")]
+        /// Price adjustment: `none` (default) | `forward`
+        #[arg(long, default_value = "none")]
         adjust: String,
         /// Trade session filter: `intraday` (default) | `all` (includes pre/post market)
         #[arg(long, default_value = "intraday")]
@@ -224,15 +223,15 @@ pub enum Commands {
     /// Static reference info for one or more symbols
     ///
     /// Returns: name, exchange, currency, `lot_size`, `total_shares`, `circulating_shares`, EPS, BPS, dividend.
-    /// Example: longbridge static TSLA.US 700.HK
-    Static {
+    /// Example: longbridge overview TSLA.US 700.HK
+    Overview {
         /// One or more symbols in <CODE>.<MARKET> format
         symbols: Vec<String>,
     },
 
-    /// Calculated financial indexes (PE, PB, DPS rate, turnover rate, etc.)
+    /// Calculated financial metrics (PE, PB, DPS rate, turnover rate, etc.)
     ///
-    /// Full index list:
+    /// Full field list:
     ///   `last_done`  `change_value`  `change_rate`  volume  turnover  `ytd_change_rate`
     ///   `turnover_rate`  `total_market_value`  `capital_flow`  amplitude  `volume_ratio`
     ///   pe (alias: `pe_ttm`)  pb  `dps_rate` (alias: `dividend_yield`)
@@ -242,18 +241,18 @@ pub enum Commands {
     ///   `outstanding_qty`  `outstanding_ratio`  premium  `itm_otm`
     ///   `warrant_delta`  `call_price`  `to_call_price`  `effective_leverage`
     ///   `leverage_ratio`  `conversion_ratio`  `balance_point`
-    /// Example: longbridge calc-index TSLA.US AAPL.US --index pe,pb,`turnover_rate`
-    CalcIndex {
+    /// Example: longbridge metrics TSLA.US AAPL.US --fields pe,pb,`turnover_rate`
+    Metrics {
         /// One or more symbols in <CODE>.<MARKET> format
         symbols: Vec<String>,
-        /// Comma-separated indexes to compute (default: pe,pb,`dps_rate`,`turnover_rate`,`total_market_value`)
-        /// Unknown index names are silently ignored.
+        /// Comma-separated fields to compute (default: pe,pb,`dps_rate`,`turnover_rate`,`total_market_value`)
+        /// Unknown field names are silently ignored.
         #[arg(
             long,
             value_delimiter = ',',
             default_value = "pe,pb,dps_rate,turnover_rate,total_market_value"
         )]
-        index: Vec<String>,
+        fields: Vec<String>,
     },
 
     /// Intraday capital distribution snapshot, or flow time series with --flow
@@ -430,10 +429,10 @@ pub enum Commands {
         market: Vec<String>,
         /// Start date (YYYY-MM-DD), defaults to today
         #[arg(long)]
-        date: Option<String>,
+        start: Option<String>,
         /// End date (YYYY-MM-DD), defaults to no limit
         #[arg(long)]
-        end_date: Option<String>,
+        end: Option<String>,
         /// Max events returned (default: 100)
         #[arg(long, default_value = "100")]
         count: u32,
@@ -548,9 +547,9 @@ pub enum Commands {
         /// Statement type: daily (default) | monthly
         #[arg(long = "type", default_value = "daily")]
         statement_type: String,
-        /// Start date of query in YYYYMMDD format (e.g. 20260121). Defaults to 30 days ago.
+        /// Start date (YYYY-MM-DD, e.g. 2026-01-21). Defaults to 30 days ago.
         #[arg(long)]
-        start_date: Option<i32>,
+        start_date: Option<String>,
         /// Number of records to return. Defaults to 30 for daily, 12 for monthly.
         #[arg(long)]
         limit: Option<i32>,
@@ -744,10 +743,10 @@ pub enum Commands {
         symbol: String,
     },
 
-    /// Investment relations (subsidiary/parent companies)
+    /// Corporate structure (subsidiary/parent companies)
     ///
-    /// Example: longbridge invest-relation 700.HK
-    InvestRelation {
+    /// Example: longbridge subsidiaries 700.HK
+    Subsidiaries {
         /// Symbol in <CODE>.<MARKET> format
         symbol: String,
     },
@@ -1240,9 +1239,9 @@ pub enum StatementCmd {
         /// Statement type: daily (default) | monthly
         #[arg(long = "type", default_value = "daily")]
         statement_type: String,
-        /// Start date of query in YYYYMMDD format (e.g. 20260121). Defaults to 30 days ago.
+        /// Start date (YYYY-MM-DD, e.g. 2026-01-21). Defaults to 30 days ago.
         #[arg(long)]
-        start_date: Option<i32>,
+        start_date: Option<String>,
         /// Number of records to return. Defaults to 30 for daily, 12 for monthly.
         #[arg(long)]
         limit: Option<i32>,
@@ -1357,9 +1356,9 @@ pub enum OrderCmd {
         ///   (case-insensitive, default: LO)
         #[arg(long, default_value = "LO")]
         order_type: String,
-        /// Time in force: Day | `GoodTilCanceled` (alias: gtc) | `GoodTilDate` (alias: gtd)
-        /// (case-insensitive, default: Day)
-        #[arg(long, default_value = "Day")]
+        /// Time in force: day | gtc (GoodTilCanceled) | gtd (GoodTilDate)
+        /// (case-insensitive)
+        #[arg(long, default_value = "day")]
         tif: String,
         /// Skip confirmation prompt (useful for scripting and AI agents)
         #[arg(long, short = 'y')]
@@ -1410,9 +1409,9 @@ pub enum OrderCmd {
         ///   (case-insensitive, default: LO)
         #[arg(long, default_value = "LO")]
         order_type: String,
-        /// Time in force: Day | `GoodTilCanceled` (alias: gtc) | `GoodTilDate` (alias: gtd)
-        /// (case-insensitive, default: Day)
-        #[arg(long, default_value = "Day")]
+        /// Time in force: day | gtc (GoodTilCanceled) | gtd (GoodTilDate)
+        /// (case-insensitive)
+        #[arg(long, default_value = "day")]
         tif: String,
         /// Skip confirmation prompt (useful for scripting and AI agents)
         #[arg(long, short = 'y')]
@@ -1640,8 +1639,8 @@ pub enum KlineCmd {
         /// End date (YYYY-MM-DD). Must be used together with --start.
         #[arg(long)]
         end: Option<String>,
-        /// Price adjustment: `no_adjust` (default) | `forward_adjust`
-        #[arg(long, default_value = "no_adjust")]
+        /// Price adjustment: `none` (default) | `forward`
+        #[arg(long, default_value = "none")]
         adjust: String,
         /// Trade session filter: intraday (default) | all (includes pre/post market)
         #[arg(long, default_value = "intraday")]
@@ -1718,9 +1717,9 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                 quote::cmd_kline(sym, &period, count, &adjust, &session, format).await
             }
         },
-        Commands::Static { symbols } => quote::cmd_static(symbols, format).await,
-        Commands::CalcIndex { symbols, index } => {
-            quote::cmd_calc_index(symbols, index, format).await
+        Commands::Overview { symbols } => quote::cmd_static(symbols, format).await,
+        Commands::Metrics { symbols, fields } => {
+            quote::cmd_calc_index(symbols, fields, format).await
         }
         Commands::Capital { symbol, flow } => {
             if flow {
@@ -1800,15 +1799,15 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             event_type,
             symbol,
             market,
-            date,
-            end_date,
+            start,
+            end,
             count,
             star,
             next,
             offset,
         } => {
             fundamental::cmd_finance_calendar(
-                event_type, symbol, market, date, end_date, count, star, next, offset, format,
+                event_type, symbol, market, start, end, count, star, next, offset, format,
                 verbose,
             )
             .await
@@ -2067,7 +2066,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
         Commands::CorpAction { symbol } => {
             fundamental::cmd_corp_action(symbol, format, verbose).await
         }
-        Commands::InvestRelation { symbol } => {
+        Commands::Subsidiaries { symbol } => {
             fundamental::cmd_invest_relation(symbol, format, verbose).await
         }
         Commands::Constituent {
@@ -2311,7 +2310,7 @@ mod tests {
             assert_eq!(symbol, Some("TSLA.US".to_string()));
             assert_eq!(period, "day");
             assert_eq!(count, 100);
-            assert_eq!(adjust, "no_adjust");
+            assert_eq!(adjust, "none");
         } else {
             panic!("expected Kline command");
         }
@@ -2366,40 +2365,40 @@ mod tests {
     }
 
     #[test]
-    fn test_static_subcommand() {
-        let cli = parse(&["longbridge", "static", "TSLA.US", "700.HK"]).unwrap();
-        if let Some(Commands::Static { symbols }) = cli.command {
+    fn test_overview_subcommand() {
+        let cli = parse(&["longbridge", "overview", "TSLA.US", "700.HK"]).unwrap();
+        if let Some(Commands::Overview { symbols }) = cli.command {
             assert_eq!(symbols.len(), 2);
         } else {
-            panic!("expected Static command");
+            panic!("expected Overview command");
         }
     }
 
     #[test]
-    fn test_calc_index_default_indexes() {
-        let cli = parse(&["longbridge", "calc-index", "TSLA.US"]).unwrap();
-        if let Some(Commands::CalcIndex { symbols, index }) = cli.command {
+    fn test_metrics_default_fields() {
+        let cli = parse(&["longbridge", "metrics", "TSLA.US"]).unwrap();
+        if let Some(Commands::Metrics { symbols, fields }) = cli.command {
             assert_eq!(symbols, vec!["TSLA.US"]);
-            assert!(index.contains(&"pe".to_string()));
+            assert!(fields.contains(&"pe".to_string()));
         } else {
-            panic!("expected CalcIndex command");
+            panic!("expected Metrics command");
         }
     }
 
     #[test]
-    fn test_calc_index_custom_indexes() {
+    fn test_metrics_custom_fields() {
         let cli = parse(&[
             "longbridge",
-            "calc-index",
+            "metrics",
             "TSLA.US",
-            "--index",
+            "--fields",
             "pe,pb,eps",
         ])
         .unwrap();
-        if let Some(Commands::CalcIndex { index, .. }) = cli.command {
-            assert_eq!(index, vec!["pe", "pb", "eps"]);
+        if let Some(Commands::Metrics { fields, .. }) = cli.command {
+            assert_eq!(fields, vec!["pe", "pb", "eps"]);
         } else {
-            panic!("expected CalcIndex command");
+            panic!("expected Metrics command");
         }
     }
 

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -41,9 +41,9 @@ fn parse_period(s: &str) -> Result<Period> {
 
 fn parse_adjust(s: &str) -> Result<AdjustType> {
     match s {
-        "no_adjust" | "none" => Ok(AdjustType::NoAdjust),
-        "forward_adjust" | "forward" => Ok(AdjustType::ForwardAdjust),
-        _ => bail!("Unknown adjust type '{s}'. Use: no_adjust forward_adjust"),
+        "none" | "no_adjust" => Ok(AdjustType::NoAdjust),
+        "forward" | "forward_adjust" => Ok(AdjustType::ForwardAdjust),
+        _ => bail!("Unknown adjust type '{s}'. Use: none forward"),
     }
 }
 

--- a/src/cli/statement.rs
+++ b/src/cli/statement.rs
@@ -9,6 +9,24 @@ use unicode_width::UnicodeWidthStr;
 
 use super::{output::print_table, ExportFormat, OutputFormat, StatementCmd, StatementSection};
 
+/// Parse a YYYY-MM-DD date string into YYYYMMDD integer required by the SDK.
+fn parse_date_to_yyyymmdd(s: &str) -> anyhow::Result<i32> {
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 3 {
+        anyhow::bail!("Invalid date '{s}': expected YYYY-MM-DD format (e.g. 2026-01-21)");
+    }
+    let year: i32 = parts[0]
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Invalid year in date '{s}'"))?;
+    let month: i32 = parts[1]
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Invalid month in date '{s}'"))?;
+    let day: i32 = parts[2]
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Invalid day in date '{s}'"))?;
+    Ok(year * 10000 + month * 100 + day)
+}
+
 /// Return the first non-empty string from the candidates, or `""`.
 fn first_non_empty<'a>(candidates: &[&'a str]) -> &'a str {
     candidates
@@ -26,18 +44,21 @@ pub async fn cmd_statement(cmd: StatementCmd, format: &OutputFormat) -> Result<(
             limit,
         } => {
             let is_monthly = matches!(statement_type.to_lowercase().as_str(), "monthly" | "m");
-            let start_date = start_date.unwrap_or_else(|| {
-                let now = OffsetDateTime::now_utc();
-                if is_monthly {
-                    let total_months = now.year() * 12 + now.month() as i32 - 1 - 12;
-                    let year = total_months / 12;
-                    let month = total_months % 12 + 1;
-                    year * 10000 + month * 100 + 1
-                } else {
-                    let d = now - time::Duration::days(30);
-                    d.year() * 10000 + i32::from(d.month() as u8) * 100 + i32::from(d.day())
+            let start_date = match start_date {
+                Some(s) => parse_date_to_yyyymmdd(&s)?,
+                None => {
+                    let now = OffsetDateTime::now_utc();
+                    if is_monthly {
+                        let total_months = now.year() * 12 + now.month() as i32 - 1 - 12;
+                        let year = total_months / 12;
+                        let month = total_months % 12 + 1;
+                        year * 10000 + month * 100 + 1
+                    } else {
+                        let d = now - time::Duration::days(30);
+                        d.year() * 10000 + i32::from(d.month() as u8) * 100 + i32::from(d.day())
+                    }
                 }
-            });
+            };
             let limit = limit.unwrap_or(if is_monthly { 12 } else { 30 });
             cmd_list(&statement_type, start_date, limit, format).await
         }

--- a/src/cli/trade.rs
+++ b/src/cli/trade.rs
@@ -48,7 +48,7 @@ fn parse_tif(s: &str) -> Result<TimeInForceType> {
         "day" => Ok(TimeInForceType::Day),
         "gtc" | "goodtilcanceled" => Ok(TimeInForceType::GoodTilCanceled),
         "gtd" | "goodtildate" => Ok(TimeInForceType::GoodTilDate),
-        _ => bail!("Unknown time in force '{s}'. Use: Day GoodTilCanceled GoodTilDate"),
+        _ => bail!("Unknown time in force '{s}'. Use: day gtc gtd"),
     }
 }
 


### PR DESCRIPTION
## Summary

Standardize CLI command and parameter naming for consistency with industry conventions (Bloomberg, GitHub CLI, AWS CLI):

- **`static` → `overview`**: More descriptive name for stock overview data
- **`calc-index` → `metrics`**: Industry-standard term; `--index` flag renamed to `--fields`
- **`--format pretty` → `--format table`**: `table` is the conventional name; `pretty` kept as alias
- **`--adjust no_adjust/forward_adjust` → `none/forward`**: Shorter, cleaner values; old values kept as aliases
- **`--tif Day/GoodTilCanceled/GoodTilDate` → `day/gtc/gtd`**: Lowercase and standard FIX Protocol abbreviations
- **`finance-calendar --date/--date-end` → `--start/--end`**: Consistent with `kline` and other date-range flags
- **`statement --start-date`**: Now accepts `YYYY-MM-DD` format (converts to `YYYYMMDD` internally)
- **README**: Updated all command examples to reflect the above renames

## Test plan

- [x] `cargo run -- overview TSLA.US 700.HK` — returns stock overview table
- [x] `cargo run -- metrics TSLA.US --fields pe,pb,turnover_rate` — returns metric values
- [x] `cargo run -- kline TSLA.US --period day --count 3 --adjust none` — returns candles
- [x] `cargo run -- kline TSLA.US --period day --count 3 --adjust forward` — returns adjusted candles
- [x] `cargo run -- finance-calendar financial --start 2026-04-01 --end 2026-04-30 --count 5` — returns events
- [x] `cargo run -- statement --start-date 2026-01-01` — YYYY-MM-DD parsed correctly
- [x] `cargo run -- --format table quote TSLA.US` — table alias renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)