### PR TITLE
cli: Add `quant run` command for server-side indicator script execution

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1051,16 +1051,17 @@ pub enum QuantCmd {
     /// Example: cat script.pine | longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31
     /// Example: longbridge quant run 700.HK --period 1h --start 2024-01-01 --end 2024-06-30 --script "..." --input '[14]'
     /// Example: longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31 --script "..." --format json
+    /// Example: longbridge quant run 700.HK --period 1m --start "2024-01-02 09:30" --end "2024-01-02 16:00" --script "..."
     Run {
         /// Symbol in <CODE>.<MARKET> format, e.g. TSLA.US 700.HK
         symbol: String,
         /// K-line period: 1m 5m 15m 30m 1h day week month year (default: day)
         #[arg(long, default_value = "day")]
         period: String,
-        /// Start date (YYYY-MM-DD) for the K-line range
+        /// Start date/datetime for the K-line range (YYYY-MM-DD or "YYYY-MM-DD HH:MM")
         #[arg(long)]
         start: String,
-        /// End date (YYYY-MM-DD) for the K-line range
+        /// End date/datetime for the K-line range (YYYY-MM-DD or "YYYY-MM-DD HH:MM")
         #[arg(long)]
         end: String,
         /// Script text. Omit to read from stdin (e.g. echo "..." | longbridge quant run ...)
@@ -1070,6 +1071,9 @@ pub enum QuantCmd {
         /// Must match the order of input.*() calls in the script.
         #[arg(long)]
         input: Option<String>,
+        /// Include chart data in the response (excluded by default)
+        #[arg(long, default_value_t = false)]
+        chart: bool,
     },
 }
 
@@ -2740,7 +2744,8 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                 end,
                 script,
                 input,
-            } => run_script::cmd_run_script(symbol, &period, &start, &end, script, input, format, verbose).await,
+                chart,
+            } => run_script::cmd_run_script(symbol, &period, &start, &end, script, input, chart, format, verbose).await,
         },
 
         Commands::Auth { .. }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,6 +14,7 @@ pub mod investors;
 pub mod news;
 pub mod output;
 pub mod quote;
+pub mod run_script;
 pub mod sharelist;
 pub mod statement;
 pub mod topic;
@@ -1016,6 +1017,59 @@ pub enum Commands {
         /// Number of sharelists to return (default: 20)
         #[arg(long, alias = "limit", default_value = "20")]
         count: u32,
+    },
+
+    // ── Quant ────────────────────────────────────────────────────────────────
+    /// Quantitative analysis: run indicator scripts against K-line data
+    ///
+    /// Subcommands: run
+    /// Example: longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31 --script "..."
+    /// Example: cat script.pine | longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31
+    Quant {
+        #[command(subcommand)]
+        cmd: QuantCmd,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum QuantCmd {
+    /// Run a quant indicator script against historical K-line data on the server
+    ///
+    /// Executes the script server-side and returns the computed indicator/plot values as JSON.
+    /// The script language is compatible with `PineScript` V6 syntax (minor exceptions may apply).
+    ///
+    /// Periods: 1m  5m  15m  30m  1h  day  week  month  year
+    ///
+    /// Script source (--script takes priority over stdin):
+    ///   --script TEXT   inline script text
+    ///   stdin           cat script.pine | longbridge quant run TSLA.US ...
+    ///
+    /// The optional --input flag accepts a JSON array matching the
+    /// order of input.*() calls in the script, e.g. --input '[14,2.0]'
+    ///
+    /// Example: longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31 --script "..."
+    /// Example: cat script.pine | longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31
+    /// Example: longbridge quant run 700.HK --period 1h --start 2024-01-01 --end 2024-06-30 --script "..." --input '[14]'
+    /// Example: longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31 --script "..." --format json
+    Run {
+        /// Symbol in <CODE>.<MARKET> format, e.g. TSLA.US 700.HK
+        symbol: String,
+        /// K-line period: 1m 5m 15m 30m 1h day week month year (default: day)
+        #[arg(long, default_value = "day")]
+        period: String,
+        /// Start date (YYYY-MM-DD) for the K-line range
+        #[arg(long)]
+        start: String,
+        /// End date (YYYY-MM-DD) for the K-line range
+        #[arg(long)]
+        end: String,
+        /// Script text. Omit to read from stdin (e.g. echo "..." | longbridge quant run ...)
+        #[arg(long)]
+        script: Option<String>,
+        /// Script input values as a JSON array, e.g. '[14,2.0]'
+        /// Must match the order of input.*() calls in the script.
+        #[arg(long)]
+        input: Option<String>,
     },
 }
 
@@ -2677,6 +2731,17 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
         Commands::Sharelist { cmd, count } => {
             sharelist::cmd_sharelist(cmd, count, format).await
         }
+
+        Commands::Quant { cmd } => match cmd {
+            QuantCmd::Run {
+                symbol,
+                period,
+                start,
+                end,
+                script,
+                input,
+            } => run_script::cmd_run_script(symbol, &period, &start, &end, script, input, format, verbose).await,
+        },
 
         Commands::Auth { .. }
         | Commands::Tui

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -104,17 +104,35 @@ pub fn parse_date(s: &str) -> anyhow::Result<time::Date> {
     time::Date::parse(s, &fmt).map_err(|e| anyhow::anyhow!("Invalid date '{s}': {e}"))
 }
 
-/// Parse a date string into `OffsetDateTime` at start of day UTC
-pub fn parse_datetime_start(s: &str) -> anyhow::Result<time::OffsetDateTime> {
-    let date = parse_date(s)?;
-    Ok(date.with_time(time::Time::MIDNIGHT).assume_utc())
+/// Parse a datetime string (YYYY-MM-DD or YYYY-MM-DD HH:MM) into `OffsetDateTime`.
+/// Returns the exact time if minutes are provided, otherwise uses the given fallback time.
+fn parse_datetime_with_fallback(
+    s: &str,
+    fallback: time::Time,
+) -> anyhow::Result<time::OffsetDateTime> {
+    if s.contains(' ') {
+        let fmt =
+            time::macros::format_description!("[year]-[month]-[day] [hour]:[minute]");
+        let dt = time::PrimitiveDateTime::parse(s, &fmt)
+            .map_err(|e| anyhow::anyhow!("Invalid datetime '{s}': {e}"))?;
+        Ok(dt.assume_utc())
+    } else {
+        let date = parse_date(s)?;
+        Ok(date.with_time(fallback).assume_utc())
+    }
 }
 
-/// Parse a date string into `OffsetDateTime` at end of day UTC
+/// Parse a date/datetime string into `OffsetDateTime` at start of day UTC.
+/// Accepts YYYY-MM-DD or YYYY-MM-DD HH:MM.
+pub fn parse_datetime_start(s: &str) -> anyhow::Result<time::OffsetDateTime> {
+    parse_datetime_with_fallback(s, time::Time::MIDNIGHT)
+}
+
+/// Parse a date/datetime string into `OffsetDateTime` at end of day UTC.
+/// Accepts YYYY-MM-DD or YYYY-MM-DD HH:MM.
 pub fn parse_datetime_end(s: &str) -> anyhow::Result<time::OffsetDateTime> {
-    let date = parse_date(s)?;
-    let end_time = time::Time::from_hms(23, 59, 59).unwrap();
-    Ok(date.with_time(end_time).assume_utc())
+    let end_of_day = time::Time::from_hms(23, 59, 59).unwrap();
+    parse_datetime_with_fallback(s, end_of_day)
 }
 
 /// Format an `OffsetDateTime` as a readable string

--- a/src/cli/run_script.rs
+++ b/src/cli/run_script.rs
@@ -31,6 +31,7 @@ pub async fn cmd_run_script(
     end: &str,
     script_arg: Option<String>,
     input: Option<String>,
+    chart: bool,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
@@ -75,8 +76,9 @@ pub async fn cmd_run_script(
         "start_time": start_time,
         "end_time": end_time,
         "script": script,
-        "input_json": input_json,
+        "inputs_json": input_json,
         "line_type": line_type,
+        "exclude_chart": !chart,
     });
 
     if verbose {

--- a/src/cli/run_script.rs
+++ b/src/cli/run_script.rs
@@ -1,0 +1,91 @@
+use anyhow::{bail, Result};
+
+use super::{
+    api::http_post,
+    output::{parse_datetime_end, parse_datetime_start, print_json_value},
+    OutputFormat,
+};
+use crate::utils::counter::symbol_to_counter_id;
+
+/// Map CLI period string to the numeric `line_type` expected by the API.
+fn period_to_line_type(period: &str) -> Result<i32> {
+    match period {
+        "1m" | "minute" => Ok(1),
+        "5m" => Ok(5),
+        "15m" => Ok(15),
+        "30m" => Ok(30),
+        "1h" | "60m" | "hour" => Ok(60),
+        "day" | "d" | "1d" => Ok(1000),
+        "week" | "w" => Ok(2000),
+        "month" | "m" | "1mo" => Ok(3000),
+        "year" | "y" => Ok(4000),
+        _ => bail!("Unknown period '{period}'. Use: 1m 5m 15m 30m 1h day week month year"),
+    }
+}
+
+/// Run a quant indicator script against historical K-line data on the server.
+pub async fn cmd_run_script(
+    symbol: String,
+    period: &str,
+    start: &str,
+    end: &str,
+    script_arg: Option<String>,
+    input: Option<String>,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    let counter_id = symbol_to_counter_id(&symbol);
+    let line_type = period_to_line_type(period)?;
+
+    // Parse date strings to seconds-level Unix timestamps.
+    let start_time = parse_datetime_start(start)?.unix_timestamp();
+    let end_time = parse_datetime_end(end)?.unix_timestamp();
+
+    // Resolve script: inline flag takes priority, then stdin.
+    let script = if let Some(s) = script_arg {
+        s
+    } else {
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| anyhow::anyhow!("Failed to read script from stdin: {e}"))?;
+        let trimmed = buf.trim().to_string();
+        if trimmed.is_empty() {
+            bail!("No script provided. Use --script or pipe script content via stdin.");
+        }
+        trimmed
+    };
+
+    // Validate and normalise input_json: default to empty array.
+    let input_json = match input {
+        Some(s) => {
+            let v: serde_json::Value = serde_json::from_str(&s)
+                .map_err(|e| anyhow::anyhow!("--input must be a valid JSON array: {e}"))?;
+            if !v.is_array() {
+                bail!("--input must be a JSON array, e.g. '[100,200,300]'");
+            }
+            s
+        }
+        None => "[]".to_string(),
+    };
+
+    let body = serde_json::json!({
+        "counter_id": counter_id,
+        "start_time": start_time,
+        "end_time": end_time,
+        "script": script,
+        "input_json": input_json,
+        "line_type": line_type,
+    });
+
+    if verbose {
+        eprintln!("* counter_id: {counter_id}");
+        eprintln!("* line_type: {line_type}");
+        eprintln!("* start_time: {start_time}  end_time: {end_time}");
+    }
+
+    let resp = http_post("/v1/quant/run_script", body, verbose).await?;
+    print_json_value(&resp, format);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds `longbridge quant run` command backed by `POST /v1/quant/run_script`
- Runs a quant indicator script (compatible with `PineScript` V6 syntax) server-side against historical K-line data and returns computed plot values as JSON
- Script can be supplied inline via `--script "..."` or piped through stdin: `echo "plot(close)" | longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31`
- Uses `quant` as parent command to allow future subcommand expansion

## Usage

```bash
# Inline script
longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31 --script "plot(close, title='Close')"

# From file via stdin
cat strategy.pine | longbridge quant run 700.HK --period 1h --start 2024-01-01 --end 2024-06-30

# With script inputs and JSON output
longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31 --script "..." --input '[14,2.0]' --format json
```

## Test plan

- [ ] `longbridge quant --help` and `longbridge quant run --help` show correct output
- [ ] `--script` inline text is sent correctly
- [ ] Stdin pipe (`echo "..." | longbridge quant run ...`) works
- [ ] Period mapping (1m→1, day→1000, week→2000, etc.) is correct
- [ ] `--input` JSON array is validated and rejected if not an array
- [ ] Invalid period returns a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)