### PR TITLE
cli: Revert command renames from #102

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AI-native CLI for the [Longbridge](https://longbridge.com) trading platform — 
 Covers every Longbridge OpenAPI endpoint: real-time quotes, depth, K-lines, options, and warrants for market data; account balances, stock and fund positions for portfolio management; and order submission, modification, cancellation, and execution history for trading. Designed for scripting, AI-agent tool-calling, and daily trading workflows from the terminal.
 
 ```bash
-$ longbridge overview NVDA.US
+$ longbridge static NVDA.US
 | Symbol  | Last    | Prev Close | Open    | High    | Low     | Volume    | Turnover        | Status |
 |---------|---------|------------|---------|---------|---------|-----------|-----------------|--------|
 | TSLA.US | 395.560 | 391.200    | 396.220 | 403.730 | 394.420 | 58068343  | 23138752546.000 | Normal |
@@ -115,8 +115,8 @@ longbridge trades TSLA.US [--count 50]              # Recent tick-by-tick trades
 longbridge intraday TSLA.US                         # Intraday minute-by-minute price and volume lines for today
 longbridge kline TSLA.US [--period day]             # OHLCV candlestick (K-line) data [--adjust none|forward]
 longbridge kline history TSLA.US --start 2024-01-01 # Historical OHLCV candlestick data within a date range
-longbridge overview TSLA.US                       # Static reference info for one or more symbols
-longbridge metrics TSLA.US --fields pe,pb,eps       # Calculated financial metrics (PE, PB, EPS, turnover rate, etc.)
+longbridge static TSLA.US                            # Static reference info for one or more symbols
+longbridge calc-index TSLA.US --fields pe,pb,eps     # Calculated financial indexes (PE, PB, EPS, turnover rate, etc.)
 longbridge capital TSLA.US                          # Capital distribution snapshot (large/medium/small inflow and outflow)
 longbridge capital TSLA.US --flow                   # Intraday capital flow time series (large/medium/small money in vs out)
 longbridge market-temp [HK|US|CN|SG]                # Market sentiment temperature index (0–100, higher = more bullish)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -223,15 +223,15 @@ pub enum Commands {
     /// Static reference info for one or more symbols
     ///
     /// Returns: name, exchange, currency, `lot_size`, `total_shares`, `circulating_shares`, EPS, BPS, dividend.
-    /// Example: longbridge overview TSLA.US 700.HK
-    Overview {
+    /// Example: longbridge static TSLA.US 700.HK
+    Static {
         /// One or more symbols in <CODE>.<MARKET> format
         symbols: Vec<String>,
     },
 
-    /// Calculated financial metrics (PE, PB, DPS rate, turnover rate, etc.)
+    /// Calculated financial indexes (PE, PB, DPS rate, turnover rate, etc.)
     ///
-    /// Full field list:
+    /// Full index list:
     ///   `last_done`  `change_value`  `change_rate`  volume  turnover  `ytd_change_rate`
     ///   `turnover_rate`  `total_market_value`  `capital_flow`  amplitude  `volume_ratio`
     ///   pe (alias: `pe_ttm`)  pb  `dps_rate` (alias: `dividend_yield`)
@@ -241,8 +241,8 @@ pub enum Commands {
     ///   `outstanding_qty`  `outstanding_ratio`  premium  `itm_otm`
     ///   `warrant_delta`  `call_price`  `to_call_price`  `effective_leverage`
     ///   `leverage_ratio`  `conversion_ratio`  `balance_point`
-    /// Example: longbridge metrics TSLA.US AAPL.US --fields pe,pb,`turnover_rate`
-    Metrics {
+    /// Example: longbridge calc-index TSLA.US AAPL.US --fields pe,pb,`turnover_rate`
+    CalcIndex {
         /// One or more symbols in <CODE>.<MARKET> format
         symbols: Vec<String>,
         /// Comma-separated fields to compute (default: pe,pb,`dps_rate`,`turnover_rate`,`total_market_value`)
@@ -1717,8 +1717,8 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                 quote::cmd_kline(sym, &period, count, &adjust, &session, format).await
             }
         },
-        Commands::Overview { symbols } => quote::cmd_static(symbols, format).await,
-        Commands::Metrics { symbols, fields } => {
+        Commands::Static { symbols } => quote::cmd_static(symbols, format).await,
+        Commands::CalcIndex { symbols, fields } => {
             quote::cmd_calc_index(symbols, fields, format).await
         }
         Commands::Capital { symbol, flow } => {
@@ -2365,40 +2365,40 @@ mod tests {
     }
 
     #[test]
-    fn test_overview_subcommand() {
-        let cli = parse(&["longbridge", "overview", "TSLA.US", "700.HK"]).unwrap();
-        if let Some(Commands::Overview { symbols }) = cli.command {
+    fn test_static_subcommand() {
+        let cli = parse(&["longbridge", "static", "TSLA.US", "700.HK"]).unwrap();
+        if let Some(Commands::Static { symbols }) = cli.command {
             assert_eq!(symbols.len(), 2);
         } else {
-            panic!("expected Overview command");
+            panic!("expected Static command");
         }
     }
 
     #[test]
-    fn test_metrics_default_fields() {
-        let cli = parse(&["longbridge", "metrics", "TSLA.US"]).unwrap();
-        if let Some(Commands::Metrics { symbols, fields }) = cli.command {
+    fn test_calc_index_default_fields() {
+        let cli = parse(&["longbridge", "calc-index", "TSLA.US"]).unwrap();
+        if let Some(Commands::CalcIndex { symbols, fields }) = cli.command {
             assert_eq!(symbols, vec!["TSLA.US"]);
             assert!(fields.contains(&"pe".to_string()));
         } else {
-            panic!("expected Metrics command");
+            panic!("expected CalcIndex command");
         }
     }
 
     #[test]
-    fn test_metrics_custom_fields() {
+    fn test_calc_index_custom_fields() {
         let cli = parse(&[
             "longbridge",
-            "metrics",
+            "calc-index",
             "TSLA.US",
             "--fields",
             "pe,pb,eps",
         ])
         .unwrap();
-        if let Some(Commands::Metrics { fields, .. }) = cli.command {
+        if let Some(Commands::CalcIndex { fields, .. }) = cli.command {
             assert_eq!(fields, vec!["pe", "pb", "eps"]);
         } else {
-            panic!("expected Metrics command");
+            panic!("expected CalcIndex command");
         }
     }
 


### PR DESCRIPTION
## Summary
- Restore original command names `static` and `calc-index` that were renamed to `overview` and `metrics` in #102
- All parameter improvements from #102 are preserved (`--fields`, `--adjust none/forward`, `--tif day/gtc/gtd`, `--start/--end`, `--format table`, statement YYYY-MM-DD parsing)

## Test plan
- [ ] `cargo run -- static TSLA.US` works
- [ ] `cargo run -- calc-index TSLA.US --fields pe,pb` works
- [ ] `cargo run -- overview` shows unknown command error
- [ ] `cargo run -- metrics` shows unknown command error

🤖 Generated with [Claude Code](https://claude.com/claude-code)