### PR TITLE
cli: Update dca command terminology to use 'recurring investment'

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,19 +263,19 @@ longbridge investors 0001067983 --format json                 # Export holdings 
 longbridge investors changes 0001067983                       # Quarter-over-quarter changes (NEW/ADDED/REDUCED/EXITED)
 longbridge investors changes 0001067983 --from 2024-12-31     # Compare latest vs a specific period
 
-longbridge dca                                                # List all DCA plans
+longbridge dca                                                # List all recurring investment plans
 longbridge dca --status Active                                # Filter by status: Active | Suspended | Finished
 longbridge dca --symbol TSLA.US                               # Filter by symbol
-longbridge dca create TSLA.US --amount 500 --frequency weekly --day-of-week mon  # Create weekly DCA plan
-longbridge dca create 700.HK --amount 1000 --frequency monthly --day-of-month 15  # Monthly DCA plan
+longbridge dca create TSLA.US --amount 500 --frequency weekly --day-of-week mon  # Create weekly recurring investment plan
+longbridge dca create 700.HK --amount 1000 --frequency monthly --day-of-month 15  # Monthly recurring investment plan
 longbridge dca update <PLAN_ID> --amount 800                  # Update plan amount
-longbridge dca pause <PLAN_ID>                                # Pause a DCA plan
-longbridge dca resume <PLAN_ID>                               # Resume a paused DCA plan
-longbridge dca stop <PLAN_ID>                                 # Permanently stop a DCA plan
+longbridge dca pause <PLAN_ID>                                # Pause a recurring investment plan
+longbridge dca resume <PLAN_ID>                               # Resume a paused recurring investment plan
+longbridge dca stop <PLAN_ID>                                 # Permanently stop a recurring investment plan
 longbridge dca history <PLAN_ID>                              # Trade history for a plan
-longbridge dca stats                                          # DCA statistics summary
+longbridge dca stats                                          # Recurring investment statistics summary
 longbridge dca calc-date TSLA.US --frequency weekly --day-of-week fri  # Calculate next trade date
-longbridge dca check TSLA.US AAPL.US 700.HK                  # Check which symbols support DCA
+longbridge dca check TSLA.US AAPL.US 700.HK                  # Check which symbols support recurring investment
 longbridge dca set-reminder 6                                 # Set reminder hours before trade (1 | 6 | 12)
 ```
 

--- a/src/cli/dca.rs
+++ b/src/cli/dca.rs
@@ -102,7 +102,7 @@ async fn cmd_list(
         }
         OutputFormat::Pretty => {
             if plans.is_empty() {
-                println!("No DCA plans found.");
+                println!("No recurring investment plans found.");
                 return Ok(());
             }
             let headers = &[
@@ -175,7 +175,7 @@ async fn cmd_create(
 
     let resp = http_post("/v1/dailycoins/create", body, false).await?;
     let plan_id = resp["plan_id"].as_str().unwrap_or("");
-    println!("DCA plan created. Plan ID: {plan_id}");
+    println!("Recurring investment plan created. Plan ID: {plan_id}");
     Ok(())
 }
 
@@ -206,7 +206,7 @@ async fn cmd_update(
     }
 
     http_post("/v1/dailycoins/update", body, false).await?;
-    println!("DCA plan {plan_id} updated.");
+    println!("Recurring investment plan {plan_id} updated.");
     Ok(())
 }
 
@@ -216,7 +216,7 @@ async fn cmd_toggle(plan_id: String, status: &str) -> Result<()> {
         "status": status,
     });
     http_post("/v1/dailycoins/toggle", body, false).await?;
-    println!("DCA plan {plan_id} status set to {status}.");
+    println!("Recurring investment plan {plan_id} status set to {status}.");
     Ok(())
 }
 
@@ -387,7 +387,7 @@ async fn cmd_check(symbols: Vec<String>, format: &OutputFormat) -> Result<()> {
                 println!("No results.");
                 return Ok(());
             }
-            let headers = &["Symbol", "Supports DCA"];
+            let headers = &["Symbol", "Supports Recurring Investment"];
             let rows: Vec<Vec<String>> = infos
                 .iter()
                 .map(|info| {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -901,14 +901,14 @@ pub enum Commands {
         subcmd: Option<InvestorsSubCmd>,
     },
 
-    // ── DCA ──────────────────────────────────────────────────────
-    /// Dollar-Cost Averaging (DCA): automatically invest a fixed amount at regular intervals
+    // ── Recurring Investment ──────────────────────────────────────────────────────
+    /// Recurring Investment: automatically invest a fixed amount at regular intervals
     ///
-    /// Create and manage DCA plans that execute recurring stock purchases on a daily, weekly,
+    /// Create and manage recurring investment plans that execute stock purchases on a daily, weekly,
     /// fortnightly, or monthly schedule. Track trade history, monitor cumulative profit,
     /// and check upcoming trade dates.
     ///
-    /// Without a subcommand, lists all DCA plans.
+    /// Without a subcommand, lists all recurring investment plans.
     /// Example: longbridge dca
     /// Example: longbridge dca --status Active
     /// Example: longbridge dca --symbol TSLA.US
@@ -985,7 +985,7 @@ pub enum InvestorsSubCmd {
 
 #[derive(Subcommand)]
 pub enum DcaCmd {
-    /// Create a new DCA plan
+    /// Create a new recurring investment plan
     ///
     /// Frequency: daily | weekly | fortnightly (every two weeks) | monthly
     /// Day of week (weekly/fortnightly): mon tue wed thu fri
@@ -1012,7 +1012,7 @@ pub enum DcaCmd {
         allow_margin: bool,
     },
 
-    /// Update an existing DCA plan
+    /// Update an existing recurring investment plan
     ///
     /// Only the fields provided will be updated.
     /// Example: longbridge dca update `<PLAN_ID>` --amount 800
@@ -1037,7 +1037,7 @@ pub enum DcaCmd {
         allow_margin: Option<bool>,
     },
 
-    /// Pause a DCA plan
+    /// Pause a recurring investment plan
     ///
     /// Example: longbridge dca pause `<PLAN_ID>`
     Pause {
@@ -1045,7 +1045,7 @@ pub enum DcaCmd {
         plan_id: String,
     },
 
-    /// Resume a paused DCA plan
+    /// Resume a paused recurring investment plan
     ///
     /// Example: longbridge dca resume `<PLAN_ID>`
     Resume {
@@ -1053,7 +1053,7 @@ pub enum DcaCmd {
         plan_id: String,
     },
 
-    /// Permanently stop a DCA plan
+    /// Permanently stop a recurring investment plan
     ///
     /// Example: longbridge dca stop `<PLAN_ID>`
     Stop {
@@ -1061,7 +1061,7 @@ pub enum DcaCmd {
         plan_id: String,
     },
 
-    /// Show trade history for a DCA plan
+    /// Show trade history for a recurring investment plan
     ///
     /// Example: longbridge dca history `<PLAN_ID>`
     /// Example: longbridge dca history `<PLAN_ID>` --page 2 --limit 50
@@ -1076,7 +1076,7 @@ pub enum DcaCmd {
         limit: u32,
     },
 
-    /// Show DCA statistics summary
+    /// Show recurring investment statistics summary
     ///
     /// Returns total invested amount, total profit, plan counts, and nearest upcoming plans.
     /// Example: longbridge dca stats
@@ -1106,7 +1106,7 @@ pub enum DcaCmd {
         day_of_month: Option<String>,
     },
 
-    /// Check whether symbols support DCA
+    /// Check whether symbols support recurring investment
     ///
     /// Example: longbridge dca check AAPL.US 700.HK TSLA.US
     Check {


### PR DESCRIPTION
Replace 'DCA' / 'Dollar-Cost Averaging' with 'recurring investment' in all user-facing help text and output messages to align with the product's English terminology. The command name `dca` is preserved for CLI compatibility.