### PR TITLE
cli: Fix `--auth-code` login and Windows URL truncation

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -99,19 +99,29 @@ pub fn open_browser(url: &str) -> bool {
     #[cfg(target_os = "macos")]
     let mut cmd = std::process::Command::new("open");
     #[cfg(target_os = "windows")]
-    let mut cmd = {
-        let mut c = std::process::Command::new("cmd");
-        c.args(["/c", "start"]);
-        c
-    };
+    {
+        // `cmd /c start "" "URL"` — the empty string is the window title required when
+        // the target starts with a quote; without it, cmd.exe misparses the argument.
+        // Quoting the URL prevents `&` in query strings from being treated as a
+        // command separator, which would silently drop everything after the first `&`.
+        return std::process::Command::new("cmd")
+            .args(["/c", "start", "", url])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .is_ok();
+    }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     let mut cmd = std::process::Command::new("xdg-open");
 
-    cmd.arg(url)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .is_ok()
+    #[cfg(not(target_os = "windows"))]
+    {
+        cmd.arg(url)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .is_ok()
+    }
 }
 
 /// Write a token JSON blob to the SDK token file path.
@@ -355,6 +365,36 @@ pub async fn refresh_if_expired() -> Result<()> {
     Err(anyhow::anyhow!(
         "Token refresh failed ({status}): {error} — please retry"
     ))
+}
+
+/// Authorization Code Flow: opens a browser on this machine and listens on
+/// `localhost:CALLBACK_PORT` for the OAuth callback.
+///
+/// Unlike `device_login`, this requires the browser to be on the same machine.
+/// The SDK handles the local callback server and token persistence.
+pub async fn auth_code_login() -> Result<()> {
+    println!("Opening browser for authorization...");
+    println!("Listening on localhost:{CALLBACK_PORT} for the OAuth callback.");
+
+    let oauth_result = longbridge::oauth::OAuthBuilder::new(client_id())
+        .callback_port(CALLBACK_PORT)
+        .build(|url| {
+            println!();
+            println!("Authorization URL: {url}");
+            println!();
+            if !open_browser(url) {
+                println!("Could not open browser automatically. Please visit the URL above.");
+            }
+        })
+        .await;
+
+    match oauth_result {
+        Ok(_) => {
+            println!("Successfully authenticated.");
+            Ok(())
+        }
+        Err(e) => Err(anyhow::anyhow!("OAuth authorization failed: {e}")),
+    }
 }
 
 /// Clear the stored OAuth token (logout). Deletes the token file used by the longbridge SDK.

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,13 +166,12 @@ async fn main() {
             cmd: cli::AuthCmd::Login {
                 auth_code: true, ..
             },
-        }) => match openapi::init_contexts().await {
-            Ok(_) => println!("Successfully authenticated."),
-            Err(e) => {
+        }) => {
+            if let Err(e) = auth::auth_code_login().await {
                 eprintln!("Authentication failed: {e:#}");
                 std::process::exit(1);
             }
-        },
+        }
 
         Some(cli::Commands::Auth {
             cmd:


### PR DESCRIPTION
## Summary

- **`--auth-code` login broken**: The handler called `init_contexts()` which immediately returns an error when no token file exists, so the browser OAuth flow was never triggered. Replaced with a new `auth_code_login()` function that calls `OAuthBuilder::build()` directly with a proper browser-opening callback.
- **Windows URL truncation**: `cmd /c start URL` treats `&` as a command separator in `cmd.exe`, silently dropping everything after the first `&` (e.g. `client_id` and other query params). Fixed by passing the URL as a separate argument with an empty title placeholder: `cmd /c start "" url`.

## Test plan

- [ ] `longbridge auth login --auth-code` opens the browser and completes OAuth flow when no token exists
- [ ] `longbridge auth login --auth-code` still works when a token already exists (re-auth)
- [ ] On Windows, the browser opens the full authorization URL including `client_id` and all query parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)