### PR TITLE
cli: Add `x-channel-id` request header

### DIFF
--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -150,11 +150,15 @@ pub async fn init_contexts() -> Result<(
     };
 
     let user_agent = concat!("longbridge-cli/", env!("CARGO_PKG_VERSION"));
+    let channel = crate::auth::read_channel();
 
     // Inject into Config so headers appear in WebSocket upgrade requests too.
     config_builder = config_builder.header("user-agent", user_agent);
     if !cli_cmd.is_empty() {
         config_builder = config_builder.header("x-cli-cmd", &cli_cmd);
+    }
+    if let Some(ref ch) = channel {
+        config_builder = config_builder.header("x-channel-id", ch.as_str());
     }
 
     let config = Arc::new(config_builder);
@@ -174,6 +178,9 @@ pub async fn init_contexts() -> Result<(
     http_client = http_client.header("user-agent", user_agent);
     if !cli_cmd.is_empty() {
         http_client = http_client.header("x-cli-cmd", cli_cmd.as_str());
+    }
+    if let Some(ref ch) = channel {
+        http_client = http_client.header("x-channel-id", ch.as_str());
     }
 
     HTTP_CLIENT


### PR DESCRIPTION
## Summary

- 将 `x-channel-key` 替换为 `x-channel-id`，通过 HTTP 请求头将 channel-id 传递到服务端
- 同时注入到 `Config`（WebSocket upgrade 请求）和 `HttpClient`（REST 请求），与 `user-agent`、`x-cli-cmd` 保持一致的注入模式
- 读取路径不变：`~/.longbridge/openapi/channel`（由 `longbridge init` 写入）

## Test plan

- [ ] 运行 `longbridge init <channel_key>` 设置 channel
- [ ] 执行任意 CLI 命令，在服务端日志确认 `x-channel-id` 头已传递

🤖 Generated with [Claude Code](https://claude.com/claude-code)