### PR TITLE
chore: Fix Homebrew formula doubling on each CI run

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           BASE_URL="https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.tag }}"
 
-          for PLATFORM in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do
+          for PLATFORM in darwin-amd64 darwin-arm64; do
             FILE="longbridge-terminal-${PLATFORM}.tar.gz"
             URL="${BASE_URL}/${FILE}"
 
@@ -80,12 +80,10 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
           DARWIN_AMD64_SHA256: ${{ steps.checksums.outputs.darwin_amd64_sha256 }}
           DARWIN_ARM64_SHA256: ${{ steps.checksums.outputs.darwin_arm64_sha256 }}
-          LINUX_AMD64_SHA256: ${{ steps.checksums.outputs.linux_amd64_sha256 }}
-          LINUX_ARM64_SHA256: ${{ steps.checksums.outputs.linux_arm64_sha256 }}
           REPO: ${{ github.repository }}
         run: |
           python3 - <<'PYEOF'
-          import re, os
+          import os, textwrap
 
           formula_path = "homebrew-tap/Casks/longbridge-terminal.rb"
           version  = os.environ["VERSION"]
@@ -93,38 +91,46 @@ jobs:
           repo     = os.environ["REPO"]
           base_url = f"https://github.com/{repo}/releases/download/{tag}"
 
-          sha_map = {
-              "darwin-amd64": os.environ["DARWIN_AMD64_SHA256"],
-              "darwin-arm64": os.environ["DARWIN_ARM64_SHA256"],
-              "linux-amd64":  os.environ["LINUX_AMD64_SHA256"],
-              "linux-arm64":  os.environ["LINUX_ARM64_SHA256"],
-          }
+          arm64_url  = f"{base_url}/longbridge-terminal-darwin-arm64.tar.gz"
+          amd64_url  = f"{base_url}/longbridge-terminal-darwin-amd64.tar.gz"
+          arm64_sha  = os.environ["DARWIN_ARM64_SHA256"]
+          amd64_sha  = os.environ["DARWIN_AMD64_SHA256"]
 
-          with open(formula_path) as f:
-              content = f.read()
+          content = textwrap.dedent(f"""\
+            cask "longbridge-terminal" do
+              version "{version}"
 
-          # Update version line
-          content = re.sub(r'(version\s+")[^"]*(")', rf'\g<1>{version}\g<2>', content)
+              on_arm do
+                url "{arm64_url}"
+                sha256 "{arm64_sha}"
+              end
 
-          for platform, sha in sha_map.items():
-              new_url = f"{base_url}/longbridge-terminal-{platform}.tar.gz"
-              # Replace url containing this platform identifier
-              content = re.sub(
-                  rf'(url\s+")https://[^"]*{re.escape(platform)}[^"]*(")',
-                  rf'\g<1>{new_url}\g<2>',
-                  content,
-              )
-              # Replace sha256 on the line immediately after a matching url
-              content = re.sub(
-                  rf'(url\s+"[^"]*{re.escape(platform)}[^"]*"\n(\s*))sha256\s+"[0-9a-f]{{64}}"',
-                  rf'\g<1>\g<2>sha256 "{sha}"',
-                  content,
-              )
+              on_intel do
+                url "{amd64_url}"
+                sha256 "{amd64_sha}"
+              end
+
+              desc "Longbridge Terminal CLI for US and HK stock market data and trading"
+              homepage "https://github.com/longbridge/longbridge-terminal"
+
+              binary "longbridge"
+
+              postflight do
+                system_command "/usr/bin/xattr",
+                  args: ["-dr", "com.apple.quarantine", staged_path]
+              end
+
+              caveats <<~EOS
+                Get started by running:
+                  longbridge -h
+              EOS
+            end
+          """)
 
           with open(formula_path, "w") as f:
               f.write(content)
 
-          print("Formula updated successfully")
+          print("Formula written successfully")
           PYEOF
 
           echo "--- Updated formula ---"


### PR DESCRIPTION
## Summary

- The `update-homebrew.yml` Python script used `\g<1>\g<2>sha256 "..."` in the sha256 regex replacement, where `\g<1>` already captured the leading whitespace and `\g<2>` duplicated it — causing the `sha256` line indentation to double on every CI run
- After ~17 releases, the file grew from 744 B to 67 MB, and the latest push attempt (128 MB) was rejected by GitHub
- Fix: replace the read-and-patch approach with template generation — the formula is now written from scratch on every run, immediately overwriting the corrupted file and preventing future recurrence
- Also removed the unused `linux-amd64` / `linux-arm64` downloads (Homebrew Casks are macOS-only)

## Test plan

- [ ] Trigger the `Update Homebrew Tap` workflow manually (`workflow_dispatch`) with a recent tag (e.g. `v0.17.1`)
- [ ] Verify the CI completes without the 100 MB push rejection
- [ ] Check `Casks/longbridge-terminal.rb` in the homebrew-tap repo is now a small, properly-formatted Ruby file

🤖 Generated with [Claude Code](https://claude.com/claude-code)