### PR TITLE
docs: update login references to use auth subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Installs the `longbridge` binary to `/usr/local/bin` (macOS/Linux) or `%LOCALAPP
 Uses **OAuth 2.0** via the Longbridge SDK — no manual token management required.
 
 ```bash
-longbridge login    # Opens browser for OAuth and saves token (managed by SDK)
-longbridge logout   # Clear saved token
+longbridge auth login    # Opens browser for OAuth and saves token (managed by SDK)
+longbridge auth logout   # Clear saved token
 longbridge check    # Verify token, region, and API endpoint connectivity
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -82,5 +82,5 @@ if ($userPath -notlike "*$installDir*") {
 Write-Host ""
 Write-Host "Longbridge CLI $version has been installed successfully."
 Write-Host ""
-Write-Host "Run 'longbridge login' to authenticate, then 'longbridge -h' for help."
+Write-Host "Run 'longbridge auth login' to authenticate, then 'longbridge -h' for help."
 Write-Host ""

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -41,7 +41,7 @@ Symbol format: <CODE>.<MARKET>\n\
 Note: crypto symbols use the .HAS suffix (Longbridge-specific). If a .HAS symbol returns no\n\
 data, crypto market access may not be enabled for this account — the data exists but is\n\
 restricted by account type.\n\n\
-Authentication: run `longbridge login` once; the token is stored at \
+Authentication: run `longbridge auth login` once; the token is stored at \
 ~/.longbridge/openapi/tokens/<client_id> and reused automatically by all commands.\n\n\
 Use --format json on any command for machine-readable output suitable for AI agents:\n\
   longbridge quote TSLA.US --format json\n\
@@ -59,7 +59,7 @@ pub struct Cli {
     #[arg(long, global = true, default_value = "pretty")]
     pub format: OutputFormat,
 
-    /// Clear stored OAuth token and exit (same as `longbridge logout`)
+    /// Clear stored OAuth token and exit (same as `longbridge auth logout`)
     #[arg(long)]
     pub logout: bool,
 

--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -83,7 +83,7 @@ pub async fn init_contexts() -> Result<(
                     tracing::warn!("Token refresh failed, clearing stale token: {msg}");
                     let _ = crate::auth::clear_token();
                     return Err(anyhow::anyhow!(
-                            "Stored token is invalid or expired. Please run 'longbridge login' to re-authenticate."
+                            "Stored token is invalid or expired. Please run 'longbridge auth login' to re-authenticate."
                         ));
                 }
                 return Err(anyhow::anyhow!("OAuth failed: {e}"));


### PR DESCRIPTION
## Summary

- Updated `longbridge login` → `longbridge auth login` in README, install script, CLI help text, and error messages
- Aligns documentation with the `auth` subcommand group introduced in v0.16.3

## Test plan

- [ ] Verify `longbridge auth login` and `longbridge auth logout` work as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)