### PR TITLE
cli: Add mcp command showing Longbridge MCP setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ longbridge positions --format json | jq '.[] | {symbol, quantity}'
 
 ```bash
 longbridge check   # Check token validity, and API connectivity
+longbridge mcp     # Show Longbridge MCP setup guide (server endpoints and client configuration)
 ```
 
 ### Quotes

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -135,6 +135,13 @@ pub enum Commands {
         shell: clap_complete::Shell,
     },
 
+    /// Show Longbridge MCP setup guide (server endpoints and client configuration)
+    ///
+    /// Prints connection endpoints and quick-setup instructions for Claude Code,
+    /// Cursor, Codex, Zed, and Cherry Studio. No authentication required.
+    /// Example: longbridge mcp
+    Mcp,
+
     // ── Quote ──────────────────────────────────────────────────────────────────
     /// Real-time quotes for one or more symbols
     ///
@@ -2675,7 +2682,8 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
         | Commands::Check
         | Commands::Update { .. }
         | Commands::Completion { .. }
-        | Commands::Init { .. } => {
+        | Commands::Init { .. }
+        | Commands::Mcp => {
             unreachable!()
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,54 @@ async fn main() {
             cli::completion::cmd_completion(shell);
         }
 
+        Some(cli::Commands::Mcp) => {
+            print!(
+                "\
+Longbridge MCP — Model Context Protocol
+========================================
+Connect AI tools to Longbridge market data, account info, and trading.
+
+Server Endpoints
+  Global:         https://openapi.longbridge.com/mcp
+  China Mainland: https://openapi.longbridge.cn/mcp
+
+Capabilities
+  • Market data  — real-time quotes, candlesticks, historical data
+  • Account info — assets, positions
+  • Trading      — place, modify, cancel orders (subject to account permissions)
+
+Authentication
+  OAuth 2.1 — authenticate once through your browser; credentials refresh
+  automatically. To revoke access, visit Longbridge account security settings.
+
+Quick Setup
+
+  Claude Code
+    claude mcp add --transport http longbridge https://openapi.longbridge.com/mcp
+    Then run /mcp in Claude Code to authenticate.
+
+  Cursor
+    Settings → MCP Servers → Add Remote MCP Server
+    Enter: https://openapi.longbridge.com/mcp
+
+  Codex
+    Settings → MCP Servers → Add Server
+    Name: longbridge  Type: Streamable HTTP
+    URL:  https://openapi.longbridge.com/mcp
+
+  Zed
+    Add to settings.json under mcpServers:
+      \"longbridge\": {{ \"url\": \"https://openapi.longbridge.com/mcp\" }}
+
+  Cherry Studio
+    Settings → MCP Servers → Add
+    URL: https://openapi.longbridge.com/mcp
+
+Full documentation: https://open.longbridge.com/docs/mcp
+"
+            );
+        }
+
         Some(cmd) => {
             let start = verbose.then(Instant::now);
             // CLI mode: init contexts (auth), then dispatch


### PR DESCRIPTION
## Summary

- 新增 `longbridge mcp` 子命令，输出 Longbridge MCP 服务接入指南
- 包含全球端点（`https://openapi.longbridge.com/mcp`）和中国大陆端点（`https://openapi.longbridge.cn/mcp`）
- 涵盖 Claude Code、Cursor、Codex、Zed、Cherry Studio 五个客户端的快速配置步骤
- 命令无需鉴权，在 OAuth init 之前处理，未登录用户也可查看

## Test plan

- [ ] `longbridge mcp` 输出正确的端点和客户端配置指南
- [ ] `longbridge --help | grep mcp` 显示命令描述
- [ ] `longbridge auth logout && longbridge mcp` 无需登录即可运行
- [ ] `cargo clippy` 无 warnings
- [ ] `cargo fmt --check` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)