### PR TITLE
cli: Add `sharelist` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,21 @@ longbridge investors 0001067983 --top 20                      # Show top 20 posi
 longbridge investors 0001067983 --format json                 # Export holdings as JSON
 longbridge investors changes 0001067983                       # Quarter-over-quarter changes (NEW/ADDED/REDUCED/EXITED)
 longbridge investors changes 0001067983 --from 2024-12-31     # Compare latest vs a specific period
+
+longbridge daily-coin                                         # List all DCA plans
+longbridge daily-coin list --status Active                    # Filter by status: Active | Suspended | Finished
+longbridge daily-coin list --symbol TSLA.US                   # Filter by symbol
+longbridge daily-coin create TSLA.US --amount 500 --frequency weekly --day-of-week mon  # Create weekly DCA plan
+longbridge daily-coin create 700.HK --amount 1000 --frequency monthly --day-of-month 15  # Monthly DCA plan
+longbridge daily-coin update <PLAN_ID> --amount 800           # Update plan amount
+longbridge daily-coin pause <PLAN_ID>                         # Suspend a DCA plan
+longbridge daily-coin resume <PLAN_ID>                        # Resume a suspended plan
+longbridge daily-coin stop <PLAN_ID>                          # Terminate a DCA plan
+longbridge daily-coin records <PLAN_ID>                       # Execution records for a plan
+longbridge daily-coin stats                                   # DCA statistics summary
+longbridge daily-coin calc-date TSLA.US --frequency weekly --day-of-week fri  # Calculate next trade date
+longbridge daily-coin check TSLA.US AAPL.US 700.HK           # Check which symbols support DCA
+longbridge daily-coin set-reminder 6                          # Set reminder hours before trade (1 | 6 | 12)
 ```
 
 <!-- COMMANDS_END -->

--- a/README.md
+++ b/README.md
@@ -271,15 +271,14 @@ longbridge daily-coin set-reminder 6                          # Set reminder hou
 longbridge sharelist                                          # List own and subscribed sharelists
 longbridge sharelist list --subscription                      # Show subscribed sharelists only
 longbridge sharelist list --own                               # Show own public sharelists only
+longbridge sharelist list --size 50 --tail-mark <CURSOR>      # Paginate results
+longbridge sharelist detail <ID>                              # Full details including constituent stocks
+longbridge sharelist create --name "My Picks" --description "..." --cover "url" --stock-group-id <GID>  # Create a sharelist
+longbridge sharelist delete <ID>                              # Delete a sharelist
+longbridge sharelist add <ID> TSLA.US AAPL.US                # Add stocks to a sharelist
+longbridge sharelist remove <ID> TSLA.US                     # Remove stocks from a sharelist
+longbridge sharelist sort <ID> TSLA.US AAPL.US 700.HK        # Reorder stocks in a sharelist
 longbridge sharelist hot [--size 20]                          # Hot (trending) sharelists
-longbridge sharelist official [--size 20]                     # Official Longbridge-curated sharelists
-longbridge sharelist stock TSLA.US [--count 10]               # Sharelists containing a specific stock
-longbridge sharelist members <ID>                             # Follower list for a sharelist
-longbridge sharelist logs <ID> [--year 2024]                  # Stock addition/removal history
-longbridge sharelist mark-read <ID> <LOG_ID>                  # Mark a change-log entry as read
-longbridge sharelist sort <ID> TSLA.US AAPL.US 700.HK         # Reorder stocks in a group sharelist
-longbridge sharelist remove-stocks <ID> TSLA.US               # Remove stocks from a group sharelist
-longbridge sharelist index 8111112-US                         # Day / YTD performance for a sharelist
 ```
 
 <!-- COMMANDS_END -->

--- a/README.md
+++ b/README.md
@@ -265,22 +265,6 @@ longbridge daily-coin check TSLA.US AAPL.US 700.HK           # Check which symbo
 longbridge daily-coin set-reminder 6                          # Set reminder hours before trade (1 | 6 | 12)
 ```
 
-### Sharelist (股单)
-
-```bash
-longbridge sharelist                                          # List own and subscribed sharelists
-longbridge sharelist list --subscription                      # Show subscribed sharelists only
-longbridge sharelist list --own                               # Show own public sharelists only
-longbridge sharelist list --size 50 --tail-mark <CURSOR>      # Paginate results
-longbridge sharelist detail <ID>                              # Full details including constituent stocks
-longbridge sharelist create --name "My Picks" --description "..." --cover "url" --stock-group-id <GID>  # Create a sharelist
-longbridge sharelist delete <ID>                              # Delete a sharelist
-longbridge sharelist add <ID> TSLA.US AAPL.US                # Add stocks to a sharelist
-longbridge sharelist remove <ID> TSLA.US                     # Remove stocks from a sharelist
-longbridge sharelist sort <ID> TSLA.US AAPL.US 700.HK        # Reorder stocks in a sharelist
-longbridge sharelist hot [--size 20]                          # Hot (trending) sharelists
-```
-
 <!-- COMMANDS_END -->
 
 ### Symbol Format

--- a/README.md
+++ b/README.md
@@ -194,6 +194,20 @@ longbridge watchlist pin TSLA.US AAPL.US           # Pin securities to the top o
 longbridge watchlist pin --remove 700.HK           # Unpin securities
 ```
 
+### Sharelist
+
+```bash
+longbridge sharelist                                              # List own and subscribed sharelists
+longbridge sharelist [--count 50]                                 # List with custom page size
+longbridge sharelist detail <id>                                  # Show full details and constituent stocks
+longbridge sharelist create --name "My Picks" [--description "…"] # Create a new sharelist
+longbridge sharelist delete <id>                                  # Delete a sharelist
+longbridge sharelist add <id> TSLA.US AAPL.US 700.HK             # Add stocks to a sharelist
+longbridge sharelist remove <id> TSLA.US                          # Remove stocks from a sharelist
+longbridge sharelist sort <id> TSLA.US AAPL.US 700.HK            # Reorder stocks in a sharelist
+longbridge sharelist popular [--count 10]                         # Get popular (trending) sharelists
+```
+
 ### Trading
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -265,6 +265,23 @@ longbridge daily-coin check TSLA.US AAPL.US 700.HK           # Check which symbo
 longbridge daily-coin set-reminder 6                          # Set reminder hours before trade (1 | 6 | 12)
 ```
 
+### Sharelist (股单)
+
+```bash
+longbridge sharelist                                          # List own and subscribed sharelists
+longbridge sharelist list --subscription                      # Show subscribed sharelists only
+longbridge sharelist list --own                               # Show own public sharelists only
+longbridge sharelist hot [--size 20]                          # Hot (trending) sharelists
+longbridge sharelist official [--size 20]                     # Official Longbridge-curated sharelists
+longbridge sharelist stock TSLA.US [--count 10]               # Sharelists containing a specific stock
+longbridge sharelist members <ID>                             # Follower list for a sharelist
+longbridge sharelist logs <ID> [--year 2024]                  # Stock addition/removal history
+longbridge sharelist mark-read <ID> <LOG_ID>                  # Mark a change-log entry as read
+longbridge sharelist sort <ID> TSLA.US AAPL.US 700.HK         # Reorder stocks in a group sharelist
+longbridge sharelist remove-stocks <ID> TSLA.US               # Remove stocks from a group sharelist
+longbridge sharelist index 8111112-US                         # Day / YTD performance for a sharelist
+```
+
 <!-- COMMANDS_END -->
 
 ### Symbol Format

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -105,7 +105,7 @@ struct AccountInfo {
     name: Option<String>,
 }
 
-/// Fetch account_no and account_type from the most recent daily statement.
+/// Fetch `account_no` and `account_type` from the most recent daily statement.
 /// Returns None if no statement is available or the fetch fails.
 async fn fetch_account_info_from_statement() -> Option<(String, String, String)> {
     let ctx = crate::openapi::statement();
@@ -186,10 +186,7 @@ pub async fn cmd_auth_status(format: &OutputFormat) -> Result<()> {
 
     // ── Connect and fetch account info ────────────────────────────────────────
     let account = match crate::openapi::init_contexts().await {
-        Ok(_) => match fetch_account_info().await {
-            Ok(info) => Some(info),
-            Err(_) => None,
-        },
+        Ok(_) => fetch_account_info().await.ok(),
         Err(_) => None,
     };
 
@@ -234,7 +231,7 @@ pub async fn cmd_auth_status(format: &OutputFormat) -> Result<()> {
                 color = status_color,
             );
             if let Some(ts) = token.logged_in_at {
-                if let Ok(dt) = OffsetDateTime::from_unix_timestamp(ts as i64) {
+                if let Ok(dt) = OffsetDateTime::from_unix_timestamp(ts.cast_signed()) {
                     println!(
                         "{:<W$} {}-{:02}-{:02} {:02}:{:02}",
                         "Logged In",
@@ -285,7 +282,9 @@ pub async fn cmd_auth_status(format: &OutputFormat) -> Result<()> {
                 // ── Quote Level ─────────────────────────────────────────────────
                 println!();
                 println!("Quote Level");
-                if !acc.quote_packages.is_empty() {
+                if acc.quote_packages.is_empty() {
+                    println!("{:<W$} {}", "Level", acc.quote_level, W = W);
+                } else {
                     let mut builder = Builder::default();
                     builder.push_record(["Package", "Start", "End"]);
                     for pkg in &acc.quote_packages {
@@ -294,8 +293,6 @@ pub async fn cmd_auth_status(format: &OutputFormat) -> Result<()> {
                         builder.push_record([&pkg.name, &start, &end]);
                     }
                     println!("{}", builder.build().with(Style::markdown()));
-                } else {
-                    println!("{:<W$} {}", "Level", acc.quote_level, W = W);
                 }
             }
         }

--- a/src/cli/daily_coin.rs
+++ b/src/cli/daily_coin.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use super::{
     api::{http_get, http_post},
     output::{print_json_value, print_table},
-    DailyCoinCmd, DailyCoinDayOfWeek, DailyCoinFrequency, OutputFormat,
+    DailyCoinCmd, DailyCoinDayOfWeek, DailyCoinFrequency, DailyCoinReminderHours, OutputFormat,
 };
 
 use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
@@ -75,7 +75,7 @@ pub async fn cmd_daily_coin(cmd: Option<DailyCoinCmd>, format: &OutputFormat) ->
             day_of_month,
         }) => cmd_calc_date(symbol, frequency, day_of_week, day_of_month, format).await,
         Some(DailyCoinCmd::Check { symbols }) => cmd_check(symbols, format).await,
-        Some(DailyCoinCmd::SetReminder { hours }) => cmd_set_reminder(hours).await,
+        Some(DailyCoinCmd::SetReminder { hours }) => cmd_set_reminder(&hours).await,
     }
 }
 
@@ -118,6 +118,7 @@ async fn cmd_list(
                 "Next Trade Date",
                 "Issues",
                 "Cum Amount",
+                "Cum Profit",
                 "Avg Cost",
             ];
             let rows: Vec<Vec<String>> = plans
@@ -136,6 +137,7 @@ async fn cmd_list(
                             .as_u64()
                             .map_or_else(|| "-".to_string(), |n| n.to_string()),
                         p["cum_amount"].as_str().unwrap_or("-").to_string(),
+                        p["cum_profit"].as_str().unwrap_or("-").to_string(),
                         p["average_cost"].as_str().unwrap_or("-").to_string(),
                     ]
                 })
@@ -250,6 +252,7 @@ async fn cmd_records(plan_id: String, page: u32, limit: u32, format: &OutputForm
                 "Exec Qty",
                 "Exec Price",
                 "Exec Amount",
+                "Reject Reason",
             ];
             let rows: Vec<Vec<String>> = records
                 .iter()
@@ -262,6 +265,7 @@ async fn cmd_records(plan_id: String, page: u32, limit: u32, format: &OutputForm
                         r["executed_qty"].as_str().unwrap_or("-").to_string(),
                         r["executed_price"].as_str().unwrap_or("-").to_string(),
                         r["executed_amount"].as_str().unwrap_or("-").to_string(),
+                        r["rejected_reason"].as_str().unwrap_or("").to_string(),
                     ]
                 })
                 .collect();
@@ -297,6 +301,27 @@ async fn cmd_stats(symbol: Option<&str>, format: &OutputFormat) -> Result<()> {
                 }),
                 format,
             );
+
+            let nearest = resp["nearest_plans"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+            if !nearest.is_empty() {
+                println!("\nNearest Plans:");
+                let headers = &["Plan ID", "Symbol"];
+                let rows: Vec<Vec<String>> = nearest
+                    .iter()
+                    .map(|p| {
+                        vec![
+                            p["plan_id"].as_str().unwrap_or("-").to_string(),
+                            p["counter_id"]
+                                .as_str()
+                                .map_or_else(|| "-".to_string(), counter_id_to_symbol),
+                        ]
+                    })
+                    .collect();
+                print_table(headers, rows, format);
+            }
         }
     }
     Ok(())
@@ -329,7 +354,17 @@ async fn cmd_calc_date(
         }
         OutputFormat::Pretty => {
             let trade_date = resp["trade_date"].as_str().unwrap_or("-");
-            println!("Next trade date (Unix timestamp): {trade_date}");
+            // Convert Unix timestamp to YYYY-MM-DD for display
+            let readable = trade_date
+                .parse::<i64>()
+                .ok()
+                .and_then(|ts| time::OffsetDateTime::from_unix_timestamp(ts).ok())
+                .and_then(|dt| {
+                    dt.format(&time::format_description::well_known::Rfc3339)
+                        .ok()
+                })
+                .unwrap_or_else(|| trade_date.to_string());
+            println!("Next trade date: {readable}");
         }
     }
     Ok(())
@@ -374,9 +409,10 @@ async fn cmd_check(symbols: Vec<String>, format: &OutputFormat) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_set_reminder(hours: String) -> Result<()> {
-    let body = serde_json::json!({ "alter_hours": hours });
+async fn cmd_set_reminder(hours: &DailyCoinReminderHours) -> Result<()> {
+    let h = hours.as_api_str();
+    let body = serde_json::json!({ "alter_hours": h });
     http_post("/v1/dailycoins/update-alter-hours", body, false).await?;
-    println!("Reminder hours updated to {hours}h before trade.");
+    println!("Reminder hours updated to {h}h before trade.");
     Ok(())
 }

--- a/src/cli/daily_coin.rs
+++ b/src/cli/daily_coin.rs
@@ -1,0 +1,382 @@
+use anyhow::Result;
+
+use super::{
+    api::{http_get, http_post},
+    output::{print_json_value, print_table},
+    DailyCoinCmd, DailyCoinDayOfWeek, DailyCoinFrequency, OutputFormat,
+};
+
+use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
+
+pub async fn cmd_daily_coin(cmd: Option<DailyCoinCmd>, format: &OutputFormat) -> Result<()> {
+    match cmd {
+        None
+        | Some(DailyCoinCmd::List {
+            status: None,
+            symbol: None,
+            page: _,
+            limit: _,
+        }) => cmd_list(None, None, 1, 20, format).await,
+        Some(DailyCoinCmd::List {
+            status,
+            symbol,
+            page,
+            limit,
+        }) => cmd_list(status.as_deref(), symbol.as_deref(), page, limit, format).await,
+        Some(DailyCoinCmd::Create {
+            symbol,
+            amount,
+            frequency,
+            day_of_week,
+            day_of_month,
+            allow_margin,
+        }) => {
+            cmd_create(
+                symbol,
+                amount,
+                frequency,
+                day_of_week,
+                day_of_month,
+                allow_margin,
+            )
+            .await
+        }
+        Some(DailyCoinCmd::Update {
+            plan_id,
+            amount,
+            frequency,
+            day_of_week,
+            day_of_month,
+            allow_margin,
+        }) => {
+            cmd_update(
+                plan_id,
+                amount,
+                frequency,
+                day_of_week,
+                day_of_month,
+                allow_margin,
+            )
+            .await
+        }
+        Some(DailyCoinCmd::Pause { plan_id }) => cmd_toggle(plan_id, "Suspended").await,
+        Some(DailyCoinCmd::Resume { plan_id }) => cmd_toggle(plan_id, "Active").await,
+        Some(DailyCoinCmd::Stop { plan_id }) => cmd_toggle(plan_id, "Finished").await,
+        Some(DailyCoinCmd::Records {
+            plan_id,
+            page,
+            limit,
+        }) => cmd_records(plan_id, page, limit, format).await,
+        Some(DailyCoinCmd::Stats { symbol }) => cmd_stats(symbol.as_deref(), format).await,
+        Some(DailyCoinCmd::CalcDate {
+            symbol,
+            frequency,
+            day_of_week,
+            day_of_month,
+        }) => cmd_calc_date(symbol, frequency, day_of_week, day_of_month, format).await,
+        Some(DailyCoinCmd::Check { symbols }) => cmd_check(symbols, format).await,
+        Some(DailyCoinCmd::SetReminder { hours }) => cmd_set_reminder(hours).await,
+    }
+}
+
+async fn cmd_list(
+    status: Option<&str>,
+    symbol: Option<&str>,
+    page: u32,
+    limit: u32,
+    format: &OutputFormat,
+) -> Result<()> {
+    let mut params: Vec<(&str, String)> =
+        vec![("page", page.to_string()), ("limit", limit.to_string())];
+    if let Some(s) = status {
+        params.push(("status", s.to_string()));
+    }
+    if let Some(s) = symbol {
+        params.push(("counter_id", symbol_to_counter_id(s)));
+    }
+
+    let param_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+    let resp = http_get("/v1/dailycoins/query", &param_refs, false).await?;
+
+    let plans = resp["plans"].as_array().cloned().unwrap_or_default();
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&plans)?);
+        }
+        OutputFormat::Pretty => {
+            if plans.is_empty() {
+                println!("No DCA plans found.");
+                return Ok(());
+            }
+            let headers = &[
+                "Plan ID",
+                "Symbol",
+                "Status",
+                "Amount",
+                "Frequency",
+                "Next Trade Date",
+                "Issues",
+                "Cum Amount",
+                "Avg Cost",
+            ];
+            let rows: Vec<Vec<String>> = plans
+                .iter()
+                .map(|p| {
+                    vec![
+                        p["plan_id"].as_str().unwrap_or("-").to_string(),
+                        p["counter_id"]
+                            .as_str()
+                            .map_or_else(|| "-".to_string(), counter_id_to_symbol),
+                        p["status"].as_str().unwrap_or("-").to_string(),
+                        p["per_invest_amount"].as_str().unwrap_or("-").to_string(),
+                        p["invest_frequency"].as_str().unwrap_or("-").to_string(),
+                        p["next_trd_date"].as_str().unwrap_or("-").to_string(),
+                        p["issue_number"]
+                            .as_u64()
+                            .map_or_else(|| "-".to_string(), |n| n.to_string()),
+                        p["cum_amount"].as_str().unwrap_or("-").to_string(),
+                        p["average_cost"].as_str().unwrap_or("-").to_string(),
+                    ]
+                })
+                .collect();
+            print_table(headers, rows, format);
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_create(
+    symbol: String,
+    amount: String,
+    frequency: DailyCoinFrequency,
+    day_of_week: Option<DailyCoinDayOfWeek>,
+    day_of_month: Option<String>,
+    allow_margin: bool,
+) -> Result<()> {
+    let mut body = serde_json::json!({
+        "counter_id": symbol_to_counter_id(&symbol),
+        "per_invest_amount": amount,
+        "invest_frequency": frequency.as_api_str(),
+    });
+
+    if let Some(dow) = day_of_week {
+        body["invest_day_of_week"] = serde_json::Value::String(dow.as_api_str().to_string());
+    }
+    if let Some(dom) = day_of_month {
+        body["invest_day_of_month"] = serde_json::Value::String(dom);
+    }
+    if allow_margin {
+        body["allow_margin_finance"] = serde_json::Value::Number(1.into());
+    }
+
+    let resp = http_post("/v1/dailycoins/create", body, false).await?;
+    let plan_id = resp["plan_id"].as_str().unwrap_or("");
+    println!("DCA plan created. Plan ID: {plan_id}");
+    Ok(())
+}
+
+async fn cmd_update(
+    plan_id: String,
+    amount: Option<String>,
+    frequency: Option<DailyCoinFrequency>,
+    day_of_week: Option<DailyCoinDayOfWeek>,
+    day_of_month: Option<String>,
+    allow_margin: Option<bool>,
+) -> Result<()> {
+    let mut body = serde_json::json!({ "plan_id": plan_id });
+
+    if let Some(a) = amount {
+        body["per_invest_amount"] = serde_json::Value::String(a);
+    }
+    if let Some(f) = frequency {
+        body["invest_frequency"] = serde_json::Value::String(f.as_api_str().to_string());
+    }
+    if let Some(dow) = day_of_week {
+        body["invest_day_of_week"] = serde_json::Value::String(dow.as_api_str().to_string());
+    }
+    if let Some(dom) = day_of_month {
+        body["invest_day_of_month"] = serde_json::Value::String(dom);
+    }
+    if let Some(m) = allow_margin {
+        body["allow_margin_finance"] = serde_json::Value::Number(i32::from(m).into());
+    }
+
+    http_post("/v1/dailycoins/update", body, false).await?;
+    println!("DCA plan {plan_id} updated.");
+    Ok(())
+}
+
+async fn cmd_toggle(plan_id: String, status: &str) -> Result<()> {
+    let body = serde_json::json!({
+        "plan_id": plan_id,
+        "status": status,
+    });
+    http_post("/v1/dailycoins/toggle", body, false).await?;
+    println!("DCA plan {plan_id} status set to {status}.");
+    Ok(())
+}
+
+async fn cmd_records(plan_id: String, page: u32, limit: u32, format: &OutputFormat) -> Result<()> {
+    let page_str = page.to_string();
+    let limit_str = limit.to_string();
+    let resp = http_get(
+        "/v1/dailycoins/query-records",
+        &[
+            ("plan_id", plan_id.as_str()),
+            ("page", &page_str),
+            ("limit", &limit_str),
+        ],
+        false,
+    )
+    .await?;
+
+    let records = resp["records"].as_array().cloned().unwrap_or_default();
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&records)?);
+        }
+        OutputFormat::Pretty => {
+            if records.is_empty() {
+                println!("No execution records found.");
+                return Ok(());
+            }
+            let headers = &[
+                "Date",
+                "Order ID",
+                "Status",
+                "Action",
+                "Exec Qty",
+                "Exec Price",
+                "Exec Amount",
+            ];
+            let rows: Vec<Vec<String>> = records
+                .iter()
+                .map(|r| {
+                    vec![
+                        r["created_at"].as_str().unwrap_or("-").to_string(),
+                        r["order_id"].as_str().unwrap_or("-").to_string(),
+                        r["status"].as_str().unwrap_or("-").to_string(),
+                        r["action"].as_str().unwrap_or("-").to_string(),
+                        r["executed_qty"].as_str().unwrap_or("-").to_string(),
+                        r["executed_price"].as_str().unwrap_or("-").to_string(),
+                        r["executed_amount"].as_str().unwrap_or("-").to_string(),
+                    ]
+                })
+                .collect();
+            print_table(headers, rows, format);
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_stats(symbol: Option<&str>, format: &OutputFormat) -> Result<()> {
+    let counter_id_str;
+    let params: Vec<(&str, &str)> = if let Some(s) = symbol {
+        counter_id_str = symbol_to_counter_id(s);
+        vec![("counter_id", counter_id_str.as_str())]
+    } else {
+        vec![]
+    };
+    let resp = http_get("/v1/dailycoins/statistic", &params, false).await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Pretty => {
+            print_json_value(
+                &serde_json::json!({
+                    "total_amount": resp["total_amount"].as_str().unwrap_or("-"),
+                    "total_profit": resp["total_profit"].as_str().unwrap_or("-"),
+                    "active_count": resp["active_count"].as_str().unwrap_or("-"),
+                    "suspended_count": resp["suspended_count"].as_str().unwrap_or("-"),
+                    "finished_count": resp["finished_count"].as_str().unwrap_or("-"),
+                    "rest_days": resp["rest_days"].as_str().unwrap_or("-"),
+                }),
+                format,
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_calc_date(
+    symbol: String,
+    frequency: DailyCoinFrequency,
+    day_of_week: Option<DailyCoinDayOfWeek>,
+    day_of_month: Option<String>,
+    format: &OutputFormat,
+) -> Result<()> {
+    let mut body = serde_json::json!({
+        "counter_id": symbol_to_counter_id(&symbol),
+        "invest_frequency": frequency.as_api_str(),
+    });
+
+    if let Some(dow) = day_of_week {
+        body["invest_day_of_week"] = serde_json::Value::String(dow.as_api_str().to_string());
+    }
+    if let Some(dom) = day_of_month {
+        body["invest_day_of_month"] = serde_json::Value::String(dom);
+    }
+
+    let resp = http_post("/v1/dailycoins/calc-trd-date", body, false).await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Pretty => {
+            let trade_date = resp["trade_date"].as_str().unwrap_or("-");
+            println!("Next trade date (Unix timestamp): {trade_date}");
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_check(symbols: Vec<String>, format: &OutputFormat) -> Result<()> {
+    let counter_ids: Vec<String> = symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
+    let body = serde_json::json!({ "counter_ids": counter_ids });
+    let resp = http_post("/v1/dailycoins/batch-check-support", body, false).await?;
+
+    let infos = resp["infos"].as_array().cloned().unwrap_or_default();
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&infos)?);
+        }
+        OutputFormat::Pretty => {
+            if infos.is_empty() {
+                println!("No results.");
+                return Ok(());
+            }
+            let headers = &["Symbol", "Supports DCA"];
+            let rows: Vec<Vec<String>> = infos
+                .iter()
+                .map(|info| {
+                    vec![
+                        info["counter_id"]
+                            .as_str()
+                            .map_or_else(|| "-".to_string(), counter_id_to_symbol),
+                        if info["support_regular_saving"].as_bool().unwrap_or(false) {
+                            "yes"
+                        } else {
+                            "no"
+                        }
+                        .to_string(),
+                    ]
+                })
+                .collect();
+            print_table(headers, rows, format);
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_set_reminder(hours: String) -> Result<()> {
+    let body = serde_json::json!({ "alter_hours": hours });
+    http_post("/v1/dailycoins/update-alter-hours", body, false).await?;
+    println!("Reminder hours updated to {hours}h before trade.");
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod api;
 pub mod asset;
 pub mod auth;
 pub mod check;
+pub mod daily_coin;
 pub mod fundamental;
 pub mod insider_trades;
 pub mod investors;
@@ -898,6 +899,26 @@ pub enum Commands {
         #[command(subcommand)]
         subcmd: Option<InvestorsSubCmd>,
     },
+
+    // ── DCA (Daily Coins) ──────────────────────────────────────────────────────
+    /// Stock DCA (daily-coin) plans: list, create, update, pause/resume/stop, records, stats
+    ///
+    /// Without a subcommand, lists all active DCA plans.
+    /// Subcommands: list  create  update  pause  resume  stop  records  stats  calc-date  check  set-reminder
+    /// Example: longbridge daily-coin
+    /// Example: longbridge daily-coin list --status Active
+    /// Example: longbridge daily-coin create AAPL.US --amount 500 --frequency monthly --day-of-month 15
+    /// Example: longbridge daily-coin create 700.HK --amount 1000 --frequency weekly --day-of-week mon
+    /// Example: longbridge daily-coin pause `<PLAN_ID>`
+    /// Example: longbridge daily-coin stop `<PLAN_ID>`
+    /// Example: longbridge daily-coin records `<PLAN_ID>`
+    /// Example: longbridge daily-coin stats
+    /// Example: longbridge daily-coin check AAPL.US 700.HK
+    #[command(name = "daily-coin")]
+    DailyCoin {
+        #[command(subcommand)]
+        cmd: Option<DailyCoinCmd>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -920,6 +941,168 @@ pub enum InvestorsSubCmd {
         /// Defaults to the filing immediately before the latest one.
         #[arg(long, value_name = "PERIOD")]
         from: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum DailyCoinCmd {
+    /// List DCA plans (default when no subcommand is given)
+    ///
+    /// Example: longbridge daily-coin list
+    /// Example: longbridge daily-coin list --status Active
+    /// Example: longbridge daily-coin list --symbol AAPL.US
+    List {
+        /// Filter by status: Active | Suspended | Finished
+        #[arg(long)]
+        status: Option<String>,
+        /// Filter by symbol (e.g. AAPL.US)
+        #[arg(long)]
+        symbol: Option<String>,
+        /// Page number (default: 1)
+        #[arg(long, default_value = "1")]
+        page: u32,
+        /// Records per page (default: 20)
+        #[arg(long, default_value = "20")]
+        limit: u32,
+    },
+
+    /// Create a new DCA plan
+    ///
+    /// Frequency: daily | weekly | fortnightly | monthly
+    /// Day of week (weekly/fortnightly): mon tue wed thu fri
+    /// Day of month (monthly): 1–28
+    /// Example: longbridge daily-coin create AAPL.US --amount 500 --frequency monthly --day-of-month 15
+    /// Example: longbridge daily-coin create 700.HK --amount 1000 --frequency weekly --day-of-week mon
+    Create {
+        /// Symbol in <CODE>.<MARKET> format (e.g. AAPL.US 700.HK)
+        symbol: String,
+        /// Amount per investment period (as a decimal string, e.g. 500)
+        #[arg(long)]
+        amount: String,
+        /// Investment frequency: daily | weekly | fortnightly | monthly
+        #[arg(long)]
+        frequency: DailyCoinFrequency,
+        /// Day of week for weekly/fortnightly: mon tue wed thu fri
+        #[arg(long)]
+        day_of_week: Option<DailyCoinDayOfWeek>,
+        /// Day of month for monthly plans (1–28)
+        #[arg(long)]
+        day_of_month: Option<String>,
+        /// Allow margin financing (default: false)
+        #[arg(long)]
+        allow_margin: bool,
+    },
+
+    /// Update an existing DCA plan
+    ///
+    /// Only the fields provided will be updated.
+    /// Example: longbridge daily-coin update `<PLAN_ID>` --amount 800
+    /// Example: longbridge daily-coin update `<PLAN_ID>` --frequency weekly --day-of-week fri
+    Update {
+        /// Plan ID (from `longbridge daily-coin list`)
+        plan_id: String,
+        /// New amount per investment period
+        #[arg(long)]
+        amount: Option<String>,
+        /// New investment frequency: daily | weekly | fortnightly | monthly
+        #[arg(long)]
+        frequency: Option<DailyCoinFrequency>,
+        /// Day of week for weekly/fortnightly: mon tue wed thu fri
+        #[arg(long)]
+        day_of_week: Option<DailyCoinDayOfWeek>,
+        /// Day of month for monthly plans (1–28)
+        #[arg(long)]
+        day_of_month: Option<String>,
+        /// Allow margin financing
+        #[arg(long)]
+        allow_margin: Option<bool>,
+    },
+
+    /// Suspend (pause) a DCA plan
+    ///
+    /// Example: longbridge daily-coin pause `<PLAN_ID>`
+    Pause {
+        /// Plan ID to suspend
+        plan_id: String,
+    },
+
+    /// Resume a suspended DCA plan
+    ///
+    /// Example: longbridge daily-coin resume `<PLAN_ID>`
+    Resume {
+        /// Plan ID to resume
+        plan_id: String,
+    },
+
+    /// Terminate (permanently stop) a DCA plan
+    ///
+    /// Example: longbridge daily-coin stop `<PLAN_ID>`
+    Stop {
+        /// Plan ID to terminate
+        plan_id: String,
+    },
+
+    /// Show execution records for a DCA plan
+    ///
+    /// Example: longbridge daily-coin records `<PLAN_ID>`
+    /// Example: longbridge daily-coin records `<PLAN_ID>` --page 2 --limit 50
+    Records {
+        /// Plan ID (from `longbridge daily-coin list`)
+        plan_id: String,
+        /// Page number (default: 1)
+        #[arg(long, default_value = "1")]
+        page: u32,
+        /// Records per page (default: 20)
+        #[arg(long, default_value = "20")]
+        limit: u32,
+    },
+
+    /// Show DCA statistics summary
+    ///
+    /// Returns total investment amount, total profit, plan counts, and nearest upcoming plans.
+    /// Example: longbridge daily-coin stats
+    /// Example: longbridge daily-coin stats --symbol AAPL.US
+    Stats {
+        /// Filter statistics by symbol
+        #[arg(long)]
+        symbol: Option<String>,
+    },
+
+    /// Calculate the next trade date for a DCA configuration
+    ///
+    /// Example: longbridge daily-coin calc-date AAPL.US --frequency monthly --day-of-month 15
+    /// Example: longbridge daily-coin calc-date 700.HK --frequency weekly --day-of-week mon
+    #[command(name = "calc-date")]
+    CalcDate {
+        /// Symbol in <CODE>.<MARKET> format
+        symbol: String,
+        /// Investment frequency: daily | weekly | fortnightly | monthly
+        #[arg(long)]
+        frequency: DailyCoinFrequency,
+        /// Day of week for weekly/fortnightly: mon tue wed thu fri
+        #[arg(long)]
+        day_of_week: Option<DailyCoinDayOfWeek>,
+        /// Day of month for monthly plans (1–28)
+        #[arg(long)]
+        day_of_month: Option<String>,
+    },
+
+    /// Check whether symbols support DCA investing
+    ///
+    /// Example: longbridge daily-coin check AAPL.US 700.HK TSLA.US
+    Check {
+        /// One or more symbols in <CODE>.<MARKET> format
+        symbols: Vec<String>,
+    },
+
+    /// Set the pre-trade reminder hours
+    ///
+    /// Valid values: 1 | 6 | 12
+    /// Example: longbridge daily-coin set-reminder 6
+    #[command(name = "set-reminder")]
+    SetReminder {
+        /// Hours before trade to send reminder: 1 | 6 | 12
+        hours: String,
     },
 }
 
@@ -1215,6 +1398,55 @@ pub enum StatementSection {
 }
 
 #[derive(ValueEnum, Clone, Debug)]
+pub enum DailyCoinFrequency {
+    #[value(name = "daily")]
+    Daily,
+    #[value(name = "weekly")]
+    Weekly,
+    #[value(name = "fortnightly")]
+    Fortnightly,
+    #[value(name = "monthly")]
+    Monthly,
+}
+
+impl DailyCoinFrequency {
+    pub fn as_api_str(&self) -> &'static str {
+        match self {
+            Self::Daily => "Daily",
+            Self::Weekly => "Weekly",
+            Self::Fortnightly => "Fortnightly",
+            Self::Monthly => "Monthly",
+        }
+    }
+}
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum DailyCoinDayOfWeek {
+    #[value(name = "mon")]
+    Mon,
+    #[value(name = "tue")]
+    Tue,
+    #[value(name = "wed")]
+    Wed,
+    #[value(name = "thu")]
+    Thu,
+    #[value(name = "fri")]
+    Fri,
+}
+
+impl DailyCoinDayOfWeek {
+    pub fn as_api_str(&self) -> &'static str {
+        match self {
+            Self::Mon => "Mon",
+            Self::Tue => "Tue",
+            Self::Wed => "Wed",
+            Self::Thu => "Thu",
+            Self::Fri => "Fri",
+        }
+    }
+}
+
+#[derive(ValueEnum, Clone, Debug)]
 pub enum ExportFormat {
     #[value(name = "csv")]
     Csv,
@@ -1350,7 +1582,7 @@ pub enum OrderCmd {
         ///   (case-insensitive, default: LO)
         #[arg(long, default_value = "LO")]
         order_type: String,
-        /// Time in force: day | gtc (GoodTilCanceled) | gtd (GoodTilDate)
+        /// Time in force: day | gtc (`GoodTilCanceled`) | gtd (`GoodTilDate`)
         /// (case-insensitive)
         #[arg(long, default_value = "day")]
         tif: String,
@@ -1403,7 +1635,7 @@ pub enum OrderCmd {
         ///   (case-insensitive, default: LO)
         #[arg(long, default_value = "LO")]
         order_type: String,
-        /// Time in force: day | gtc (GoodTilCanceled) | gtd (GoodTilDate)
+        /// Time in force: day | gtc (`GoodTilCanceled`) | gtd (`GoodTilDate`)
         /// (case-insensitive)
         #[arg(long, default_value = "day")]
         tif: String,
@@ -2215,6 +2447,8 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                 .await
             }
         },
+
+        Commands::DailyCoin { cmd } => daily_coin::cmd_daily_coin(cmd, format).await,
 
         Commands::Auth { .. }
         | Commands::Tui

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -929,7 +929,7 @@ pub enum Commands {
     /// Example: longbridge sharelist
     /// Example: longbridge sharelist --count 50
     /// Example: longbridge sharelist detail `<ID>`
-    /// Example: longbridge sharelist create --name "My Picks" --stock-group-id `<GROUP_ID>`
+    /// Example: longbridge sharelist create --name "My Picks"
     /// Example: longbridge sharelist delete `<ID>`
     /// Example: longbridge sharelist add `<ID>` TSLA.US AAPL.US
     /// Example: longbridge sharelist remove `<ID>` TSLA.US
@@ -1501,8 +1501,7 @@ pub enum SharelistCmd {
 
     /// Create a new sharelist
     ///
-    /// Requires a watchlist group ID to link the sharelist to an existing watchlist group.
-    /// Example: longbridge sharelist create --name "My Tech Picks" --stock-group-id `<GROUP_ID>`
+    /// Example: longbridge sharelist create --name "My Tech Picks"
     Create {
         /// Sharelist name
         #[arg(long)]
@@ -1510,9 +1509,6 @@ pub enum SharelistCmd {
         /// Sharelist description
         #[arg(long, default_value = "")]
         description: String,
-        /// Watchlist group ID to link this sharelist to
-        #[arg(long)]
-        stock_group_id: String,
     },
 
     /// Delete a sharelist

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -922,20 +922,18 @@ pub enum Commands {
     },
 
     // ── Sharelist (股单) ───────────────────────────────────────────────────────
-    /// Sharelist (股单): community stock lists — browse, members, logs, and management
+    /// Sharelist (股单): community stock lists — list, detail, create, delete, and manage stocks
     ///
     /// Without a subcommand, lists the current user's own and subscribed sharelists.
-    /// Subcommands: hot  official  stock  members  logs  mark-read  sort  remove-stocks  index
+    /// Subcommands: list  detail  create  delete  add  remove  sort  hot
     /// Example: longbridge sharelist
-    /// Example: longbridge sharelist hot --size 10
-    /// Example: longbridge sharelist official
-    /// Example: longbridge sharelist stock TSLA.US --count 5
-    /// Example: longbridge sharelist members `<ID>`
-    /// Example: longbridge sharelist logs `<ID>` --year 2024
-    /// Example: longbridge sharelist mark-read `<ID>` `<LOG_ID>`
+    /// Example: longbridge sharelist detail `<ID>`
+    /// Example: longbridge sharelist create --name "My Picks" --stock-group-id `<GROUP_ID>`
+    /// Example: longbridge sharelist delete `<ID>`
+    /// Example: longbridge sharelist add `<ID>` TSLA.US AAPL.US
+    /// Example: longbridge sharelist remove `<ID>` TSLA.US
     /// Example: longbridge sharelist sort `<ID>` TSLA.US AAPL.US 700.HK
-    /// Example: longbridge sharelist remove-stocks `<ID>` TSLA.US
-    /// Example: longbridge sharelist index 8111112-US
+    /// Example: longbridge sharelist hot --size 10
     Sharelist {
         #[command(subcommand)]
         cmd: Option<SharelistCmd>,
@@ -1491,7 +1489,8 @@ impl DailyCoinReminderHours {
 pub enum SharelistCmd {
     /// List the current user's own and subscribed sharelists
     ///
-    /// Returns public sharelists created by the user and sharelists they have subscribed to.
+    /// Without flags, returns both own and subscribed sharelists.
+    /// Use --subscription to show only subscribed, --own to show only own public sharelists.
     /// Example: longbridge sharelist
     /// Example: longbridge sharelist list --subscription
     /// Example: longbridge sharelist list --own
@@ -1510,85 +1509,64 @@ pub enum SharelistCmd {
         tail_mark: Option<String>,
     },
 
-    /// Get hot (trending) sharelists
+    /// Show full details for a sharelist including its constituent stocks
     ///
-    /// Returns community sharelists ranked by popularity.
-    /// Example: longbridge sharelist hot
-    /// Example: longbridge sharelist hot --size 10
-    Hot {
-        /// Number of results to return (default: 20)
-        #[arg(long, default_value = "20")]
-        size: u32,
-    },
-
-    /// Get official (Longbridge-curated) sharelists
-    ///
-    /// Returns sharelists maintained by Longbridge.
-    /// Example: longbridge sharelist official
-    /// Example: longbridge sharelist official --size 10
-    Official {
-        /// Number of results per page (default: 20)
-        #[arg(long, default_value = "20")]
-        size: u32,
-        /// Pagination cursor from a previous response
-        #[arg(long)]
-        tail_mark: Option<String>,
-    },
-
-    /// Get sharelists that contain a specific stock
-    ///
-    /// Example: longbridge sharelist stock TSLA.US
-    /// Example: longbridge sharelist stock TSLA.US --count 10
-    Stock {
-        /// Symbol in `<CODE>.<MARKET>` format (e.g. TSLA.US 700.HK)
-        symbol: String,
-        /// Number of results to return (default: 10)
-        #[arg(long, default_value = "10")]
-        count: u32,
-    },
-
-    /// Get the follower list for a sharelist
-    ///
-    /// Example: longbridge sharelist members `<ID>`
-    /// Example: longbridge sharelist members `<ID>` --count 50
-    Members {
+    /// Example: longbridge sharelist detail `<ID>`
+    Detail {
         /// Sharelist ID
         id: String,
-        /// Number of results per page (default: 20)
-        #[arg(long, default_value = "20")]
-        count: u32,
-        /// Pagination cursor from a previous response
-        #[arg(long)]
-        tail_mark: Option<String>,
     },
 
-    /// Get the change log for a sharelist
+    /// Create a new sharelist
     ///
-    /// Shows stock additions and removals over a year. Defaults to the current year.
-    /// Example: longbridge sharelist logs `<ID>`
-    /// Example: longbridge sharelist logs `<ID>` --year 2024
-    Logs {
+    /// Requires a watchlist group ID to link the sharelist to an existing watchlist group.
+    /// Example: longbridge sharelist create --name "My Tech Picks" --description "Top tech stocks" --cover "" --stock-group-id `<GROUP_ID>`
+    Create {
+        /// Sharelist name
+        #[arg(long)]
+        name: String,
+        /// Sharelist description
+        #[arg(long, default_value = "")]
+        description: String,
+        /// Cover image URL (can be empty)
+        #[arg(long, default_value = "")]
+        cover: String,
+        /// Watchlist group ID to link this sharelist to
+        #[arg(long)]
+        stock_group_id: String,
+    },
+
+    /// Delete a sharelist
+    ///
+    /// Example: longbridge sharelist delete `<ID>`
+    Delete {
+        /// Sharelist ID to delete
+        id: String,
+    },
+
+    /// Add stocks to a sharelist
+    ///
+    /// Example: longbridge sharelist add `<ID>` TSLA.US AAPL.US 700.HK
+    Add {
         /// Sharelist ID
         id: String,
-        /// Year to query (default: current year)
-        #[arg(long)]
-        year: Option<String>,
+        /// Symbols to add (e.g. TSLA.US AAPL.US 700.HK)
+        symbols: Vec<String>,
     },
 
-    /// Mark a sharelist change-log entry as read
+    /// Remove stocks from a sharelist
     ///
-    /// Example: longbridge sharelist mark-read `<SHARELIST_ID>` `<LOG_ID>`
-    #[command(name = "mark-read")]
-    MarkRead {
+    /// Example: longbridge sharelist remove `<ID>` TSLA.US AAPL.US
+    Remove {
         /// Sharelist ID
         id: String,
-        /// Log entry ID to mark as read
-        log_id: String,
+        /// Symbols to remove (e.g. TSLA.US AAPL.US)
+        symbols: Vec<String>,
     },
 
-    /// Reorder the stocks in a group sharelist
+    /// Reorder the stocks in a sharelist
     ///
-    /// Pass all stock symbols in the desired order.
+    /// Pass all symbol in the desired order; the full list replaces the existing order.
     /// Example: longbridge sharelist sort `<ID>` TSLA.US AAPL.US 700.HK
     Sort {
         /// Sharelist ID
@@ -1597,24 +1575,14 @@ pub enum SharelistCmd {
         symbols: Vec<String>,
     },
 
-    /// Remove stocks from a group sharelist
+    /// Get hot (trending) sharelists
     ///
-    /// Example: longbridge sharelist remove-stocks `<ID>` TSLA.US AAPL.US
-    #[command(name = "remove-stocks")]
-    RemoveStocks {
-        /// Sharelist ID
-        id: String,
-        /// Symbols to remove (e.g. TSLA.US AAPL.US)
-        symbols: Vec<String>,
-    },
-
-    /// Get index data for a sharelist (day change, YTD change)
-    ///
-    /// The symbol is the sharelist identifier in `<NUMBER>-<MARKET>` format (e.g. `8111112-US`).
-    /// Example: longbridge sharelist index 8111112-US
-    Index {
-        /// Sharelist symbol (e.g. 8111112-US)
-        symbol: String,
+    /// Example: longbridge sharelist hot
+    /// Example: longbridge sharelist hot --size 10
+    Hot {
+        /// Number of results to return (default: 20)
+        #[arg(long, default_value = "20")]
+        size: u32,
     },
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -925,18 +925,22 @@ pub enum Commands {
     /// Sharelist (股单): community stock lists — list, detail, create, delete, and manage stocks
     ///
     /// Without a subcommand, lists the current user's own and subscribed sharelists.
-    /// Subcommands: list  detail  create  delete  add  remove  sort  popular
+    /// Without a subcommand, lists own and subscribed sharelists.
     /// Example: longbridge sharelist
+    /// Example: longbridge sharelist --count 50
     /// Example: longbridge sharelist detail `<ID>`
     /// Example: longbridge sharelist create --name "My Picks" --stock-group-id `<GROUP_ID>`
     /// Example: longbridge sharelist delete `<ID>`
     /// Example: longbridge sharelist add `<ID>` TSLA.US AAPL.US
     /// Example: longbridge sharelist remove `<ID>` TSLA.US
     /// Example: longbridge sharelist sort `<ID>` TSLA.US AAPL.US 700.HK
-    /// Example: longbridge sharelist popular --size 10
+    /// Example: longbridge sharelist popular --count 10
     Sharelist {
         #[command(subcommand)]
         cmd: Option<SharelistCmd>,
+        /// Number of sharelists to return (default: 20)
+        #[arg(long, default_value = "20")]
+        count: u32,
     },
 }
 
@@ -1487,18 +1491,6 @@ impl DailyCoinReminderHours {
 
 #[derive(Subcommand)]
 pub enum SharelistCmd {
-    /// List the current user's own and subscribed sharelists
-    ///
-    /// Example: longbridge sharelist
-    List {
-        /// Number of results per page (default: 20)
-        #[arg(long, default_value = "20")]
-        count: u32,
-        /// Pagination cursor from a previous response
-        #[arg(long)]
-        tail_mark: Option<String>,
-    },
-
     /// Show full details for a sharelist including its constituent stocks
     ///
     /// Example: longbridge sharelist detail `<ID>`
@@ -1510,7 +1502,7 @@ pub enum SharelistCmd {
     /// Create a new sharelist
     ///
     /// Requires a watchlist group ID to link the sharelist to an existing watchlist group.
-    /// Example: longbridge sharelist create --name "My Tech Picks" --description "Top tech stocks" --cover "" --stock-group-id `<GROUP_ID>`
+    /// Example: longbridge sharelist create --name "My Tech Picks" --stock-group-id `<GROUP_ID>`
     Create {
         /// Sharelist name
         #[arg(long)]
@@ -1518,9 +1510,6 @@ pub enum SharelistCmd {
         /// Sharelist description
         #[arg(long, default_value = "")]
         description: String,
-        /// Cover image URL (can be empty)
-        #[arg(long, default_value = "")]
-        cover: String,
         /// Watchlist group ID to link this sharelist to
         #[arg(long)]
         stock_group_id: String,
@@ -1568,11 +1557,11 @@ pub enum SharelistCmd {
     /// Get popular (trending) sharelists
     ///
     /// Example: longbridge sharelist popular
-    /// Example: longbridge sharelist popular --size 10
+    /// Example: longbridge sharelist popular --count 10
     Popular {
         /// Number of results to return (default: 20)
         #[arg(long, default_value = "20")]
-        size: u32,
+        count: u32,
     },
 }
 
@@ -2580,7 +2569,9 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
 
         Commands::DailyCoin { cmd } => daily_coin::cmd_daily_coin(cmd, format).await,
 
-        Commands::Sharelist { cmd } => sharelist::cmd_sharelist(cmd, format).await,
+        Commands::Sharelist { cmd, count } => {
+            sharelist::cmd_sharelist(cmd, count, format).await
+        }
 
         Commands::Auth { .. }
         | Commands::Tui

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1123,7 +1123,7 @@ pub enum DailyCoinCmd {
     #[command(name = "set-reminder")]
     SetReminder {
         /// Hours before trade to send reminder: 1 | 6 | 12
-        hours: String,
+        hours: DailyCoinReminderHours,
     },
 }
 
@@ -1463,6 +1463,26 @@ impl DailyCoinDayOfWeek {
             Self::Wed => "Wed",
             Self::Thu => "Thu",
             Self::Fri => "Fri",
+        }
+    }
+}
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum DailyCoinReminderHours {
+    #[value(name = "1")]
+    One,
+    #[value(name = "6")]
+    Six,
+    #[value(name = "12")]
+    Twelve,
+}
+
+impl DailyCoinReminderHours {
+    pub fn as_api_str(&self) -> &'static str {
+        match self {
+            Self::One => "1",
+            Self::Six => "6",
+            Self::Twelve => "12",
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,7 @@ pub mod investors;
 pub mod news;
 pub mod output;
 pub mod quote;
+pub mod sharelist;
 pub mod statement;
 pub mod topic;
 pub mod trade;
@@ -919,6 +920,26 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: Option<DailyCoinCmd>,
     },
+
+    // ── Sharelist (股单) ───────────────────────────────────────────────────────
+    /// Sharelist (股单): community stock lists — browse, members, logs, and management
+    ///
+    /// Without a subcommand, lists the current user's own and subscribed sharelists.
+    /// Subcommands: hot  official  stock  members  logs  mark-read  sort  remove-stocks  index
+    /// Example: longbridge sharelist
+    /// Example: longbridge sharelist hot --size 10
+    /// Example: longbridge sharelist official
+    /// Example: longbridge sharelist stock TSLA.US --count 5
+    /// Example: longbridge sharelist members `<ID>`
+    /// Example: longbridge sharelist logs `<ID>` --year 2024
+    /// Example: longbridge sharelist mark-read `<ID>` `<LOG_ID>`
+    /// Example: longbridge sharelist sort `<ID>` TSLA.US AAPL.US 700.HK
+    /// Example: longbridge sharelist remove-stocks `<ID>` TSLA.US
+    /// Example: longbridge sharelist index 8111112-US
+    Sharelist {
+        #[command(subcommand)]
+        cmd: Option<SharelistCmd>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1444,6 +1465,137 @@ impl DailyCoinDayOfWeek {
             Self::Fri => "Fri",
         }
     }
+}
+
+#[derive(Subcommand)]
+pub enum SharelistCmd {
+    /// List the current user's own and subscribed sharelists
+    ///
+    /// Returns public sharelists created by the user and sharelists they have subscribed to.
+    /// Example: longbridge sharelist
+    /// Example: longbridge sharelist list --subscription
+    /// Example: longbridge sharelist list --own
+    List {
+        /// Return subscribed sharelists
+        #[arg(long)]
+        subscription: bool,
+        /// Return own public sharelists
+        #[arg(long)]
+        own: bool,
+        /// Number of results per page (default: 20)
+        #[arg(long, default_value = "20")]
+        size: u32,
+        /// Pagination cursor from a previous response
+        #[arg(long)]
+        tail_mark: Option<String>,
+    },
+
+    /// Get hot (trending) sharelists
+    ///
+    /// Returns community sharelists ranked by popularity.
+    /// Example: longbridge sharelist hot
+    /// Example: longbridge sharelist hot --size 10
+    Hot {
+        /// Number of results to return (default: 20)
+        #[arg(long, default_value = "20")]
+        size: u32,
+    },
+
+    /// Get official (Longbridge-curated) sharelists
+    ///
+    /// Returns sharelists maintained by Longbridge.
+    /// Example: longbridge sharelist official
+    /// Example: longbridge sharelist official --size 10
+    Official {
+        /// Number of results per page (default: 20)
+        #[arg(long, default_value = "20")]
+        size: u32,
+        /// Pagination cursor from a previous response
+        #[arg(long)]
+        tail_mark: Option<String>,
+    },
+
+    /// Get sharelists that contain a specific stock
+    ///
+    /// Example: longbridge sharelist stock TSLA.US
+    /// Example: longbridge sharelist stock TSLA.US --count 10
+    Stock {
+        /// Symbol in `<CODE>.<MARKET>` format (e.g. TSLA.US 700.HK)
+        symbol: String,
+        /// Number of results to return (default: 10)
+        #[arg(long, default_value = "10")]
+        count: u32,
+    },
+
+    /// Get the follower list for a sharelist
+    ///
+    /// Example: longbridge sharelist members `<ID>`
+    /// Example: longbridge sharelist members `<ID>` --count 50
+    Members {
+        /// Sharelist ID
+        id: String,
+        /// Number of results per page (default: 20)
+        #[arg(long, default_value = "20")]
+        count: u32,
+        /// Pagination cursor from a previous response
+        #[arg(long)]
+        tail_mark: Option<String>,
+    },
+
+    /// Get the change log for a sharelist
+    ///
+    /// Shows stock additions and removals over a year. Defaults to the current year.
+    /// Example: longbridge sharelist logs `<ID>`
+    /// Example: longbridge sharelist logs `<ID>` --year 2024
+    Logs {
+        /// Sharelist ID
+        id: String,
+        /// Year to query (default: current year)
+        #[arg(long)]
+        year: Option<String>,
+    },
+
+    /// Mark a sharelist change-log entry as read
+    ///
+    /// Example: longbridge sharelist mark-read `<SHARELIST_ID>` `<LOG_ID>`
+    #[command(name = "mark-read")]
+    MarkRead {
+        /// Sharelist ID
+        id: String,
+        /// Log entry ID to mark as read
+        log_id: String,
+    },
+
+    /// Reorder the stocks in a group sharelist
+    ///
+    /// Pass all stock symbols in the desired order.
+    /// Example: longbridge sharelist sort `<ID>` TSLA.US AAPL.US 700.HK
+    Sort {
+        /// Sharelist ID
+        id: String,
+        /// Symbols in the desired order (e.g. TSLA.US AAPL.US 700.HK)
+        symbols: Vec<String>,
+    },
+
+    /// Remove stocks from a group sharelist
+    ///
+    /// Example: longbridge sharelist remove-stocks `<ID>` TSLA.US AAPL.US
+    #[command(name = "remove-stocks")]
+    RemoveStocks {
+        /// Sharelist ID
+        id: String,
+        /// Symbols to remove (e.g. TSLA.US AAPL.US)
+        symbols: Vec<String>,
+    },
+
+    /// Get index data for a sharelist (day change, YTD change)
+    ///
+    /// The symbol is the sharelist identifier in `<NUMBER>-<MARKET>` format (e.g. `8111112-US`).
+    /// Example: longbridge sharelist index 8111112-US
+    Index {
+        /// Sharelist symbol (e.g. 8111112-US)
+        symbol: String,
+    },
 }
 
 #[derive(ValueEnum, Clone, Debug)]
@@ -2449,6 +2601,8 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
         },
 
         Commands::DailyCoin { cmd } => daily_coin::cmd_daily_coin(cmd, format).await,
+
+        Commands::Sharelist { cmd } => sharelist::cmd_sharelist(cmd, format).await,
 
         Commands::Auth { .. }
         | Commands::Tui

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -925,7 +925,7 @@ pub enum Commands {
     /// Sharelist (股单): community stock lists — list, detail, create, delete, and manage stocks
     ///
     /// Without a subcommand, lists the current user's own and subscribed sharelists.
-    /// Subcommands: list  detail  create  delete  add  remove  sort  hot
+    /// Subcommands: list  detail  create  delete  add  remove  sort  popular
     /// Example: longbridge sharelist
     /// Example: longbridge sharelist detail `<ID>`
     /// Example: longbridge sharelist create --name "My Picks" --stock-group-id `<GROUP_ID>`
@@ -933,7 +933,7 @@ pub enum Commands {
     /// Example: longbridge sharelist add `<ID>` TSLA.US AAPL.US
     /// Example: longbridge sharelist remove `<ID>` TSLA.US
     /// Example: longbridge sharelist sort `<ID>` TSLA.US AAPL.US 700.HK
-    /// Example: longbridge sharelist hot --size 10
+    /// Example: longbridge sharelist popular --size 10
     Sharelist {
         #[command(subcommand)]
         cmd: Option<SharelistCmd>,
@@ -1489,21 +1489,11 @@ impl DailyCoinReminderHours {
 pub enum SharelistCmd {
     /// List the current user's own and subscribed sharelists
     ///
-    /// Without flags, returns both own and subscribed sharelists.
-    /// Use --subscription to show only subscribed, --own to show only own public sharelists.
     /// Example: longbridge sharelist
-    /// Example: longbridge sharelist list --subscription
-    /// Example: longbridge sharelist list --own
     List {
-        /// Return subscribed sharelists
-        #[arg(long)]
-        subscription: bool,
-        /// Return own public sharelists
-        #[arg(long)]
-        own: bool,
         /// Number of results per page (default: 20)
         #[arg(long, default_value = "20")]
-        size: u32,
+        count: u32,
         /// Pagination cursor from a previous response
         #[arg(long)]
         tail_mark: Option<String>,
@@ -1575,11 +1565,11 @@ pub enum SharelistCmd {
         symbols: Vec<String>,
     },
 
-    /// Get hot (trending) sharelists
+    /// Get popular (trending) sharelists
     ///
-    /// Example: longbridge sharelist hot
-    /// Example: longbridge sharelist hot --size 10
-    Hot {
+    /// Example: longbridge sharelist popular
+    /// Example: longbridge sharelist popular --size 10
+    Popular {
         /// Number of results to return (default: 20)
         #[arg(long, default_value = "20")]
         size: u32,

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -7,24 +7,24 @@ use super::{
 };
 use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
 
-pub async fn cmd_sharelist(cmd: Option<SharelistCmd>, format: &OutputFormat) -> Result<()> {
+pub async fn cmd_sharelist(
+    cmd: Option<SharelistCmd>,
+    count: u32,
+    format: &OutputFormat,
+) -> Result<()> {
     match cmd {
-        None => cmd_list(20, None, format).await,
-        Some(SharelistCmd::List { count, tail_mark }) => {
-            cmd_list(count, tail_mark.as_deref(), format).await
-        }
+        None => cmd_list(count, None, format).await,
         Some(SharelistCmd::Detail { id }) => cmd_detail(id, format).await,
         Some(SharelistCmd::Create {
             name,
             description,
-            cover,
             stock_group_id,
-        }) => cmd_create(name, description, cover, stock_group_id).await,
+        }) => cmd_create(name, description, stock_group_id).await,
         Some(SharelistCmd::Delete { id }) => cmd_delete(id).await,
         Some(SharelistCmd::Add { id, symbols }) => cmd_add(id, symbols).await,
         Some(SharelistCmd::Remove { id, symbols }) => cmd_remove(id, symbols).await,
         Some(SharelistCmd::Sort { id, symbols }) => cmd_sort(id, symbols).await,
-        Some(SharelistCmd::Popular { size }) => cmd_popular(size, format).await,
+        Some(SharelistCmd::Popular { count }) => cmd_popular(count, format).await,
     }
 }
 
@@ -99,7 +99,7 @@ async fn cmd_detail(id: String, format: &OutputFormat) -> Result<()> {
                 4 => "Industry",
                 _ => "-",
             };
-            println!("ID:          {}", sl["id"].as_u64().unwrap_or(0));
+            println!("ID:          {}", sl["id"].as_str().unwrap_or("-"));
             println!("Name:        {}", sl["name"].as_str().unwrap_or("-"));
             println!("Type:        {sl_type}");
             println!("Description: {}", sl["description"].as_str().unwrap_or("-"));
@@ -142,16 +142,11 @@ async fn cmd_detail(id: String, format: &OutputFormat) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_create(
-    name: String,
-    description: String,
-    cover: String,
-    stock_group_id: String,
-) -> Result<()> {
+async fn cmd_create(name: String, description: String, stock_group_id: String) -> Result<()> {
     let body = serde_json::json!({
         "name": name,
         "description": description,
-        "cover": cover,
+        "cover": "https://pub.pbkrs.com/files/202107/kaJSk6BsvPt6NJ3Q/sharelist_v1.png",
         "stock_group_id": stock_group_id,
     });
     let resp = http_post("/v1/sharelists", body, false).await?;
@@ -168,11 +163,7 @@ async fn cmd_delete(id: String) -> Result<()> {
 }
 
 async fn cmd_add(id: String, symbols: Vec<String>) -> Result<()> {
-    let counter_ids = symbols
-        .iter()
-        .map(|s| symbol_to_counter_id(s))
-        .collect::<Vec<_>>()
-        .join(",");
+    let counter_ids: Vec<String> = symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
     let path = format!("/v1/sharelists/{id}/items");
     let body = serde_json::json!({ "counter_ids": counter_ids });
     http_post(&path, body, false).await?;
@@ -181,11 +172,7 @@ async fn cmd_add(id: String, symbols: Vec<String>) -> Result<()> {
 }
 
 async fn cmd_remove(id: String, symbols: Vec<String>) -> Result<()> {
-    let counter_ids = symbols
-        .iter()
-        .map(|s| symbol_to_counter_id(s))
-        .collect::<Vec<_>>()
-        .join(",");
+    let counter_ids: Vec<String> = symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
     let path = format!("/v1/sharelists/{id}/items");
     let body = serde_json::json!({ "counter_ids": counter_ids });
     http_delete(&path, body, false).await?;
@@ -194,11 +181,7 @@ async fn cmd_remove(id: String, symbols: Vec<String>) -> Result<()> {
 }
 
 async fn cmd_sort(id: String, symbols: Vec<String>) -> Result<()> {
-    let counter_ids = symbols
-        .iter()
-        .map(|s| symbol_to_counter_id(s))
-        .collect::<Vec<_>>()
-        .join(",");
+    let counter_ids: Vec<String> = symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
     let path = format!("/v1/sharelists/{id}/items/sort");
     let body = serde_json::json!({ "counter_ids": counter_ids });
     http_post(&path, body, false).await?;
@@ -206,8 +189,8 @@ async fn cmd_sort(id: String, symbols: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_popular(size: u32, format: &OutputFormat) -> Result<()> {
-    let size_str = size.to_string();
+async fn cmd_popular(count: u32, format: &OutputFormat) -> Result<()> {
+    let size_str = count.to_string();
     let resp = http_get("/v1/sharelists/popular", &[("size", &size_str)], false).await?;
 
     let sharelists = resp["sharelists"].as_array().cloned().unwrap_or_default();

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -141,9 +141,8 @@ async fn cmd_detail(id: String, format: &OutputFormat) -> Result<()> {
 async fn cmd_create(name: String, description: String) -> Result<()> {
     let body = serde_json::json!({
         "name": name,
-        "description": description,
+        "description": if description.is_empty() { name } else { description },
         "cover": "https://pub.pbkrs.com/files/202107/kaJSk6BsvPt6NJ3Q/sharelist_v1.png",
-        "stock_group_id": "0",
     });
     let resp = http_post("/v1/sharelists", body, false).await?;
     let sharelist_id = resp["sharelist_id"].as_str().unwrap_or("");

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
+use rust_decimal::Decimal;
 
 use super::{
     api::{http_delete, http_get, http_post},
-    output::print_table,
+    output::{fmt_dec, print_table},
     OutputFormat, SharelistCmd,
 };
 use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
@@ -116,6 +119,32 @@ async fn cmd_detail(id: String, format: &OutputFormat) -> Result<()> {
 
             let stocks = sl["stocks"].as_array().cloned().unwrap_or_default();
             if !stocks.is_empty() {
+                let symbols: Vec<String> = stocks
+                    .iter()
+                    .filter_map(|s| s["counter_id"].as_str())
+                    .map(counter_id_to_symbol)
+                    .collect();
+
+                let quote_map: HashMap<String, (String, String)> = {
+                    let ctx = crate::openapi::quote();
+                    ctx.quote(symbols)
+                        .await
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|q| {
+                            let price = fmt_dec(q.last_done);
+                            let chg = if q.prev_close.is_zero() {
+                                "-".to_string()
+                            } else {
+                                let pct = (q.last_done - q.prev_close) / q.prev_close
+                                    * Decimal::ONE_HUNDRED;
+                                format!("{pct:.2}%")
+                            };
+                            (q.symbol, (price, chg))
+                        })
+                        .collect()
+                };
+
                 println!("\nConstituents ({}):", stocks.len());
                 let headers = &["Symbol", "Name", "Price", "Day Chg"];
                 let rows: Vec<Vec<String>> = stocks
@@ -124,11 +153,15 @@ async fn cmd_detail(id: String, format: &OutputFormat) -> Result<()> {
                         let symbol = s["counter_id"]
                             .as_str()
                             .map_or_else(|| "-".to_string(), counter_id_to_symbol);
+                        let (price, chg) = quote_map
+                            .get(&symbol)
+                            .cloned()
+                            .unwrap_or_else(|| ("-".to_string(), "-".to_string()));
                         vec![
                             symbol,
                             s["name"].as_str().unwrap_or("-").to_string(),
-                            s["price"].as_str().unwrap_or("-").to_string(),
-                            s["chg"].as_str().unwrap_or("-").to_string(),
+                            price,
+                            chg,
                         ]
                     })
                     .collect();

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -9,46 +9,25 @@ use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
 
 pub async fn cmd_sharelist(cmd: Option<SharelistCmd>, format: &OutputFormat) -> Result<()> {
     match cmd {
-        None
-        | Some(SharelistCmd::List {
-            subscription: _,
-            own: _,
-            size: _,
-            tail_mark: _,
-        }) => {
-            let cmd = cmd.unwrap_or(SharelistCmd::List {
-                subscription: false,
-                own: false,
-                size: 20,
-                tail_mark: None,
-            });
-            if let SharelistCmd::List {
-                subscription,
-                own,
-                size,
-                tail_mark,
-            } = cmd
-            {
-                cmd_list(subscription, own, size, tail_mark.as_deref(), format).await
-            } else {
-                unreachable!()
-            }
-        }
-        Some(SharelistCmd::Hot { size }) => cmd_hot(size, format).await,
-        Some(SharelistCmd::Official { size, tail_mark }) => {
-            cmd_official(size, tail_mark.as_deref(), format).await
-        }
-        Some(SharelistCmd::Stock { symbol, count }) => cmd_stock(symbol, count, format).await,
-        Some(SharelistCmd::Members {
-            id,
-            count,
+        None => cmd_list(false, false, 20, None, format).await,
+        Some(SharelistCmd::List {
+            subscription,
+            own,
+            size,
             tail_mark,
-        }) => cmd_members(id, count, tail_mark.as_deref(), format).await,
-        Some(SharelistCmd::Logs { id, year }) => cmd_logs(id, year.as_deref(), format).await,
-        Some(SharelistCmd::MarkRead { id, log_id }) => cmd_mark_read(id, log_id).await,
+        }) => cmd_list(subscription, own, size, tail_mark.as_deref(), format).await,
+        Some(SharelistCmd::Detail { id }) => cmd_detail(id, format).await,
+        Some(SharelistCmd::Create {
+            name,
+            description,
+            cover,
+            stock_group_id,
+        }) => cmd_create(name, description, cover, stock_group_id).await,
+        Some(SharelistCmd::Delete { id }) => cmd_delete(id).await,
+        Some(SharelistCmd::Add { id, symbols }) => cmd_add(id, symbols).await,
+        Some(SharelistCmd::Remove { id, symbols }) => cmd_remove(id, symbols).await,
         Some(SharelistCmd::Sort { id, symbols }) => cmd_sort(id, symbols).await,
-        Some(SharelistCmd::RemoveStocks { id, symbols }) => cmd_remove_stocks(id, symbols).await,
-        Some(SharelistCmd::Index { symbol }) => cmd_index(symbol, format).await,
+        Some(SharelistCmd::Hot { size }) => cmd_hot(size, format).await,
     }
 }
 
@@ -71,7 +50,7 @@ async fn cmd_list(
         params.push(("tail_mark", tm));
     }
 
-    let resp = http_get("/v1/social/sharelists", &params, false).await?;
+    let resp = http_get("/v1/sharelists", &params, false).await?;
 
     match format {
         OutputFormat::Json => {
@@ -99,16 +78,158 @@ async fn cmd_list(
             }
 
             if let Some(next) = resp["tail_mark"].as_str() {
-                println!("\nNext page cursor: {next}");
+                if !next.is_empty() {
+                    println!("\nNext page cursor: {next}");
+                }
             }
         }
     }
     Ok(())
 }
 
+async fn cmd_detail(id: String, format: &OutputFormat) -> Result<()> {
+    let path = format!("/v1/sharelists/{id}");
+    let resp = http_get(
+        &path,
+        &[
+            ("constituent", "true"),
+            ("quote", "true"),
+            ("subscription", "true"),
+        ],
+        false,
+    )
+    .await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Pretty => {
+            let sl = &resp["sharelist"];
+            let sl_type = match sl["sharelist_type"].as_u64().unwrap_or(0) {
+                0 => "Regular",
+                1 => "Group",
+                2 => "Auto Group",
+                3 => "Official",
+                4 => "Industry",
+                _ => "-",
+            };
+            println!("ID:          {}", sl["id"].as_u64().unwrap_or(0));
+            println!("Name:        {}", sl["name"].as_str().unwrap_or("-"));
+            println!("Type:        {sl_type}");
+            println!("Description: {}", sl["description"].as_str().unwrap_or("-"));
+            println!(
+                "Subscribers: {}",
+                sl["subscribers_count"].as_u64().unwrap_or(0)
+            );
+            println!("Day Chg:     {}", sl["chg"].as_str().unwrap_or("-"));
+            println!(
+                "YTD Chg:     {}",
+                sl["this_year_chg"].as_str().unwrap_or("-")
+            );
+            println!(
+                "Subscribed:  {}",
+                sl["subscribed"].as_bool().unwrap_or(false)
+            );
+
+            let stocks = sl["stocks"].as_array().cloned().unwrap_or_default();
+            if !stocks.is_empty() {
+                println!("\nConstituents ({}):", stocks.len());
+                let headers = &["Symbol", "Name", "Price", "Day Chg"];
+                let rows: Vec<Vec<String>> = stocks
+                    .iter()
+                    .map(|s| {
+                        let symbol = s["counter_id"]
+                            .as_str()
+                            .map_or_else(|| "-".to_string(), counter_id_to_symbol);
+                        vec![
+                            symbol,
+                            s["name"].as_str().unwrap_or("-").to_string(),
+                            s["price"].as_str().unwrap_or("-").to_string(),
+                            s["chg"].as_str().unwrap_or("-").to_string(),
+                        ]
+                    })
+                    .collect();
+                print_table(headers, rows, format);
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_create(
+    name: String,
+    description: String,
+    cover: String,
+    stock_group_id: String,
+) -> Result<()> {
+    let body = serde_json::json!({
+        "name": name,
+        "description": description,
+        "cover": cover,
+        "stock_group_id": stock_group_id,
+    });
+    let resp = http_post("/v2/sharelists", body, false).await?;
+    let sharelist_id = resp["sharelist_id"].as_str().unwrap_or("");
+    println!("Sharelist created. ID: {sharelist_id}");
+    Ok(())
+}
+
+async fn cmd_delete(id: String) -> Result<()> {
+    let body = serde_json::json!({ "id": id });
+    http_post("/v2/sharelist/delete", body, false).await?;
+    println!("Sharelist {id} deleted.");
+    Ok(())
+}
+
+async fn cmd_add(id: String, symbols: Vec<String>) -> Result<()> {
+    let counter_ids = symbols
+        .iter()
+        .map(|s| symbol_to_counter_id(s))
+        .collect::<Vec<_>>()
+        .join(",");
+    let body = serde_json::json!({
+        "id": id,
+        "counter_ids": counter_ids,
+    });
+    http_post("/v1/sharelist/add_stock", body, false).await?;
+    println!("Added {} stock(s) to sharelist {id}.", symbols.len());
+    Ok(())
+}
+
+async fn cmd_remove(id: String, symbols: Vec<String>) -> Result<()> {
+    let counter_ids = symbols
+        .iter()
+        .map(|s| symbol_to_counter_id(s))
+        .collect::<Vec<_>>()
+        .join(",");
+    let body = serde_json::json!({
+        "id": id,
+        "counter_ids": counter_ids,
+    });
+    http_post("/v1/sharelist/delete_stock", body, false).await?;
+    println!("Removed {} stock(s) from sharelist {id}.", symbols.len());
+    Ok(())
+}
+
+async fn cmd_sort(id: String, symbols: Vec<String>) -> Result<()> {
+    let counter_ids = symbols
+        .iter()
+        .map(|s| symbol_to_counter_id(s))
+        .collect::<Vec<_>>()
+        .join(",");
+    let body = serde_json::json!({
+        "id": id,
+        "counter_ids": counter_ids,
+    });
+    http_post("/v1/sharelist/sort_stock", body, false).await?;
+    println!("Stocks reordered in sharelist {id}.");
+    Ok(())
+}
+
 async fn cmd_hot(size: u32, format: &OutputFormat) -> Result<()> {
     let size_str = size.to_string();
-    let resp = http_get("/v1/social/hot_sharelists", &[("size", &size_str)], false).await?;
+    let resp = http_get("/v1/sharelists/hot", &[("size", &size_str)], false).await?;
 
     let sharelists = resp["sharelists"].as_array().cloned().unwrap_or_default();
 
@@ -127,239 +248,8 @@ async fn cmd_hot(size: u32, format: &OutputFormat) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_official(size: u32, tail_mark: Option<&str>, format: &OutputFormat) -> Result<()> {
-    let size_str = size.to_string();
-    let mut params: Vec<(&str, &str)> = vec![("limit", &size_str)];
-    if let Some(tm) = tail_mark {
-        params.push(("tail_mark", tm));
-    }
-
-    let resp = http_get("/v1/social/lb_sharelists", &params, false).await?;
-
-    let sharelists = resp["sharelists"].as_array().cloned().unwrap_or_default();
-
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&resp)?);
-        }
-        OutputFormat::Pretty => {
-            if sharelists.is_empty() {
-                println!("No official sharelists found.");
-                return Ok(());
-            }
-            print_sharelist_table(&sharelists, format);
-
-            if let Some(tm) = resp["next_params"]["tail_mark"].as_str() {
-                println!("\nNext page cursor: {tm}");
-            }
-        }
-    }
-    Ok(())
-}
-
-async fn cmd_stock(symbol: String, count: u32, format: &OutputFormat) -> Result<()> {
-    let counter_id = symbol_to_counter_id(&symbol);
-    let count_str = count.to_string();
-    let resp = http_get(
-        "/v1/social/stock/sharelists",
-        &[("counter_id", &counter_id), ("limit", &count_str)],
-        false,
-    )
-    .await?;
-
-    let sharelists = resp["sharelists"].as_array().cloned().unwrap_or_default();
-
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&sharelists)?);
-        }
-        OutputFormat::Pretty => {
-            if sharelists.is_empty() {
-                println!("No sharelists found for {symbol}.");
-                return Ok(());
-            }
-            print_sharelist_table(&sharelists, format);
-        }
-    }
-    Ok(())
-}
-
-async fn cmd_members(
-    id: String,
-    count: u32,
-    tail_mark: Option<&str>,
-    format: &OutputFormat,
-) -> Result<()> {
-    let count_str = count.to_string();
-    let mut params: Vec<(&str, &str)> = vec![("id", &id), ("limit", &count_str)];
-    if let Some(tm) = tail_mark {
-        params.push(("tail_mark", tm));
-    }
-
-    let resp = http_get("/v1/social/sharelist/profiles", &params, false).await?;
-
-    let profiles = resp["profiles"].as_array().cloned().unwrap_or_default();
-
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&resp)?);
-        }
-        OutputFormat::Pretty => {
-            if profiles.is_empty() {
-                println!("No members found.");
-                return Ok(());
-            }
-            let headers = &["Member ID", "Nickname", "Followers", "Following", "Bio"];
-            let rows: Vec<Vec<String>> = profiles
-                .iter()
-                .map(|p| {
-                    vec![
-                        p["member_id"].as_str().unwrap_or("-").to_string(),
-                        p["nickname"].as_str().unwrap_or("-").to_string(),
-                        p["followers_count"].as_str().unwrap_or("-").to_string(),
-                        p["following_count"].as_str().unwrap_or("-").to_string(),
-                        p["description"].as_str().unwrap_or("").to_string(),
-                    ]
-                })
-                .collect();
-            print_table(headers, rows, format);
-
-            if let Some(next) = resp["meta"]["tail_mark"].as_u64() {
-                println!("\nNext page cursor: {next}");
-            }
-        }
-    }
-    Ok(())
-}
-
-async fn cmd_logs(id: String, year: Option<&str>, format: &OutputFormat) -> Result<()> {
-    let mut params: Vec<(&str, &str)> = vec![("sharelist_id", &id)];
-    if let Some(y) = year {
-        params.push(("year", y));
-    }
-
-    let resp = http_get("/v1/social/sharelist/logs", &params, false).await?;
-
-    let logs = resp["logs"].as_array().cloned().unwrap_or_default();
-
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&resp)?);
-        }
-        OutputFormat::Pretty => {
-            if logs.is_empty() {
-                println!("No logs found.");
-                return Ok(());
-            }
-            let headers = &["Time", "Action", "Symbols"];
-            let rows: Vec<Vec<String>> = logs
-                .iter()
-                .map(|entry| {
-                    let op = match entry["operate"].as_str().unwrap_or("") {
-                        "0" => "Add",
-                        "1" => "Remove",
-                        "2" => "Create",
-                        other => other,
-                    };
-                    let stocks: Vec<String> = entry["stocks"]
-                        .as_array()
-                        .unwrap_or(&vec![])
-                        .iter()
-                        .filter_map(|s| s.as_str())
-                        .map(counter_id_to_symbol)
-                        .collect();
-                    vec![
-                        entry["log_time"].as_str().unwrap_or("-").to_string(),
-                        op.to_string(),
-                        stocks.join(", "),
-                    ]
-                })
-                .collect();
-            print_table(headers, rows, format);
-
-            let add = resp["add_count"].as_u64().unwrap_or(0);
-            let remove = resp["remove_count"].as_u64().unwrap_or(0);
-            println!("\nAdded: {add}  Removed: {remove}");
-            if let Some(prev) = resp["previous_year"].as_str() {
-                if !prev.is_empty() {
-                    println!("Previous year with data: {prev}");
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-async fn cmd_mark_read(id: String, log_id: String) -> Result<()> {
-    let body = serde_json::json!({
-        "sharelist_id": id,
-        "log_id": log_id,
-    });
-    http_post("/v1/social/sharelist/log/mark_read", body, false).await?;
-    println!("Log {log_id} marked as read.");
-    Ok(())
-}
-
-async fn cmd_sort(id: String, symbols: Vec<String>) -> Result<()> {
-    let counter_ids: Vec<String> = symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
-    let body = serde_json::json!({
-        "sharelist_id": id,
-        "counter_ids": counter_ids,
-    });
-    http_post("/v1/social/group_sharelist/sort_stocks", body, false).await?;
-    println!("Stocks sorted in sharelist {id}.");
-    Ok(())
-}
-
-async fn cmd_remove_stocks(id: String, symbols: Vec<String>) -> Result<()> {
-    let counter_ids: Vec<String> = symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
-    let body = serde_json::json!({
-        "sharelist_id": id,
-        "counter_ids": counter_ids,
-    });
-    http_post("/v1/social/group_sharelist/del_stocks", body, false).await?;
-    println!("Removed {} stock(s) from sharelist {id}.", symbols.len());
-    Ok(())
-}
-
-async fn cmd_index(symbol: String, format: &OutputFormat) -> Result<()> {
-    let resp = http_get(
-        "/v1/stock-info/sharelist-index",
-        &[("symbol", &symbol)],
-        false,
-    )
-    .await?;
-
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&resp)?);
-        }
-        OutputFormat::Pretty => {
-            let headers = &["Name", "Counter ID", "Day Chg", "YTD Chg"];
-            let rows = vec![vec![
-                resp["name"].as_str().unwrap_or("-").to_string(),
-                resp["counter_id"]
-                    .as_str()
-                    .map_or_else(|| "-".to_string(), counter_id_to_symbol),
-                resp["chg"].as_str().unwrap_or("-").to_string(),
-                resp["ytd_chg"].as_str().unwrap_or("-").to_string(),
-            ]];
-            print_table(headers, rows, format);
-        }
-    }
-    Ok(())
-}
-
 fn print_sharelist_table(sharelists: &[serde_json::Value], format: &OutputFormat) {
-    let headers = &[
-        "ID",
-        "Name",
-        "Type",
-        "Day Chg",
-        "YTD Chg",
-        "Subscribers",
-        "Stocks",
-    ];
+    let headers = &["ID", "Name", "Type", "Day Chg", "YTD Chg", "Subscribers"];
     let rows: Vec<Vec<String>> = sharelists
         .iter()
         .map(|sl| {
@@ -371,7 +261,6 @@ fn print_sharelist_table(sharelists: &[serde_json::Value], format: &OutputFormat
                 4 => "Industry",
                 _ => "-",
             };
-            let stock_count = sl["stocks"].as_array().map_or(0, Vec::len).to_string();
             vec![
                 sl["id"].as_u64().map_or_else(
                     || sl["id"].as_str().unwrap_or("-").to_string(),
@@ -384,7 +273,6 @@ fn print_sharelist_table(sharelists: &[serde_json::Value], format: &OutputFormat
                 sl["subscribers_count"]
                     .as_u64()
                     .map_or_else(|| "-".to_string(), |n| n.to_string()),
-                stock_count,
             ]
         })
         .collect();

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use super::{
-    api::{http_get, http_post},
+    api::{http_delete, http_get, http_post, http_put},
     output::print_table,
     OutputFormat, SharelistCmd,
 };
@@ -169,15 +169,15 @@ async fn cmd_create(
         "cover": cover,
         "stock_group_id": stock_group_id,
     });
-    let resp = http_post("/v1/sharelists", body, false).await?;
+    let resp = http_put("/v1/sharelists", body, false).await?;
     let sharelist_id = resp["sharelist_id"].as_str().unwrap_or("");
     println!("Sharelist created. ID: {sharelist_id}");
     Ok(())
 }
 
 async fn cmd_delete(id: String) -> Result<()> {
-    let body = serde_json::json!({ "id": id });
-    http_post("/v1/sharelist/delete", body, false).await?;
+    let path = format!("/v1/sharelists/{id}");
+    http_delete(&path, serde_json::Value::Null, false).await?;
     println!("Sharelist {id} deleted.");
     Ok(())
 }

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -159,7 +159,11 @@ async fn cmd_delete(id: String) -> Result<()> {
 }
 
 async fn cmd_add(id: String, symbols: Vec<String>) -> Result<()> {
-    let counter_ids: Vec<String> = symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
+    let counter_ids = symbols
+        .iter()
+        .map(|s| symbol_to_counter_id(s))
+        .collect::<Vec<_>>()
+        .join(",");
     let path = format!("/v1/sharelists/{id}/items");
     let body = serde_json::json!({ "counter_ids": counter_ids });
     http_post(&path, body, false).await?;
@@ -168,7 +172,11 @@ async fn cmd_add(id: String, symbols: Vec<String>) -> Result<()> {
 }
 
 async fn cmd_remove(id: String, symbols: Vec<String>) -> Result<()> {
-    let counter_ids: Vec<String> = symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
+    let counter_ids = symbols
+        .iter()
+        .map(|s| symbol_to_counter_id(s))
+        .collect::<Vec<_>>()
+        .join(",");
     let path = format!("/v1/sharelists/{id}/items");
     let body = serde_json::json!({ "counter_ids": counter_ids });
     http_delete(&path, body, false).await?;
@@ -177,7 +185,11 @@ async fn cmd_remove(id: String, symbols: Vec<String>) -> Result<()> {
 }
 
 async fn cmd_sort(id: String, symbols: Vec<String>) -> Result<()> {
-    let counter_ids: Vec<String> = symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
+    let counter_ids = symbols
+        .iter()
+        .map(|s| symbol_to_counter_id(s))
+        .collect::<Vec<_>>()
+        .join(",");
     let path = format!("/v1/sharelists/{id}/items/sort");
     let body = serde_json::json!({ "counter_ids": counter_ids });
     http_post(&path, body, false).await?;

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use super::{
-    api::{http_delete, http_get, http_post, http_put},
+    api::{http_delete, http_get, http_post},
     output::print_table,
     OutputFormat, SharelistCmd,
 };
@@ -169,7 +169,7 @@ async fn cmd_create(
         "cover": cover,
         "stock_group_id": stock_group_id,
     });
-    let resp = http_put("/v1/sharelists", body, false).await?;
+    let resp = http_post("/v1/sharelists", body, false).await?;
     let sharelist_id = resp["sharelist_id"].as_str().unwrap_or("");
     println!("Sharelist created. ID: {sharelist_id}");
     Ok(())
@@ -188,11 +188,9 @@ async fn cmd_add(id: String, symbols: Vec<String>) -> Result<()> {
         .map(|s| symbol_to_counter_id(s))
         .collect::<Vec<_>>()
         .join(",");
-    let body = serde_json::json!({
-        "id": id,
-        "counter_ids": counter_ids,
-    });
-    http_post("/v1/sharelist/add_stock", body, false).await?;
+    let path = format!("/v1/sharelists/{id}/items");
+    let body = serde_json::json!({ "counter_ids": counter_ids });
+    http_post(&path, body, false).await?;
     println!("Added {} stock(s) to sharelist {id}.", symbols.len());
     Ok(())
 }
@@ -203,11 +201,9 @@ async fn cmd_remove(id: String, symbols: Vec<String>) -> Result<()> {
         .map(|s| symbol_to_counter_id(s))
         .collect::<Vec<_>>()
         .join(",");
-    let body = serde_json::json!({
-        "id": id,
-        "counter_ids": counter_ids,
-    });
-    http_post("/v1/sharelist/delete_stock", body, false).await?;
+    let path = format!("/v1/sharelists/{id}/items");
+    let body = serde_json::json!({ "counter_ids": counter_ids });
+    http_delete(&path, body, false).await?;
     println!("Removed {} stock(s) from sharelist {id}.", symbols.len());
     Ok(())
 }
@@ -218,18 +214,16 @@ async fn cmd_sort(id: String, symbols: Vec<String>) -> Result<()> {
         .map(|s| symbol_to_counter_id(s))
         .collect::<Vec<_>>()
         .join(",");
-    let body = serde_json::json!({
-        "id": id,
-        "counter_ids": counter_ids,
-    });
-    http_post("/v1/sharelist/sort_stock", body, false).await?;
+    let path = format!("/v1/sharelists/{id}/items/sort");
+    let body = serde_json::json!({ "counter_ids": counter_ids });
+    http_post(&path, body, false).await?;
     println!("Stocks reordered in sharelist {id}.");
     Ok(())
 }
 
 async fn cmd_hot(size: u32, format: &OutputFormat) -> Result<()> {
     let size_str = size.to_string();
-    let resp = http_get("/v1/sharelists/hot", &[("size", &size_str)], false).await?;
+    let resp = http_get("/v1/sharelists/popular", &[("size", &size_str)], false).await?;
 
     let sharelists = resp["sharelists"].as_array().cloned().unwrap_or_default();
 

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -13,7 +13,7 @@ pub async fn cmd_sharelist(
     format: &OutputFormat,
 ) -> Result<()> {
     match cmd {
-        None => cmd_list(count, None, format).await,
+        None => cmd_list(count, format).await,
         Some(SharelistCmd::Detail { id }) => cmd_detail(id, format).await,
         Some(SharelistCmd::Create { name, description }) => cmd_create(name, description).await,
         Some(SharelistCmd::Delete { id }) => cmd_delete(id).await,
@@ -24,12 +24,13 @@ pub async fn cmd_sharelist(
     }
 }
 
-async fn cmd_list(count: u32, tail_mark: Option<&str>, format: &OutputFormat) -> Result<()> {
+async fn cmd_list(count: u32, format: &OutputFormat) -> Result<()> {
     let size_str = count.to_string();
-    let mut params: Vec<(&str, &str)> = vec![("size", &size_str)];
-    if let Some(tm) = tail_mark {
-        params.push(("tail_mark", tm));
-    }
+    let params: Vec<(&str, &str)> = vec![
+        ("size", &size_str),
+        ("self", "true"),
+        ("subscription", "true"),
+    ];
 
     let resp = http_get("/v1/sharelists", &params, false).await?;
 

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -15,11 +15,7 @@ pub async fn cmd_sharelist(
     match cmd {
         None => cmd_list(count, None, format).await,
         Some(SharelistCmd::Detail { id }) => cmd_detail(id, format).await,
-        Some(SharelistCmd::Create {
-            name,
-            description,
-            stock_group_id,
-        }) => cmd_create(name, description, stock_group_id).await,
+        Some(SharelistCmd::Create { name, description }) => cmd_create(name, description).await,
         Some(SharelistCmd::Delete { id }) => cmd_delete(id).await,
         Some(SharelistCmd::Add { id, symbols }) => cmd_add(id, symbols).await,
         Some(SharelistCmd::Remove { id, symbols }) => cmd_remove(id, symbols).await,
@@ -142,12 +138,12 @@ async fn cmd_detail(id: String, format: &OutputFormat) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_create(name: String, description: String, stock_group_id: String) -> Result<()> {
+async fn cmd_create(name: String, description: String) -> Result<()> {
     let body = serde_json::json!({
         "name": name,
         "description": description,
         "cover": "https://pub.pbkrs.com/files/202107/kaJSk6BsvPt6NJ3Q/sharelist_v1.png",
-        "stock_group_id": stock_group_id,
+        "stock_group_id": "0",
     });
     let resp = http_post("/v1/sharelists", body, false).await?;
     let sharelist_id = resp["sharelist_id"].as_str().unwrap_or("");

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -9,13 +9,10 @@ use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
 
 pub async fn cmd_sharelist(cmd: Option<SharelistCmd>, format: &OutputFormat) -> Result<()> {
     match cmd {
-        None => cmd_list(false, false, 20, None, format).await,
-        Some(SharelistCmd::List {
-            subscription,
-            own,
-            size,
-            tail_mark,
-        }) => cmd_list(subscription, own, size, tail_mark.as_deref(), format).await,
+        None => cmd_list(20, None, format).await,
+        Some(SharelistCmd::List { count, tail_mark }) => {
+            cmd_list(count, tail_mark.as_deref(), format).await
+        }
         Some(SharelistCmd::Detail { id }) => cmd_detail(id, format).await,
         Some(SharelistCmd::Create {
             name,
@@ -27,25 +24,13 @@ pub async fn cmd_sharelist(cmd: Option<SharelistCmd>, format: &OutputFormat) -> 
         Some(SharelistCmd::Add { id, symbols }) => cmd_add(id, symbols).await,
         Some(SharelistCmd::Remove { id, symbols }) => cmd_remove(id, symbols).await,
         Some(SharelistCmd::Sort { id, symbols }) => cmd_sort(id, symbols).await,
-        Some(SharelistCmd::Hot { size }) => cmd_hot(size, format).await,
+        Some(SharelistCmd::Popular { size }) => cmd_popular(size, format).await,
     }
 }
 
-async fn cmd_list(
-    subscription: bool,
-    own: bool,
-    size: u32,
-    tail_mark: Option<&str>,
-    format: &OutputFormat,
-) -> Result<()> {
-    let size_str = size.to_string();
+async fn cmd_list(count: u32, tail_mark: Option<&str>, format: &OutputFormat) -> Result<()> {
+    let size_str = count.to_string();
     let mut params: Vec<(&str, &str)> = vec![("size", &size_str)];
-    if subscription {
-        params.push(("subscription", "true"));
-    }
-    if own {
-        params.push(("self", "true"));
-    }
     if let Some(tm) = tail_mark {
         params.push(("tail_mark", tm));
     }
@@ -221,7 +206,7 @@ async fn cmd_sort(id: String, symbols: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_hot(size: u32, format: &OutputFormat) -> Result<()> {
+async fn cmd_popular(size: u32, format: &OutputFormat) -> Result<()> {
     let size_str = size.to_string();
     let resp = http_get("/v1/sharelists/popular", &[("size", &size_str)], false).await?;
 
@@ -233,7 +218,7 @@ async fn cmd_hot(size: u32, format: &OutputFormat) -> Result<()> {
         }
         OutputFormat::Pretty => {
             if sharelists.is_empty() {
-                println!("No hot sharelists found.");
+                println!("No popular sharelists found.");
                 return Ok(());
             }
             print_sharelist_table(&sharelists, format);

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -169,7 +169,7 @@ async fn cmd_create(
         "cover": cover,
         "stock_group_id": stock_group_id,
     });
-    let resp = http_post("/v2/sharelists", body, false).await?;
+    let resp = http_post("/v1/sharelists", body, false).await?;
     let sharelist_id = resp["sharelist_id"].as_str().unwrap_or("");
     println!("Sharelist created. ID: {sharelist_id}");
     Ok(())
@@ -177,7 +177,7 @@ async fn cmd_create(
 
 async fn cmd_delete(id: String) -> Result<()> {
     let body = serde_json::json!({ "id": id });
-    http_post("/v2/sharelist/delete", body, false).await?;
+    http_post("/v1/sharelist/delete", body, false).await?;
     println!("Sharelist {id} deleted.");
     Ok(())
 }

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -1,0 +1,392 @@
+use anyhow::Result;
+
+use super::{
+    api::{http_get, http_post},
+    output::print_table,
+    OutputFormat, SharelistCmd,
+};
+use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
+
+pub async fn cmd_sharelist(cmd: Option<SharelistCmd>, format: &OutputFormat) -> Result<()> {
+    match cmd {
+        None
+        | Some(SharelistCmd::List {
+            subscription: _,
+            own: _,
+            size: _,
+            tail_mark: _,
+        }) => {
+            let cmd = cmd.unwrap_or(SharelistCmd::List {
+                subscription: false,
+                own: false,
+                size: 20,
+                tail_mark: None,
+            });
+            if let SharelistCmd::List {
+                subscription,
+                own,
+                size,
+                tail_mark,
+            } = cmd
+            {
+                cmd_list(subscription, own, size, tail_mark.as_deref(), format).await
+            } else {
+                unreachable!()
+            }
+        }
+        Some(SharelistCmd::Hot { size }) => cmd_hot(size, format).await,
+        Some(SharelistCmd::Official { size, tail_mark }) => {
+            cmd_official(size, tail_mark.as_deref(), format).await
+        }
+        Some(SharelistCmd::Stock { symbol, count }) => cmd_stock(symbol, count, format).await,
+        Some(SharelistCmd::Members {
+            id,
+            count,
+            tail_mark,
+        }) => cmd_members(id, count, tail_mark.as_deref(), format).await,
+        Some(SharelistCmd::Logs { id, year }) => cmd_logs(id, year.as_deref(), format).await,
+        Some(SharelistCmd::MarkRead { id, log_id }) => cmd_mark_read(id, log_id).await,
+        Some(SharelistCmd::Sort { id, symbols }) => cmd_sort(id, symbols).await,
+        Some(SharelistCmd::RemoveStocks { id, symbols }) => cmd_remove_stocks(id, symbols).await,
+        Some(SharelistCmd::Index { symbol }) => cmd_index(symbol, format).await,
+    }
+}
+
+async fn cmd_list(
+    subscription: bool,
+    own: bool,
+    size: u32,
+    tail_mark: Option<&str>,
+    format: &OutputFormat,
+) -> Result<()> {
+    let size_str = size.to_string();
+    let mut params: Vec<(&str, &str)> = vec![("size", &size_str)];
+    if subscription {
+        params.push(("subscription", "true"));
+    }
+    if own {
+        params.push(("self", "true"));
+    }
+    if let Some(tm) = tail_mark {
+        params.push(("tail_mark", tm));
+    }
+
+    let resp = http_get("/v1/social/sharelists", &params, false).await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Pretty => {
+            let sharelists = resp["sharelists"].as_array().cloned().unwrap_or_default();
+            let subscribed = resp["subscribed_sharelists"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+
+            if sharelists.is_empty() && subscribed.is_empty() {
+                println!("No sharelists found.");
+                return Ok(());
+            }
+
+            if !sharelists.is_empty() {
+                println!("My Sharelists:");
+                print_sharelist_table(&sharelists, format);
+            }
+            if !subscribed.is_empty() {
+                println!("\nSubscribed Sharelists:");
+                print_sharelist_table(&subscribed, format);
+            }
+
+            if let Some(next) = resp["tail_mark"].as_str() {
+                println!("\nNext page cursor: {next}");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_hot(size: u32, format: &OutputFormat) -> Result<()> {
+    let size_str = size.to_string();
+    let resp = http_get("/v1/social/hot_sharelists", &[("size", &size_str)], false).await?;
+
+    let sharelists = resp["sharelists"].as_array().cloned().unwrap_or_default();
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&sharelists)?);
+        }
+        OutputFormat::Pretty => {
+            if sharelists.is_empty() {
+                println!("No hot sharelists found.");
+                return Ok(());
+            }
+            print_sharelist_table(&sharelists, format);
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_official(size: u32, tail_mark: Option<&str>, format: &OutputFormat) -> Result<()> {
+    let size_str = size.to_string();
+    let mut params: Vec<(&str, &str)> = vec![("limit", &size_str)];
+    if let Some(tm) = tail_mark {
+        params.push(("tail_mark", tm));
+    }
+
+    let resp = http_get("/v1/social/lb_sharelists", &params, false).await?;
+
+    let sharelists = resp["sharelists"].as_array().cloned().unwrap_or_default();
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Pretty => {
+            if sharelists.is_empty() {
+                println!("No official sharelists found.");
+                return Ok(());
+            }
+            print_sharelist_table(&sharelists, format);
+
+            if let Some(tm) = resp["next_params"]["tail_mark"].as_str() {
+                println!("\nNext page cursor: {tm}");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_stock(symbol: String, count: u32, format: &OutputFormat) -> Result<()> {
+    let counter_id = symbol_to_counter_id(&symbol);
+    let count_str = count.to_string();
+    let resp = http_get(
+        "/v1/social/stock/sharelists",
+        &[("counter_id", &counter_id), ("limit", &count_str)],
+        false,
+    )
+    .await?;
+
+    let sharelists = resp["sharelists"].as_array().cloned().unwrap_or_default();
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&sharelists)?);
+        }
+        OutputFormat::Pretty => {
+            if sharelists.is_empty() {
+                println!("No sharelists found for {symbol}.");
+                return Ok(());
+            }
+            print_sharelist_table(&sharelists, format);
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_members(
+    id: String,
+    count: u32,
+    tail_mark: Option<&str>,
+    format: &OutputFormat,
+) -> Result<()> {
+    let count_str = count.to_string();
+    let mut params: Vec<(&str, &str)> = vec![("id", &id), ("limit", &count_str)];
+    if let Some(tm) = tail_mark {
+        params.push(("tail_mark", tm));
+    }
+
+    let resp = http_get("/v1/social/sharelist/profiles", &params, false).await?;
+
+    let profiles = resp["profiles"].as_array().cloned().unwrap_or_default();
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Pretty => {
+            if profiles.is_empty() {
+                println!("No members found.");
+                return Ok(());
+            }
+            let headers = &["Member ID", "Nickname", "Followers", "Following", "Bio"];
+            let rows: Vec<Vec<String>> = profiles
+                .iter()
+                .map(|p| {
+                    vec![
+                        p["member_id"].as_str().unwrap_or("-").to_string(),
+                        p["nickname"].as_str().unwrap_or("-").to_string(),
+                        p["followers_count"].as_str().unwrap_or("-").to_string(),
+                        p["following_count"].as_str().unwrap_or("-").to_string(),
+                        p["description"].as_str().unwrap_or("").to_string(),
+                    ]
+                })
+                .collect();
+            print_table(headers, rows, format);
+
+            if let Some(next) = resp["meta"]["tail_mark"].as_u64() {
+                println!("\nNext page cursor: {next}");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_logs(id: String, year: Option<&str>, format: &OutputFormat) -> Result<()> {
+    let mut params: Vec<(&str, &str)> = vec![("sharelist_id", &id)];
+    if let Some(y) = year {
+        params.push(("year", y));
+    }
+
+    let resp = http_get("/v1/social/sharelist/logs", &params, false).await?;
+
+    let logs = resp["logs"].as_array().cloned().unwrap_or_default();
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Pretty => {
+            if logs.is_empty() {
+                println!("No logs found.");
+                return Ok(());
+            }
+            let headers = &["Time", "Action", "Symbols"];
+            let rows: Vec<Vec<String>> = logs
+                .iter()
+                .map(|entry| {
+                    let op = match entry["operate"].as_str().unwrap_or("") {
+                        "0" => "Add",
+                        "1" => "Remove",
+                        "2" => "Create",
+                        other => other,
+                    };
+                    let stocks: Vec<String> = entry["stocks"]
+                        .as_array()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .filter_map(|s| s.as_str())
+                        .map(counter_id_to_symbol)
+                        .collect();
+                    vec![
+                        entry["log_time"].as_str().unwrap_or("-").to_string(),
+                        op.to_string(),
+                        stocks.join(", "),
+                    ]
+                })
+                .collect();
+            print_table(headers, rows, format);
+
+            let add = resp["add_count"].as_u64().unwrap_or(0);
+            let remove = resp["remove_count"].as_u64().unwrap_or(0);
+            println!("\nAdded: {add}  Removed: {remove}");
+            if let Some(prev) = resp["previous_year"].as_str() {
+                if !prev.is_empty() {
+                    println!("Previous year with data: {prev}");
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_mark_read(id: String, log_id: String) -> Result<()> {
+    let body = serde_json::json!({
+        "sharelist_id": id,
+        "log_id": log_id,
+    });
+    http_post("/v1/social/sharelist/log/mark_read", body, false).await?;
+    println!("Log {log_id} marked as read.");
+    Ok(())
+}
+
+async fn cmd_sort(id: String, symbols: Vec<String>) -> Result<()> {
+    let counter_ids: Vec<String> = symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
+    let body = serde_json::json!({
+        "sharelist_id": id,
+        "counter_ids": counter_ids,
+    });
+    http_post("/v1/social/group_sharelist/sort_stocks", body, false).await?;
+    println!("Stocks sorted in sharelist {id}.");
+    Ok(())
+}
+
+async fn cmd_remove_stocks(id: String, symbols: Vec<String>) -> Result<()> {
+    let counter_ids: Vec<String> = symbols.iter().map(|s| symbol_to_counter_id(s)).collect();
+    let body = serde_json::json!({
+        "sharelist_id": id,
+        "counter_ids": counter_ids,
+    });
+    http_post("/v1/social/group_sharelist/del_stocks", body, false).await?;
+    println!("Removed {} stock(s) from sharelist {id}.", symbols.len());
+    Ok(())
+}
+
+async fn cmd_index(symbol: String, format: &OutputFormat) -> Result<()> {
+    let resp = http_get(
+        "/v1/stock-info/sharelist-index",
+        &[("symbol", &symbol)],
+        false,
+    )
+    .await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+        OutputFormat::Pretty => {
+            let headers = &["Name", "Counter ID", "Day Chg", "YTD Chg"];
+            let rows = vec![vec![
+                resp["name"].as_str().unwrap_or("-").to_string(),
+                resp["counter_id"]
+                    .as_str()
+                    .map_or_else(|| "-".to_string(), counter_id_to_symbol),
+                resp["chg"].as_str().unwrap_or("-").to_string(),
+                resp["ytd_chg"].as_str().unwrap_or("-").to_string(),
+            ]];
+            print_table(headers, rows, format);
+        }
+    }
+    Ok(())
+}
+
+fn print_sharelist_table(sharelists: &[serde_json::Value], format: &OutputFormat) {
+    let headers = &[
+        "ID",
+        "Name",
+        "Type",
+        "Day Chg",
+        "YTD Chg",
+        "Subscribers",
+        "Stocks",
+    ];
+    let rows: Vec<Vec<String>> = sharelists
+        .iter()
+        .map(|sl| {
+            let sl_type = match sl["sharelist_type"].as_u64().unwrap_or(0) {
+                0 => "Regular",
+                1 => "Group",
+                2 => "Auto Group",
+                3 => "Official",
+                4 => "Industry",
+                _ => "-",
+            };
+            let stock_count = sl["stocks"].as_array().map_or(0, Vec::len).to_string();
+            vec![
+                sl["id"].as_u64().map_or_else(
+                    || sl["id"].as_str().unwrap_or("-").to_string(),
+                    |n| n.to_string(),
+                ),
+                sl["name"].as_str().unwrap_or("-").to_string(),
+                sl_type.to_string(),
+                sl["chg"].as_str().unwrap_or("-").to_string(),
+                sl["this_year_chg"].as_str().unwrap_or("-").to_string(),
+                sl["subscribers_count"]
+                    .as_u64()
+                    .map_or_else(|| "-".to_string(), |n| n.to_string()),
+                stock_count,
+            ]
+        })
+        .collect();
+    print_table(headers, rows, format);
+}

--- a/src/cli/statement.rs
+++ b/src/cli/statement.rs
@@ -44,19 +44,18 @@ pub async fn cmd_statement(cmd: StatementCmd, format: &OutputFormat) -> Result<(
             limit,
         } => {
             let is_monthly = matches!(statement_type.to_lowercase().as_str(), "monthly" | "m");
-            let start_date = match start_date {
-                Some(s) => parse_date_to_yyyymmdd(&s)?,
-                None => {
-                    let now = OffsetDateTime::now_utc();
-                    if is_monthly {
-                        let total_months = now.year() * 12 + now.month() as i32 - 1 - 12;
-                        let year = total_months / 12;
-                        let month = total_months % 12 + 1;
-                        year * 10000 + month * 100 + 1
-                    } else {
-                        let d = now - time::Duration::days(30);
-                        d.year() * 10000 + i32::from(d.month() as u8) * 100 + i32::from(d.day())
-                    }
+            let start_date = if let Some(s) = start_date {
+                parse_date_to_yyyymmdd(&s)?
+            } else {
+                let now = OffsetDateTime::now_utc();
+                if is_monthly {
+                    let total_months = now.year() * 12 + now.month() as i32 - 1 - 12;
+                    let year = total_months / 12;
+                    let month = total_months % 12 + 1;
+                    year * 10000 + month * 100 + 1
+                } else {
+                    let d = now - time::Duration::days(30);
+                    d.year() * 10000 + i32::from(d.month() as u8) * 100 + i32::from(d.day())
                 }
             };
             let limit = limit.unwrap_or(if is_monthly { 12 } else { 30 });

--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -58,20 +58,22 @@ pub async fn init_contexts() -> Result<(
         )
     } else {
         tracing::info!("No API key env vars found, using OAuth authentication");
-        // Build OAuth client: loads token from ~/.longbridge/openapi/tokens/<client_id>
-        // or starts browser authorization. Token refresh is automatic inside the SDK.
+        // If no token file exists, refuse to start a browser/callback-server flow.
+        // CLI commands require a stored token; users must run `longbridge auth login` first.
+        let token_path = crate::auth::token_file_path()?;
+        if !token_path.exists() {
+            return Err(anyhow::anyhow!(
+                "Not authenticated. Please run 'longbridge auth login' first."
+            ));
+        }
+        // Token file exists: load it via OAuthBuilder (SDK handles refresh automatically).
         let oauth_result = longbridge::oauth::OAuthBuilder::new(crate::auth::client_id())
             .callback_port(crate::auth::CALLBACK_PORT)
-            .build(|url| {
-                println!("Open the following URL in your browser to authorize:");
-                println!();
-                println!("  {url}");
-                println!();
-                if crate::auth::open_browser(url) {
-                    println!("Browser opened. Waiting for authorization...");
-                } else {
-                    println!("Waiting for authorization...");
-                }
+            .build(|_url| {
+                // This callback is only invoked if the token file is missing or fully
+                // expired and cannot be refreshed — in practice, we guard above, so
+                // reaching here would be a race condition.  Just log; do not open browser.
+                tracing::warn!("OAuth browser flow triggered unexpectedly");
             })
             .await;
 

--- a/src/utils/counter.rs
+++ b/src/utils/counter.rs
@@ -16,7 +16,7 @@ fn us_etf_set() -> &'static HashSet<&'static str> {
 /// Convert a `counter_id` (e.g. `ST/US/TSLA`, `ETF/US/SPY`, `IX/US/DJI`, `ST/HK/700`) back to
 /// a display symbol (e.g. `TSLA.US`, `SPY.US`, `.DJI.US`, `700.HK`).
 ///
-/// US index counter_ids (`IX/US/...`) map to leading-dot symbols (e.g. `.DJI.US`).
+/// US index `counter_ids` (`IX/US/...`) map to leading-dot symbols (e.g. `.DJI.US`).
 pub fn counter_id_to_symbol(counter_id: &str) -> String {
     let parts: Vec<&str> = counter_id.splitn(3, '/').collect();
     if parts.len() == 3 {


### PR DESCRIPTION
## Summary

Adds `longbridge sharelist` command to manage community stock lists (sharelists). Without a subcommand, lists both own and subscribed sharelists.

- **list** — shows own and subscribed sharelists in separate sections
- **detail** — shows sharelist info and constituent stocks with live Price and Day Chg fetched via the quote API
- **create** — creates a new sharelist with a name and optional description
- **delete** — deletes a sharelist by ID
- **add / remove** — adds or removes stocks from a sharelist (symbols as `TSLA.US` format)
- **sort** — reorders stocks in a sharelist
- **popular** — lists trending sharelists

## Test plan

- [ ] `longbridge sharelist` — own and subscribed sharelists listed
- [ ] `longbridge sharelist create --name "Test"` — returns new ID
- [ ] `longbridge sharelist detail <ID>` — shows info and constituent quotes
- [ ] `longbridge sharelist add <ID> TSLA.US AAPL.US` — stocks added
- [ ] `longbridge sharelist sort <ID> AAPL.US TSLA.US` — order updated
- [ ] `longbridge sharelist remove <ID> AAPL.US` — stock removed
- [ ] `longbridge sharelist popular` — trending list returned
- [ ] `longbridge sharelist delete <ID>` — sharelist removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)