### PR TITLE
cli: Add shell completion command (bash, zsh, fish, elvish, powershell)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,6 +2418,7 @@ dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
  "clap",
+ "clap_complete",
  "cli-candlestick-chart",
  "crossterm",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bevy_app = "0.11"
 bevy_ecs = "0.11"
 bytemuck = { version = "1.14", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 tabled = "0.20"
 tar = "0.4"
 cli-candlestick-chart = { version = "0.4.1", path = "crates/cli-candlestick-chart", default-features = false }

--- a/README.md
+++ b/README.md
@@ -84,6 +84,43 @@ Token is shared between CLI and TUI. After `login`, all commands work without re
 
 The CLI auto-detects China Mainland on each startup by probing `geotest.lbkrs.com` in the background and caches the result. If detected, CN API endpoints are used automatically on the next run.
 
+## Shell Completion
+
+Enable tab-completion for `longbridge` commands and flags in your shell:
+
+**Bash** — add to `~/.bashrc` or `~/.bash_profile`:
+
+```bash
+eval "$(longbridge completion bash)"
+```
+
+Or generate a static file (faster startup):
+
+```bash
+longbridge completion bash > ~/.bash_completion
+# then add to ~/.bashrc:  source ~/.bash_completion
+```
+
+**Zsh** — add to `~/.zshrc`:
+
+```zsh
+# Create the completion directory if it doesn't exist
+mkdir -p ~/.zfunc
+longbridge completion zsh > ~/.zfunc/_longbridge
+
+# Add before compinit in ~/.zshrc:
+fpath=(~/.zfunc $fpath)
+autoload -Uz compinit && compinit
+```
+
+**Fish**:
+
+```fish
+longbridge completion fish > ~/.config/fish/completions/longbridge.fish
+```
+
+After reloading your shell, `longbridge <TAB>` will suggest subcommands, flags, and values.
+
 ## CLI Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -94,29 +94,16 @@ Enable tab-completion for `longbridge` commands and flags in your shell:
 eval "$(longbridge completion bash)"
 ```
 
-Or generate a static file (faster startup):
-
-```bash
-longbridge completion bash > ~/.bash_completion
-# then add to ~/.bashrc:  source ~/.bash_completion
-```
-
 **Zsh** — add to `~/.zshrc`:
 
 ```zsh
-# Create the completion directory if it doesn't exist
-mkdir -p ~/.zfunc
-longbridge completion zsh > ~/.zfunc/_longbridge
-
-# Add before compinit in ~/.zshrc:
-fpath=(~/.zfunc $fpath)
-autoload -Uz compinit && compinit
+eval "$(longbridge completion zsh)"
 ```
 
-**Fish**:
+**Fish** — add to `~/.config/fish/config.fish`:
 
 ```fish
-longbridge completion fish > ~/.config/fish/completions/longbridge.fish
+longbridge completion fish | source
 ```
 
 After reloading your shell, `longbridge <TAB>` will suggest subcommands, flags, and values.

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Enable tab-completion for `longbridge` commands and flags in your shell:
 **Bash** — add to `~/.bashrc` or `~/.bash_profile`:
 
 ```bash
-eval "$(longbridge completion bash)"
+source <(longbridge completion bash)
 ```
 
 **Zsh** — add to `~/.zshrc`:
 
 ```zsh
-eval "$(longbridge completion zsh)"
+source <(longbridge completion zsh)
 ```
 
 **Fish** — add to `~/.config/fish/config.fish`:

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -13,9 +13,7 @@ pub const CALLBACK_PORT: u16 = 60355;
 
 /// Whether the staging environment is active (`LONGBRIDGE_ENV=staging`).
 pub fn is_test_env() -> bool {
-    std::env::var("LONGBRIDGE_ENV")
-        .map(|v| v == "staging")
-        .unwrap_or(false)
+    std::env::var("LONGBRIDGE_ENV").is_ok_and(|v| v == "staging")
 }
 
 /// Return the OAuth client ID for the current environment.

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -1,0 +1,9 @@
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+
+use crate::cli::Cli;
+
+pub fn cmd_completion(shell: Shell) {
+    let mut cmd = Cli::command();
+    generate(shell, &mut cmd, "longbridge", &mut std::io::stdout());
+}

--- a/src/cli/investors.rs
+++ b/src/cli/investors.rs
@@ -427,7 +427,7 @@ pub async fn cmd_investors_list(top: usize, format: &OutputFormat) -> Result<()>
             .into_iter()
             .map(|(cik, (period, aum))| (cik, period, aum))
             .collect();
-        all_ranked.sort_unstable_by(|a, b| b.2.cmp(&a.2));
+        all_ranked.sort_unstable_by_key(|b| std::cmp::Reverse(b.2));
         all_ranked.truncate(200);
         let padded_ciks: Vec<String> = all_ranked
             .iter()
@@ -1052,7 +1052,7 @@ async fn show_holdings(
     let mut holdings = consolidate_holdings(raw_holdings);
     apply_value_multiplier(&mut holdings);
 
-    holdings.sort_unstable_by(|a, b| b.value.cmp(&a.value));
+    holdings.sort_unstable_by_key(|b| std::cmp::Reverse(b.value));
 
     #[allow(clippy::cast_precision_loss)]
     let total_value: u64 = holdings.iter().map(|h| h.value).sum();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod api;
 pub mod asset;
 pub mod auth;
 pub mod check;
+pub mod completion;
 pub mod dca;
 pub mod fundamental;
 pub mod insider_trades;
@@ -107,6 +108,20 @@ pub enum Commands {
     /// Real-time watchlist, candlestick charts, portfolio view, stock search, Vim-like keybindings.
     /// Example: longbridge tui
     Tui,
+
+    /// Generate shell completion script
+    ///
+    /// Prints a shell completion script to stdout.
+    /// Redirect the output to the appropriate file and reload your shell to enable tab-completion.
+    ///
+    /// Example (bash):  `longbridge completion bash >> ~/.bash_completion`
+    /// Example (zsh):   `longbridge completion zsh  > ~/.zfunc/_longbridge`
+    ///                  (add `fpath=(~/.zfunc $fpath)` and `autoload -Uz compinit && compinit` to `~/.zshrc`)
+    /// Example (fish):  `longbridge completion fish > ~/.config/fish/completions/longbridge.fish`
+    Completion {
+        /// Target shell: bash, zsh, fish, elvish, or powershell
+        shell: clap_complete::Shell,
+    },
 
     // ── Quote ──────────────────────────────────────────────────────────────────
     /// Real-time quotes for one or more symbols
@@ -2646,7 +2661,8 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
         Commands::Auth { .. }
         | Commands::Tui
         | Commands::Check
-        | Commands::Update { .. } => {
+        | Commands::Update { .. }
+        | Commands::Completion { .. } => {
             unreachable!()
         }
     }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -79,14 +79,18 @@ pub fn fmt_decimal(v: &Option<rust_decimal::Decimal>) -> String {
 
 /// Format optional decimal divided by 100 with 3 decimal places (API returns percentage values, e.g. implied volatility, rho)
 pub fn fmt_decimal_div100(v: &Option<rust_decimal::Decimal>) -> String {
-    v.map(|d| format!("{:.3}", d / rust_decimal::Decimal::ONE_HUNDRED))
-        .unwrap_or_else(|| "-".to_string())
+    v.map_or_else(
+        || "-".to_string(),
+        |d| format!("{:.3}", d / rust_decimal::Decimal::ONE_HUNDRED),
+    )
 }
 
 /// Format optional decimal divided by 252 with 3 decimal places (convert annualized greek to per-trading-day, e.g. theta, vega)
 pub fn fmt_decimal_div252(v: &Option<rust_decimal::Decimal>) -> String {
-    v.map(|d| format!("{:.3}", d / rust_decimal::Decimal::from(252u32)))
-        .unwrap_or_else(|| "-".to_string())
+    v.map_or_else(
+        || "-".to_string(),
+        |d| format!("{:.3}", d / rust_decimal::Decimal::from(252u32)),
+    )
 }
 
 /// Format decimal

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2694,7 +2694,9 @@ pub async fn cmd_option_volume_stats(
             let call: i64 = val_str(&data["c"]).parse().unwrap_or(0);
             let put: i64 = val_str(&data["p"]).parse().unwrap_or(0);
             let pc_ratio = if call > 0 {
-                format!("{:.4}", put as f64 / call as f64)
+                #[allow(clippy::cast_precision_loss)]
+                let ratio = put as f64 / call as f64;
+                format!("{ratio:.4}")
             } else {
                 "-".to_string()
             };

--- a/src/cli/trade.rs
+++ b/src/cli/trade.rs
@@ -755,7 +755,7 @@ pub async fn cmd_portfolio(format: &OutputFormat) -> Result<()> {
                 // Sort by value descending
                 let mut dist: Vec<(String, rust_decimal::Decimal)> =
                     market_values.into_iter().collect();
-                dist.sort_by(|a, b| b.1.cmp(&a.1));
+                dist.sort_by_key(|b| std::cmp::Reverse(b.1));
 
                 let dist_headers = &["Market", "Value (USD)", "%"];
                 let dist_rows = dist

--- a/src/data/watchlist.rs
+++ b/src/data/watchlist.rs
@@ -42,7 +42,7 @@ impl Watchlist {
         let mut seen = HashSet::new();
         let mut all = Vec::new();
 
-        for counter in watchlist_counters.into_iter().chain(holdings.into_iter()) {
+        for counter in watchlist_counters.into_iter().chain(holdings) {
             if seen.insert(counter.clone()) {
                 all.push(counter);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,6 +199,10 @@ async fn main() {
             }
         }
 
+        Some(cli::Commands::Completion { shell }) => {
+            cli::completion::cmd_completion(shell);
+        }
+
         Some(cmd) => {
             let start = verbose.then(Instant::now);
             // CLI mode: init contexts (auth), then dispatch

--- a/src/tui/systems/portfolio.rs
+++ b/src/tui/systems/portfolio.rs
@@ -252,7 +252,7 @@ pub fn render_portfolio(
                     .map(|(m, v)| (format!("{m:?}"), v, Some(m)))
                     .collect();
                 entries.push(("Cash".to_string(), overview.total_cash, None));
-                entries.sort_by(|a, b| b.1.cmp(&a.1));
+                entries.sort_by_key(|b| std::cmp::Reverse(b.1));
 
                 let mut spans: Vec<Span> = Vec::new();
                 for (label, value, market_opt) in &entries {

--- a/src/update.rs
+++ b/src/update.rs
@@ -77,8 +77,7 @@ fn cache_is_fresh() -> bool {
     };
     modified
         .elapsed()
-        .map(|d| d.as_secs() < CHECK_INTERVAL_SECS)
-        .unwrap_or(false)
+        .is_ok_and(|d| d.as_secs() < CHECK_INTERVAL_SECS)
 }
 
 /// Compare two version strings (e.g., "0.9.0" vs "0.10.0").


### PR DESCRIPTION
Adds `longbridge completion <shell>` using clap_complete. The command runs without authentication and prints a completion script to stdout. README gains a Shell Completion setup section. Also fixes pre-existing clippy pedantic warnings across several files.