### PR TITLE
cli: Add `short-positions`, `option volume` and `volume daily` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ longbridge dca stats                                          # Recurring invest
 longbridge dca calc-date TSLA.US --frequency weekly --day-of-week fri  # Calculate next trade date
 longbridge dca check TSLA.US AAPL.US 700.HK                  # Check which symbols support recurring investment
 longbridge dca set-reminder 6                                 # Set reminder hours before trade (1 | 6 | 12)
+
+longbridge option volume-stats AAPL.US                        # Option Call/Put volume and Put/Call ratio for a US stock
+longbridge option volume-daily AAPL.US                        # Daily option Call/Put volume and open interest history
+longbridge option volume-daily AAPL.US --count 60             # Return last 60 trading days
+longbridge short-positions AAPL.US                            # US stock short selling data (short interest, ratio, days to cover)
+longbridge short-positions TSLA.US --count 50                 # Return last 50 short interest records
 ```
 
 <!-- COMMANDS_END -->

--- a/README.md
+++ b/README.md
@@ -278,9 +278,9 @@ longbridge dca calc-date TSLA.US --frequency weekly --day-of-week fri  # Calcula
 longbridge dca check TSLA.US AAPL.US 700.HK                  # Check which symbols support recurring investment
 longbridge dca set-reminder 6                                 # Set reminder hours before trade (1 | 6 | 12)
 
-longbridge option volume-stats AAPL.US                        # Option Call/Put volume and Put/Call ratio for a US stock
-longbridge option volume-daily AAPL.US                        # Daily option Call/Put volume and open interest history
-longbridge option volume-daily AAPL.US --count 60             # Return last 60 trading days
+longbridge option volume AAPL.US                              # Real-time option Call/Put volume and Put/Call ratio
+longbridge option volume daily AAPL.US                        # Daily option Call/Put volume and open interest history
+longbridge option volume daily AAPL.US --count 60             # Return last 60 trading days
 longbridge short-positions AAPL.US                            # US stock short selling data (short interest, ratio, days to cover)
 longbridge short-positions TSLA.US --count 50                 # Return last 50 short interest records
 ```

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -307,11 +307,13 @@ pub enum Commands {
     Subscriptions,
 
     // ── Options & Warrants ──────────────────────────────────────────────────────
-    /// Option quotes and option chain
+    /// Option quotes, option chain, and option volume statistics
     ///
-    /// Subcommands: quote  chain
+    /// Subcommands: quote  chain  volume-stats  volume-daily
     /// Example: longbridge option quote AAPL240119C190000
     /// Example: longbridge option chain AAPL.US --date 2024-01-19
+    /// Example: longbridge option volume-stats AAPL.US
+    /// Example: longbridge option volume-daily AAPL.US
     Option {
         #[command(subcommand)]
         cmd: OptionCmd,
@@ -943,6 +945,20 @@ pub enum Commands {
         /// Records per page (default: 20)
         #[arg(long, default_value = "20")]
         limit: u32,
+    },
+
+    // ── Short positions ─────────────────────────────────────────────────
+    /// US stock short selling data (short interest, short ratio, days to cover)
+    ///
+    /// Only supports US-listed stocks and ETFs.
+    /// Example: longbridge short-positions AAPL.US
+    /// Example: longbridge short-positions TSLA.US --count 50
+    ShortPositions {
+        /// Symbol in <CODE>.<MARKET> format (US market only, e.g. AAPL.US)
+        symbol: String,
+        /// Number of records to return (1–100, default: 20)
+        #[arg(long, default_value = "20")]
+        count: u32,
     },
 
     // ── Sharelist ───────────────────────────────────────────────────────
@@ -1921,17 +1937,6 @@ pub enum TopicCmd {
 
 #[derive(Subcommand)]
 pub enum OptionCmd {
-    /// Real-time quotes for option contracts
-    ///
-    /// Returns all fields from the option quote API: price, volume, implied/historical
-    /// volatility, open interest, strike, expiry, contract type/size/multiplier, direction,
-    /// and underlying symbol.
-    /// Example: longbridge option quote AAPL240119C190000
-    Quote {
-        /// Option contract symbols (OCC format for US, e.g. AAPL240119C190000)
-        symbols: Vec<String>,
-    },
-
     /// Option chain: expiry dates, or strike prices for a given expiry
     ///
     /// Without --date: returns all available expiry dates.
@@ -1944,6 +1949,37 @@ pub enum OptionCmd {
         /// Expiry date (YYYY-MM-DD). Omit to list all expiry dates.
         #[arg(long)]
         date: Option<String>,
+    },
+
+    /// Real-time quotes for option contracts
+    ///
+    /// Returns all fields from the option quote API: price, volume, implied/historical
+    /// volatility, open interest, strike, expiry, contract type/size/multiplier, direction,
+    /// and underlying symbol.
+    /// Example: longbridge option quote AAPL240119C190000
+    Quote {
+        /// Option contract symbols (OCC format for US, e.g. AAPL240119C190000)
+        symbols: Vec<String>,
+    },
+
+    /// Daily Call/Put volume and open interest history
+    ///
+    /// Example: longbridge option volume-daily AAPL.US
+    /// Example: longbridge option volume-daily AAPL.US --count 60
+    VolumeDaily {
+        /// Symbol in <CODE>.<MARKET> format (US market only, e.g. AAPL.US)
+        symbol: String,
+        /// Number of trading days to return (default: 20)
+        #[arg(long, default_value = "20")]
+        count: u32,
+    },
+
+    /// Current Call/Put volume and Put/Call ratio
+    ///
+    /// Example: longbridge option volume-stats AAPL.US
+    VolumeStats {
+        /// Symbol in <CODE>.<MARKET> format (US market only, e.g. AAPL.US)
+        symbol: String,
     },
 }
 
@@ -2131,6 +2167,12 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             OptionCmd::Quote { symbols } => quote::cmd_option_quote(symbols, format).await,
             OptionCmd::Chain { symbol, date } => {
                 quote::cmd_option_chain(symbol, date, format).await
+            }
+            OptionCmd::VolumeStats { symbol } => {
+                quote::cmd_option_volume_stats(symbol, format, verbose).await
+            }
+            OptionCmd::VolumeDaily { symbol, count } => {
+                quote::cmd_option_volume_daily(symbol, count, format, verbose).await
             }
         },
         Commands::Warrant { symbol, cmd } => match cmd {
@@ -2574,6 +2616,10 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             page,
             limit,
         } => dca::cmd_dca(cmd, status.as_deref(), symbol.as_deref(), page, limit, format).await,
+
+        Commands::ShortPositions { symbol, count } => {
+            quote::cmd_short_positions(symbol, count, format, verbose).await
+        }
 
         Commands::Sharelist { cmd, count } => {
             sharelist::cmd_sharelist(cmd, count, format).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -309,11 +309,11 @@ pub enum Commands {
     // ── Options & Warrants ──────────────────────────────────────────────────────
     /// Option quotes, option chain, and option volume statistics
     ///
-    /// Subcommands: quote  chain  volume-stats  volume-daily
+    /// Subcommands: chain  quote  volume
     /// Example: longbridge option quote AAPL240119C190000
     /// Example: longbridge option chain AAPL.US --date 2024-01-19
-    /// Example: longbridge option volume-stats AAPL.US
-    /// Example: longbridge option volume-daily AAPL.US
+    /// Example: longbridge option volume AAPL.US
+    /// Example: longbridge option volume daily AAPL.US
     Option {
         #[command(subcommand)]
         cmd: OptionCmd,
@@ -1962,24 +1962,32 @@ pub enum OptionCmd {
         symbols: Vec<String>,
     },
 
+    /// Real-time Call/Put volume snapshot; with `daily` subcommand shows historical data
+    ///
+    /// Without subcommand: returns today's real-time Call/Put volume and Put/Call ratio.
+    /// Example: longbridge option volume AAPL.US
+    /// Example: longbridge option volume daily AAPL.US
+    /// Example: longbridge option volume daily AAPL.US --count 60
+    Volume {
+        /// Symbol in <CODE>.<MARKET> format (US market only). Omit when using a subcommand.
+        symbol: Option<String>,
+        #[command(subcommand)]
+        cmd: Option<VolumeSubCmd>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum VolumeSubCmd {
     /// Daily Call/Put volume and open interest history
     ///
-    /// Example: longbridge option volume-daily AAPL.US
-    /// Example: longbridge option volume-daily AAPL.US --count 60
-    VolumeDaily {
+    /// Example: longbridge option volume daily AAPL.US
+    /// Example: longbridge option volume daily AAPL.US --count 60
+    Daily {
         /// Symbol in <CODE>.<MARKET> format (US market only, e.g. AAPL.US)
         symbol: String,
         /// Number of trading days to return (default: 20)
         #[arg(long, default_value = "20")]
         count: u32,
-    },
-
-    /// Current Call/Put volume and Put/Call ratio
-    ///
-    /// Example: longbridge option volume-stats AAPL.US
-    VolumeStats {
-        /// Symbol in <CODE>.<MARKET> format (US market only, e.g. AAPL.US)
-        symbol: String,
     },
 }
 
@@ -2168,12 +2176,19 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             OptionCmd::Chain { symbol, date } => {
                 quote::cmd_option_chain(symbol, date, format).await
             }
-            OptionCmd::VolumeStats { symbol } => {
-                quote::cmd_option_volume_stats(symbol, format, verbose).await
-            }
-            OptionCmd::VolumeDaily { symbol, count } => {
-                quote::cmd_option_volume_daily(symbol, count, format, verbose).await
-            }
+            OptionCmd::Volume { symbol, cmd } => match cmd {
+                Some(VolumeSubCmd::Daily { symbol: s, count }) => {
+                    quote::cmd_option_volume_daily(s, count, format, verbose).await
+                }
+                None => {
+                    let sym = symbol.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Symbol required. Usage: longbridge option volume <SYMBOL>"
+                        )
+                    })?;
+                    quote::cmd_option_volume_stats(sym, format, verbose).await
+                }
+            },
         },
         Commands::Warrant { symbol, cmd } => match cmd {
             Some(WarrantCmd::Quote { symbols }) => quote::cmd_warrant_quote(symbols, format).await,

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2694,18 +2694,18 @@ pub async fn cmd_option_volume_stats(
             let call: i64 = val_str(&data["c"]).parse().unwrap_or(0);
             let put: i64 = val_str(&data["p"]).parse().unwrap_or(0);
             let pc_ratio = if call > 0 {
-                format!("{:.2}", put as f64 / call as f64)
+                format!("{:.4}", put as f64 / call as f64)
             } else {
                 "-".to_string()
             };
             println!("Option Volume Stats — {symbol}\n");
             print_table(
-                &["type", "volume"],
-                vec![
-                    vec!["Call".to_string(), format_with_commas(call)],
-                    vec!["Put".to_string(), format_with_commas(put)],
-                    vec!["P/C Ratio".to_string(), pc_ratio],
-                ],
+                &["call_vol", "put_vol", "pc_ratio"],
+                vec![vec![
+                    format_with_commas(call),
+                    format_with_commas(put),
+                    pc_ratio,
+                ]],
                 format,
             );
         }
@@ -2750,11 +2750,19 @@ pub async fn cmd_option_volume_daily(
             items.reverse();
             println!("Option Volume Daily — {symbol}\n");
             let headers = [
-                "date", "call_vol", "put_vol", "p/c_vol", "call_oi", "put_oi", "p/c_oi",
+                "date",
+                "total_vol",
+                "call_vol",
+                "put_vol",
+                "pc_vol",
+                "call_oi",
+                "put_oi",
+                "pc_oi",
             ];
             let rows: Vec<Vec<String>> = items
                 .iter()
                 .map(|item| {
+                    let total_vol: i64 = val_str(&item["total_volume"]).parse().unwrap_or(0);
                     let call_vol: i64 = val_str(&item["total_call_volume"]).parse().unwrap_or(0);
                     let put_vol: i64 = val_str(&item["total_put_volume"]).parse().unwrap_or(0);
                     let call_oi: i64 = val_str(&item["total_call_open_interest"])
@@ -2765,6 +2773,7 @@ pub async fn cmd_option_volume_daily(
                         .unwrap_or(0);
                     vec![
                         fmt_ts(&val_str(&item["timestamp"])),
+                        format_with_commas(total_vol),
                         format_with_commas(call_vol),
                         format_with_commas(put_vol),
                         val_str(&item["put_call_volume_ratio"]),
@@ -2806,13 +2815,14 @@ pub async fn cmd_short_positions(
     match format {
         OutputFormat::Json => print_json(&data),
         OutputFormat::Pretty => {
-            let items = match data.get("data").and_then(|v| v.as_array()) {
+            let mut items = match data.get("data").and_then(|v| v.as_array()) {
                 Some(a) if !a.is_empty() => a.clone(),
                 _ => {
                     println!("No short selling data found for {symbol}.");
                     return Ok(());
                 }
             };
+            items.reverse();
             println!("Short Selling Data — {symbol}\n");
             let headers = [
                 "date",

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2676,6 +2676,182 @@ pub async fn cmd_anomaly(
     Ok(())
 }
 
+pub async fn cmd_option_volume_stats(
+    symbol: String,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    let cid = symbol_to_counter_id(&symbol);
+    let data = http_get(
+        "/v1/quote/option-volume-stats",
+        &[("underlying_counter_id", cid.as_str())],
+        verbose,
+    )
+    .await?;
+    match format {
+        OutputFormat::Json => print_json(&data),
+        OutputFormat::Pretty => {
+            let call: i64 = val_str(&data["c"]).parse().unwrap_or(0);
+            let put: i64 = val_str(&data["p"]).parse().unwrap_or(0);
+            let pc_ratio = if call > 0 {
+                format!("{:.2}", put as f64 / call as f64)
+            } else {
+                "-".to_string()
+            };
+            println!("Option Volume Stats — {symbol}\n");
+            print_table(
+                &["type", "volume"],
+                vec![
+                    vec!["Call".to_string(), format_with_commas(call)],
+                    vec!["Put".to_string(), format_with_commas(put)],
+                    vec!["P/C Ratio".to_string(), pc_ratio],
+                ],
+                format,
+            );
+        }
+    }
+    Ok(())
+}
+
+pub async fn cmd_option_volume_daily(
+    symbol: String,
+    count: u32,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    let cid = symbol_to_counter_id(&symbol);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .to_string();
+    let count_str = count.to_string();
+    let data = http_get(
+        "/v1/quote/option-volume-stats/daily",
+        &[
+            ("counter_id", cid.as_str()),
+            ("timestamp", now.as_str()),
+            ("line_num", count_str.as_str()),
+            ("direction", "1"),
+        ],
+        verbose,
+    )
+    .await?;
+    match format {
+        OutputFormat::Json => print_json(&data),
+        OutputFormat::Pretty => {
+            let mut items = match data.get("stats").and_then(|v| v.as_array()) {
+                Some(a) if !a.is_empty() => a.clone(),
+                _ => {
+                    println!("No option volume data found for {symbol}.");
+                    return Ok(());
+                }
+            };
+            items.reverse();
+            println!("Option Volume Daily — {symbol}\n");
+            let headers = [
+                "date", "call_vol", "put_vol", "p/c_vol", "call_oi", "put_oi", "p/c_oi",
+            ];
+            let rows: Vec<Vec<String>> = items
+                .iter()
+                .map(|item| {
+                    let call_vol: i64 = val_str(&item["total_call_volume"]).parse().unwrap_or(0);
+                    let put_vol: i64 = val_str(&item["total_put_volume"]).parse().unwrap_or(0);
+                    let call_oi: i64 = val_str(&item["total_call_open_interest"])
+                        .parse()
+                        .unwrap_or(0);
+                    let put_oi: i64 = val_str(&item["total_put_open_interest"])
+                        .parse()
+                        .unwrap_or(0);
+                    vec![
+                        fmt_ts(&val_str(&item["timestamp"])),
+                        format_with_commas(call_vol),
+                        format_with_commas(put_vol),
+                        val_str(&item["put_call_volume_ratio"]),
+                        format_with_commas(call_oi),
+                        format_with_commas(put_oi),
+                        val_str(&item["put_call_open_interest_ratio"]),
+                    ]
+                })
+                .collect();
+            print_table(&headers, rows, format);
+        }
+    }
+    Ok(())
+}
+
+pub async fn cmd_short_positions(
+    symbol: String,
+    count: u32,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    let cid = symbol_to_counter_id(&symbol);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .to_string();
+    let count_str = count.clamp(1, 100).to_string();
+    let data = http_get(
+        "/v1/quote/short-positions/us",
+        &[
+            ("counter_id", cid.as_str()),
+            ("last_timestamp", now.as_str()),
+            ("page_size", count_str.as_str()),
+        ],
+        verbose,
+    )
+    .await?;
+    match format {
+        OutputFormat::Json => print_json(&data),
+        OutputFormat::Pretty => {
+            let items = match data.get("data").and_then(|v| v.as_array()) {
+                Some(a) if !a.is_empty() => a.clone(),
+                _ => {
+                    println!("No short selling data found for {symbol}.");
+                    return Ok(());
+                }
+            };
+            println!("Short Selling Data — {symbol}\n");
+            let headers = [
+                "date",
+                "rate%",
+                "short_shares",
+                "avg_daily_vol",
+                "days_cover",
+                "close",
+            ];
+            let rows: Vec<Vec<String>> = items
+                .iter()
+                .map(|item| {
+                    let ts = val_str(&item["timestamp"]);
+                    let rate = val_str(&item["rate"])
+                        .parse::<f64>()
+                        .map_or_else(|_| val_str(&item["rate"]), |v| format!("{:.2}%", v * 100.0));
+                    let short_shares: i64 =
+                        val_str(&item["current_shares_short"]).parse().unwrap_or(0);
+                    let avg_vol: i64 = val_str(&item["avg_daily_share_volume"])
+                        .parse()
+                        .unwrap_or(0);
+                    let days = val_str(&item["days_to_cover"]);
+                    let close = val_str(&item["close"]);
+                    vec![
+                        fmt_ts(&ts),
+                        rate,
+                        format_with_commas(short_shares),
+                        format_with_commas(avg_vol),
+                        days,
+                        close,
+                    ]
+                })
+                .collect();
+            print_table(&headers, rows, format);
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Add `longbridge short-positions <SYMBOL.US>` — US stock short selling data (short interest, ratio, days to cover, avg daily volume, close price); newest records first; `--count` 1–100, default 20
- Add `longbridge option volume <SYMBOL.US>` — real-time Call/Put volume snapshot (call_vol, put_vol, pc_ratio) followed by daily history table (total_vol, call_vol, put_vol, pc_vol, call_oi, put_oi, pc_oi); `--count` controls history depth
- `option volume daily` subcommand replaced by a single unified `option volume` that prints stats then daily history in one output
- Both option volume commands folded under the existing `option` command; help lists `chain / quote / volume` in alphabetical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)