### PR TITLE
cli: Fix OAuth token refresh hang and improve `auth status` accuracy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,8 @@ let order = ctx.submit_order(opts).await?;
 
 1. **Rate Limiting**: Longbridge OpenAPI rate limits to "no more than 10 calls per second"
 2. **Token Expiration**: The SDK automatically refreshes the access token when needed
-3. **Market Support**: Supports Hong Kong, US, and China A-share markets
+3. **CN / Global token interoperability**: The `.cn` and `.com` OAuth endpoints share the same user data and token validation. A token issued by one endpoint is accepted by the other. The two regions differ only in routing/acceleration, not in auth logic. Do not treat region as a token-refresh issue.
+4. **Market Support**: Supports Hong Kong, US, and China A-share markets
 4. **Testing**: Per user instructions, update flow has no test coverage
 5. **Logging**: Uses `tracing` library, log files configured via `logger::init()`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,6 +2413,7 @@ dependencies = [
  "arrayvec",
  "async-trait",
  "atomic",
+ "base64 0.22.1",
  "bevy_app",
  "bevy_ecs",
  "bitflags 2.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ split-debuginfo = "packed" # 将 Debug Info 单独打包为 .pdb (Windows) 或 .
 ansi-parser = "0.9.1"
 ansi-to-tui = "8.0.1"
 anyhow = "1.0"
+base64 = "0.22"
 arrayvec = "0.7"
 atomic = "0.6.0"
 bevy_app = "0.11"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -194,9 +194,15 @@ pub async fn device_login(verbose: bool) -> Result<()> {
         .unwrap_or_else(|| device_resp["verification_uri"].as_str().unwrap_or(""));
     let verification_url_owned;
     let verification_url = if let Some(ref ch) = channel {
-        let sep = if verification_url_base.contains('?') { '&' } else { '?' };
-        verification_url_owned =
-            format!("{verification_url_base}{sep}channel={}", percent_encoding::utf8_percent_encode(ch, percent_encoding::NON_ALPHANUMERIC));
+        let sep = if verification_url_base.contains('?') {
+            '&'
+        } else {
+            '?'
+        };
+        verification_url_owned = format!(
+            "{verification_url_base}{sep}channel={}",
+            percent_encoding::utf8_percent_encode(ch, percent_encoding::NON_ALPHANUMERIC)
+        );
         verification_url_owned.as_str()
     } else {
         verification_url_base
@@ -261,6 +267,94 @@ pub async fn device_login(verbose: bool) -> Result<()> {
             None => anyhow::bail!("Unexpected token poll response"),
         }
     }
+}
+
+/// Refresh the access token in-place if it has expired.
+///
+/// - Not expired → returns `Ok(())` immediately (no network call).
+/// - Expired, refresh succeeds → writes new token to disk, returns `Ok(())`.
+/// - Expired, server says invalid/expired refresh token → clears token file,
+///   returns an error directing the user to re-authenticate.
+/// - Expired, network/transient error → returns an error asking the user to
+///   retry (token file is **not** cleared; the refresh token is still valid).
+pub async fn refresh_if_expired() -> Result<()> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let token_path = token_file_path()?;
+    let Ok(contents) = fs::read_to_string(&token_path) else {
+        return Ok(()); // unreadable — let OAuthBuilder handle it
+    };
+    let Ok(data) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return Ok(()); // unparseable — let OAuthBuilder handle it
+    };
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    if data["expires_at"].as_u64().unwrap_or(0) > now {
+        return Ok(()); // still valid
+    }
+
+    let Some(refresh_token) = data["refresh_token"].as_str().filter(|s| !s.is_empty()) else {
+        let _ = clear_token();
+        return Err(anyhow::anyhow!(
+            "No refresh token found. Please run 'longbridge auth login' to re-authenticate."
+        ));
+    };
+    let refresh_token = refresh_token.to_string();
+
+    let client_id = client_id();
+    let http_client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .context("Failed to build HTTP client for token refresh")?;
+
+    let url = format!("{}/token", oauth_base_url());
+    tracing::debug!("Refreshing expired access token via {url}");
+
+    let resp = http_client
+        .post(&url)
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token.as_str()),
+            ("client_id", client_id),
+        ])
+        .send()
+        .await
+        .context("Token refresh request failed — please retry")?;
+
+    let status = resp.status();
+    if status.is_success() {
+        let mut token_resp = resp
+            .json::<serde_json::Value>()
+            .await
+            .context("Failed to parse token refresh response")?;
+
+        // Preserve the existing refresh token if the server did not rotate it.
+        if token_resp["refresh_token"].is_null() || token_resp["refresh_token"].as_str().is_none() {
+            token_resp["refresh_token"] = serde_json::Value::String(refresh_token);
+        }
+
+        save_token(client_id, &token_resp)?;
+        tracing::debug!("Access token refreshed successfully");
+        return Ok(());
+    }
+
+    let err_resp = resp.json::<serde_json::Value>().await.unwrap_or_default();
+    let error = err_resp["error"].as_str().unwrap_or("unknown");
+
+    if error == "invalid_grant" {
+        let _ = clear_token();
+        return Err(anyhow::anyhow!(
+            "Refresh token has expired. Please run 'longbridge auth login' to re-authenticate."
+        ));
+    }
+
+    // Other server errors (5xx etc.) — keep token intact, let the user retry.
+    Err(anyhow::anyhow!(
+        "Token refresh failed ({status}): {error} — please retry"
+    ))
 }
 
 /// Clear the stored OAuth token (logout). Deletes the token file used by the longbridge SDK.

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -45,6 +45,17 @@ struct TokenState {
     logged_in_at: Option<u64>,
 }
 
+/// Decode the `exp` field from a JWT payload without verifying the signature.
+fn jwt_exp(token: &str) -> Option<u64> {
+    use base64::Engine as _;
+    let payload = token.split('.').nth(1)?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let v: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    v["exp"].as_u64()
+}
+
 fn read_token_state() -> Result<TokenState> {
     let token_path = crate::auth::token_file_path()?;
     let now = SystemTime::now()
@@ -79,9 +90,26 @@ fn read_token_state() -> Result<TokenState> {
     }
 
     if expires_at > now {
-        Ok(TokenState {
+        return Ok(TokenState {
             status: "valid",
             detail: format!("expires in {}", format_duration(expires_at - now)),
+            logged_in_at,
+        });
+    }
+
+    // Access token is expired — check if the refresh token is still usable.
+    let refresh_token_valid = data["refresh_token"]
+        .as_str()
+        .and_then(jwt_exp)
+        .is_some_and(|exp| exp > now);
+
+    if refresh_token_valid {
+        Ok(TokenState {
+            status: "refresh_pending",
+            detail: format!(
+                "access token expired {} ago, will auto-refresh on next command",
+                format_duration(now - expires_at)
+            ),
             logged_in_at,
         })
     } else {
@@ -219,7 +247,8 @@ pub async fn cmd_auth_status(format: &OutputFormat) -> Result<()> {
             // ── Token ──────────────────────────────────────────────────────────
             let (status_str, status_color) = match token.status {
                 "not_found" => ("not found", RED),
-                "expired" => ("expired", YELLOW),
+                "expired" => ("expired", RED),
+                "refresh_pending" => ("refresh pending", YELLOW),
                 _ => ("valid", GREEN),
             };
             println!("Token");

--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -66,13 +66,17 @@ pub async fn init_contexts() -> Result<(
                 "Not authenticated. Please run 'longbridge auth login' first."
             ));
         }
-        // Token file exists: load it via OAuthBuilder (SDK handles refresh automatically).
+        // Refresh the access token ourselves if it has expired, before handing
+        // off to the SDK.  This avoids a 5-minute browser-callback timeout that
+        // the SDK would trigger when its own refresh fallback fires.
+        crate::auth::refresh_if_expired().await?;
+
+        // Token file exists and is fresh: load it via OAuthBuilder.
+        // The browser-flow callback below should never fire because we handled
+        // expiry above; it is kept as a last-resort safety net.
         let oauth_result = longbridge::oauth::OAuthBuilder::new(crate::auth::client_id())
             .callback_port(crate::auth::CALLBACK_PORT)
             .build(|_url| {
-                // This callback is only invoked if the token file is missing or fully
-                // expired and cannot be refreshed — in practice, we guard above, so
-                // reaching here would be a race condition.  Just log; do not open browser.
                 tracing::warn!("OAuth browser flow triggered unexpectedly");
             })
             .await;
@@ -80,15 +84,7 @@ pub async fn init_contexts() -> Result<(
         let oauth = match oauth_result {
             Ok(o) => o,
             Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("refresh token") || msg.contains("parse server response") {
-                    tracing::warn!("Token refresh failed, clearing stale token: {msg}");
-                    let _ = crate::auth::clear_token();
-                    return Err(anyhow::anyhow!(
-                            "Stored token is invalid or expired. Please run 'longbridge auth login' to re-authenticate."
-                        ));
-                }
-                return Err(anyhow::anyhow!("OAuth failed: {e}"));
+                return Err(anyhow::anyhow!("OAuth initialization failed: {e}"));
             }
         };
 


### PR DESCRIPTION
## Summary

- **Token refresh hang fixed**: when the access token expired and the network was flaky, the app silently waited 5 minutes before failing. Now it fails immediately with a clear error, and the token file is preserved for the next retry.
- **`auth status` now shows three states** instead of two:
  - `valid` (green) — access token live
  - `refresh pending` (yellow) — access token expired, refresh token still valid; next command auto-refreshes with no user action needed
  - `expired` (red) — both tokens expired; `longbridge auth login` required

Previously `refresh pending` was shown as `expired`, causing users and AI agents to incorrectly conclude they needed to re-authenticate.

## Test plan

- [x] Expired access token, healthy network → silent refresh, command succeeds
- [x] Expired access token, network error → immediate error "please retry", token preserved
- [x] Expired refresh token → immediate error "please re-auth", token cleared
- [x] `auth status` with expired access + valid refresh → shows `refresh pending`
- [x] `auth status` with both tokens expired → shows `expired`

🤖 Generated with [Claude Code](https://claude.com/claude-code)