### PR TITLE
cli: Add `alert` enable/disable subcommands

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1074,6 +1074,20 @@ pub enum AlertCmd {
         /// Alert id from the `id` column in `longbridge alert`
         id: String,
     },
+    /// Enable a price alert by id
+    ///
+    /// Example: longbridge alert enable 486469
+    Enable {
+        /// Alert id from the `id` column in `longbridge alert`
+        id: String,
+    },
+    /// Disable a price alert by id
+    ///
+    /// Example: longbridge alert disable 486469
+    Disable {
+        /// Alert id from the `id` column in `longbridge alert`
+        id: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2132,6 +2146,12 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             }
             Some(AlertCmd::Delete { id }) => {
                 trade::cmd_alert_delete(id, format, verbose).await
+            }
+            Some(AlertCmd::Enable { id }) => {
+                trade::cmd_alert_set_enabled(id, true, format, verbose).await
+            }
+            Some(AlertCmd::Disable { id }) => {
+                trade::cmd_alert_set_enabled(id, false, format, verbose).await
             }
             None => trade::cmd_alert_list(symbol, format, verbose).await,
         },

--- a/src/cli/trade.rs
+++ b/src/cli/trade.rs
@@ -1322,6 +1322,60 @@ pub async fn cmd_alert_delete(id: String, format: &OutputFormat, verbose: bool) 
     Ok(())
 }
 
+pub async fn cmd_alert_set_enabled(
+    id: String,
+    enabled: bool,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    // Fetch the existing alert to get all required fields
+    let list_data = super::api::http_get("/v1/notify/reminders", &[], verbose).await?;
+    let stocks = list_data["lists"].as_array().unwrap_or(&Vec::new()).clone();
+
+    let id_num: i64 = id.parse().unwrap_or(0);
+    let mut found = false;
+
+    for stock in &stocks {
+        let counter_id = stock["counter_id"].as_str().unwrap_or("");
+        if let Some(indicators) = stock["indicators"].as_array() {
+            for ind in indicators {
+                let ind_id = ind["id"].as_str().and_then(|s| s.parse::<i64>().ok()).unwrap_or(0);
+                if ind_id == id_num {
+                    let body = serde_json::json!({
+                        "id": ind_id,
+                        "counter_id": counter_id,
+                        "indicator_id": ind["indicator_id"].as_str().unwrap_or("1"),
+                        "value_map": ind["value_map"],
+                        "frequency": ind["frequency"],
+                        "enabled": enabled,
+                        "scope": ind["scope"],
+                        "state": ind["state"],
+                    });
+                    super::api::http_post("/v1/notify/reminders", body, verbose).await?;
+                    found = true;
+                    break;
+                }
+            }
+        }
+        if found {
+            break;
+        }
+    }
+
+    if !found {
+        bail!("Alert id {id} not found");
+    }
+
+    let action = if enabled { "enabled" } else { "disabled" };
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::json!({"id": id, "status": action}));
+        }
+        OutputFormat::Pretty => println!("Alert {id} {action}"),
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- Add `longbridge alert enable <id>` and `longbridge alert disable <id>` subcommands to toggle price alerts without deleting them
- Implementation fetches the existing alert's full fields then re-posts with updated `enabled` state (API only supports POST upsert)

## Test plan
- [x] `longbridge alert disable 112326` — disables alert, confirmed via `longbridge alert TSLA.US`
- [x] `longbridge alert enable 112326` — re-enables alert, ✓ reappears in list
- [x] `longbridge alert disable <invalid_id>` — returns "Alert id not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)