### PR TITLE
cli: Require terms agreement before creating a recurring investment plan

### DIFF
--- a/src/cli/dca.rs
+++ b/src/cli/dca.rs
@@ -172,8 +172,8 @@ fn confirm_terms() -> Result<bool> {
     println!(
         "\n{BOLD}{YELLOW}Terms and Conditions — Recurring Investment{RESET}\n\n\
         Please read the Terms and Conditions before proceeding:\n\n\
-        {BOLD}Longbridge HK:{RESET}\n  {link_hk}\n\n\
         {BOLD}Longbridge SG:{RESET}\n  {link_sg}\n\n\
+        {BOLD}Longbridge HK:{RESET}\n  {link_hk}\n\n\
         {DIM}Tip: pass --agree-terms to skip this prompt.\n\
         By using that flag you confirm you have read and agreed to the Terms and Conditions.{RESET}\n"
     );

--- a/src/cli/dca.rs
+++ b/src/cli/dca.rs
@@ -8,7 +8,6 @@ use super::{
 
 use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
 use crate::utils::datetime::format_timestamp;
-use crate::utils::text::hyperlink;
 
 pub async fn cmd_dca(
     cmd: Option<DcaCmd>,
@@ -166,8 +165,8 @@ fn confirm_terms() -> Result<bool> {
     const URL_HK: &str = "https://pub.lbkrs.com/static/offline/202510/Cbq7M3dMEsABF2tU/Terms_and_Conditions_for_the_Recurring_Investment-en.pdf";
     const URL_SG: &str = "https://pub.lbkrs.com/static/offline/202511/QLnmVqLGUtvfQiFv/_SG__Terms_and_Conditions_for_the_Recurring_Investment.pdf";
 
-    let link_hk = format!("{CYAN}{}{RESET}", hyperlink(URL_HK, URL_HK));
-    let link_sg = format!("{CYAN}{}{RESET}", hyperlink(URL_SG, URL_SG));
+    let link_hk = format!("{CYAN}{URL_HK}{RESET}");
+    let link_sg = format!("{CYAN}{URL_SG}{RESET}");
 
     println!(
         "\n{BOLD}{YELLOW}Terms and Conditions — Recurring Investment{RESET}\n\n\
@@ -175,7 +174,7 @@ fn confirm_terms() -> Result<bool> {
         {BOLD}Longbridge SG:{RESET}\n  {link_sg}\n\n\
         {BOLD}Longbridge HK:{RESET}\n  {link_hk}\n\n\
         {DIM}Tip: pass --agree-terms to skip this prompt.\n\
-        By using that flag you confirm you have read and agreed to the Terms and Conditions.{RESET}\n"
+        BY USING THAT FLAG YOU CONFIRM YOU HAVE READ AND AGREED TO THE TERMS AND CONDITIONS.{RESET}\n"
     );
     print!("Do you agree to the Terms and Conditions? [y/N]: ");
     std::io::stdout().flush()?;

--- a/src/cli/dca.rs
+++ b/src/cli/dca.rs
@@ -8,6 +8,7 @@ use super::{
 
 use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
 use crate::utils::datetime::format_timestamp;
+use crate::utils::text::hyperlink;
 
 pub async fn cmd_dca(
     cmd: Option<DcaCmd>,
@@ -26,6 +27,7 @@ pub async fn cmd_dca(
             day_of_week,
             day_of_month,
             allow_margin,
+            agree_terms,
         }) => {
             cmd_create(
                 symbol,
@@ -34,6 +36,7 @@ pub async fn cmd_dca(
                 day_of_week,
                 day_of_month,
                 allow_margin,
+                agree_terms,
             )
             .await
         }
@@ -151,6 +154,36 @@ async fn cmd_list(
     Ok(())
 }
 
+fn confirm_terms() -> Result<bool> {
+    use std::io::Write;
+
+    const BOLD: &str = "\x1b[1m";
+    const YELLOW: &str = "\x1b[33m";
+    const CYAN: &str = "\x1b[36m";
+    const DIM: &str = "\x1b[2m";
+    const RESET: &str = "\x1b[0m";
+
+    const URL_HK: &str = "https://pub.lbkrs.com/static/offline/202510/Cbq7M3dMEsABF2tU/Terms_and_Conditions_for_the_Recurring_Investment-en.pdf";
+    const URL_SG: &str = "https://pub.lbkrs.com/static/offline/202511/QLnmVqLGUtvfQiFv/_SG__Terms_and_Conditions_for_the_Recurring_Investment.pdf";
+
+    let link_hk = format!("{CYAN}{}{RESET}", hyperlink(URL_HK, URL_HK));
+    let link_sg = format!("{CYAN}{}{RESET}", hyperlink(URL_SG, URL_SG));
+
+    println!(
+        "\n{BOLD}{YELLOW}Terms and Conditions — Recurring Investment{RESET}\n\n\
+        Please read the Terms and Conditions before proceeding:\n\n\
+        {BOLD}Longbridge HK:{RESET}\n  {link_hk}\n\n\
+        {BOLD}Longbridge SG:{RESET}\n  {link_sg}\n\n\
+        {DIM}Tip: pass --agree-terms to skip this prompt.\n\
+        By using that flag you confirm you have read and agreed to the Terms and Conditions.{RESET}\n"
+    );
+    print!("Do you agree to the Terms and Conditions? [y/N]: ");
+    std::io::stdout().flush()?;
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    Ok(input.trim().eq_ignore_ascii_case("y"))
+}
+
 async fn cmd_create(
     symbol: String,
     amount: String,
@@ -158,7 +191,13 @@ async fn cmd_create(
     day_of_week: Option<DcaDayOfWeek>,
     day_of_month: Option<String>,
     allow_margin: bool,
+    agree_terms: bool,
 ) -> Result<()> {
+    if !agree_terms && !confirm_terms()? {
+        println!("Recurring investment plan creation cancelled.");
+        return Ok(());
+    }
+
     let mut body = serde_json::json!({
         "counter_id": symbol_to_counter_id(&symbol),
         "per_invest_amount": amount,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1018,6 +1018,9 @@ pub enum DcaCmd {
         /// Allow margin financing for the investment amount (default: false)
         #[arg(long)]
         allow_margin: bool,
+        /// Agree to the Terms and Conditions without interactive prompt
+        #[arg(long)]
+        agree_terms: bool,
     },
 
     /// Update an existing recurring investment plan

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -1,3 +1,9 @@
+/// Format a terminal OSC 8 hyperlink: displays `label` but links to `url`.
+/// Falls back to plain `url` on terminals that do not support OSC 8.
+pub fn hyperlink(url: &str, label: &str) -> String {
+    format!("\x1b]8;;{url}\x1b\\{label}\x1b]8;;\x1b\\")
+}
+
 /// Strip HTML tags from a string, returning plain text.
 pub fn strip_html(s: &str) -> String {
     let mut out = String::new();

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -1,9 +1,3 @@
-/// Format a terminal OSC 8 hyperlink: displays `label` but links to `url`.
-/// Falls back to plain `url` on terminals that do not support OSC 8.
-pub fn hyperlink(url: &str, label: &str) -> String {
-    format!("\x1b]8;;{url}\x1b\\{label}\x1b]8;;\x1b\\")
-}
-
 /// Strip HTML tags from a string, returning plain text.
 pub fn strip_html(s: &str) -> String {
     let mut out = String::new();


### PR DESCRIPTION
## Summary

- Show Terms and Conditions (HK & SG) with colored, clickable OSC 8 hyperlinks before creating a DCA plan
- Prompt user to confirm agreement interactively (`[y/N]`)
- Add `--agree-terms` flag to skip the interactive prompt; passing the flag implies acceptance of the Terms and Conditions
- Add `hyperlink()` utility to `src/utils/text.rs` for OSC 8 terminal hyperlinks

## Test plan

- [ ] `longbridge dca create AAPL.US --amount 100 --frequency daily` — should show terms prompt
- [ ] Enter `y` — should proceed to create plan
- [ ] Enter `n` or press Enter — should cancel with message
- [ ] `longbridge dca create AAPL.US --amount 100 --frequency daily --agree-terms` — should skip prompt and create directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)