### PR TITLE
cli: Add local MCP server (longbridge mcp serve)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom 0.2.17",
  "once_cell",
- "version_check",
+ "version_check 0.9.5",
 ]
 
 [[package]]
@@ -28,7 +28,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
- "version_check",
+ "version_check 0.9.5",
  "zerocopy",
 ]
 
@@ -73,11 +73,21 @@ dependencies = [
 
 [[package]]
 name = "ansi-parser"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb2392079bf27198570d6af79ecbd9ec7d8f16d3ec6b60933922fdb66287127"
+dependencies = [
+ "heapless 0.5.6",
+ "nom 4.2.3",
+]
+
+[[package]]
+name = "ansi-parser"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43e7fd8284f025d0bd143c2855618ecdf697db55bde39211e5c9faec7669173"
 dependencies = [
- "heapless",
+ "heapless 0.8.0",
  "nom 7.1.3",
 ]
 
@@ -92,6 +102,15 @@ dependencies = [
  "simdutf8",
  "smallvec",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -166,6 +185,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.7",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +264,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -472,7 +514,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -596,6 +638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +696,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width 0.1.14",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
@@ -665,7 +728,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -674,7 +737,7 @@ version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
- "clap",
+ "clap 4.5.60",
 ]
 
 [[package]]
@@ -699,7 +762,17 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 name = "cli-candlestick-chart"
 version = "0.4.1"
 dependencies = [
+ "ansi-parser 0.8.0",
+ "clap 2.34.0",
  "colored",
+ "crossterm 0.26.1",
+ "csv",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "terminal_size",
+ "tui",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -724,7 +797,7 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
@@ -785,7 +858,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
 ]
 
 [[package]]
@@ -793,6 +866,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -829,7 +912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
 dependencies = [
  "crokey-proc_macros",
- "crossterm",
+ "crossterm 0.29.0",
  "once_cell",
  "serde",
  "strict",
@@ -841,7 +924,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "proc-macro2",
  "quote",
  "strict",
@@ -906,6 +989,38 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -915,9 +1030,9 @@ dependencies = [
  "derive_more 2.1.1",
  "document-features",
  "futures-core",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
- "rustix",
+ "rustix 1.1.3",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -938,7 +1053,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -1015,7 +1130,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.114",
 ]
 
@@ -1155,7 +1270,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1254,7 +1369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1358,6 +1473,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1524,12 +1654,30 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
- "version_check",
+ "version_check 0.9.5",
 ]
 
 [[package]]
@@ -1638,6 +1786,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -1702,11 +1859,23 @@ dependencies = [
 
 [[package]]
 name = "heapless"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
+dependencies = [
+ "as-slice",
+ "generic-array 0.13.3",
+ "hash32 0.1.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -1715,6 +1884,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1886,6 +2070,19 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -2104,6 +2301,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2477,12 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -2407,7 +2621,7 @@ dependencies = [
 name = "longbridge-terminal"
 version = "0.17.3"
 dependencies = [
- "ansi-parser",
+ "ansi-parser 0.9.1",
  "ansi-to-tui",
  "anyhow",
  "arrayvec",
@@ -2418,10 +2632,10 @@ dependencies = [
  "bevy_ecs",
  "bitflags 2.10.0",
  "bytemuck",
- "clap",
+ "clap 4.5.60",
  "clap_complete",
  "cli-candlestick-chart",
- "crossterm",
+ "crossterm 0.29.0",
  "csv",
  "dashmap",
  "dirs 5.0.1",
@@ -2603,6 +2817,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -2637,6 +2863,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2683,6 +2926,16 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+dependencies = [
+ "memchr",
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -2715,7 +2968,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2838,6 +3091,50 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3249,7 +3546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3364,7 +3661,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3488,7 +3785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
 dependencies = [
  "cfg-if",
- "crossterm",
+ "crossterm 0.29.0",
  "instability",
  "ratatui-core",
 ]
@@ -3632,10 +3929,12 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3647,6 +3946,7 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
@@ -3882,6 +4182,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -3889,8 +4203,8 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3981,6 +4295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4022,6 +4345,29 @@ name = "sec2md"
 version = "0.1.0"
 dependencies = [
  "scraper",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4212,7 +4558,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
+ "mio 1.1.1",
  "signal-hook",
 ]
 
@@ -4318,6 +4665,12 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -4450,7 +4803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -4514,8 +4867,8 @@ dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
- "windows-sys 0.59.0",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4543,6 +4896,16 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix 0.37.28",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4621,6 +4984,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -4755,7 +5127,7 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -4773,6 +5145,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -5060,6 +5442,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
+dependencies = [
+ "bitflags 1.3.2",
+ "cassowary",
+ "crossterm 0.25.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "tui-input"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5122,7 +5517,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
- "version_check",
+ "version_check 0.9.5",
 ]
 
 [[package]]
@@ -5227,6 +5622,24 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -5429,7 +5842,7 @@ checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
  "ordered-float",
- "strsim",
+ "strsim 0.11.1",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
 ]
@@ -5486,7 +5899,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5841,7 +6254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ windows-sys = { version = "0.48.0", features = [
     "Win32_System_IO",
 ] }
 
+[workspace]
+
 [lints.clippy]
 all = { level = "deny", priority = -1 }
 cast_possible_truncation = "allow"

--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ longbridge option volume daily AAPL.US                        # Daily option Cal
 longbridge option volume daily AAPL.US --count 60             # Return last 60 trading days
 longbridge short-positions AAPL.US                            # US stock short selling data (short interest, ratio, days to cover)
 longbridge short-positions TSLA.US --count 50                 # Return last 50 short interest records
+
+longbridge mcp serve                                          # Start a local MCP server over stdio (for Claude Desktop, Cursor, etc.)
+longbridge mcp guide                                          # Show MCP client setup guide
 ```
 
 <!-- COMMANDS_END -->

--- a/crates/sec2md/src/lib.rs
+++ b/crates/sec2md/src/lib.rs
@@ -147,9 +147,8 @@ fn walk(elem: ElementRef<'_>, conv: &mut Converter) {
         "h4" | "h5" | "h6" => heading(elem, conv, "#### "),
 
         // Block containers.
-        "p" | "div" | "section" | "article" | "header" | "footer" | "main" | "aside"
-        | "nav" | "blockquote" | "pre" | "address" | "figure" | "figcaption"
-        | "details" | "summary" => {
+        "p" | "div" | "section" | "article" | "header" | "footer" | "main" | "aside" | "nav"
+        | "blockquote" | "pre" | "address" | "figure" | "figcaption" | "details" | "summary" => {
             conv.begin_block();
             walk_children(elem, conv);
             conv.end_block();
@@ -227,8 +226,8 @@ fn walk(elem: ElementRef<'_>, conv: &mut Converter) {
         }
 
         // Inline containers: handle style-based bold/italic.
-        "span" | "a" | "label" | "sup" | "sub" | "u" | "s" | "del" | "mark" | "cite"
-        | "abbr" | "code" | "samp" | "kbd" | "var" | "time" | "data" => {
+        "span" | "a" | "label" | "sup" | "sub" | "u" | "s" | "del" | "mark" | "cite" | "abbr"
+        | "code" | "samp" | "kbd" | "var" | "time" | "data" => {
             let bold = is_bold_style(el);
             let italic = is_italic_style(el);
             if bold || italic {
@@ -358,7 +357,6 @@ fn html_escape(s: &str) -> String {
         .replace('>', "&gt;")
 }
 
-
 // ---------------------------------------------------------------------------
 // Text collection (for tables, bold, etc.)
 // ---------------------------------------------------------------------------
@@ -417,7 +415,11 @@ fn collect_text_rec(elem: ElementRef<'_>, parts: &mut Vec<String>) {
 // ---------------------------------------------------------------------------
 
 fn is_hidden(el: &scraper::node::Element) -> bool {
-    let style = el.attr("style").unwrap_or("").replace(' ', "").to_lowercase();
+    let style = el
+        .attr("style")
+        .unwrap_or("")
+        .replace(' ', "")
+        .to_lowercase();
     style.contains("display:none")
 }
 
@@ -461,31 +463,46 @@ fn is_xbrl_inline(tag: &str) -> bool {
     let local = tag.rfind(':').map_or(tag, |i| &tag[i + 1..]);
     matches!(
         local,
-        "nonnumeric" | "nonfraction" | "continuation" | "fraction" | "numerator"
-            | "denominator"
+        "nonnumeric" | "nonfraction" | "continuation" | "fraction" | "numerator" | "denominator"
     ) || tag.starts_with("ixt:")
         || tag.starts_with("ixt-sec:")
 }
 
 fn is_bold_style(el: &scraper::node::Element) -> bool {
-    let style = el.attr("style").unwrap_or("").replace(' ', "").to_lowercase();
+    let style = el
+        .attr("style")
+        .unwrap_or("")
+        .replace(' ', "")
+        .to_lowercase();
     style.contains("font-weight:bold") || style.contains("font-weight:700")
 }
 
 fn is_italic_style(el: &scraper::node::Element) -> bool {
-    let style = el.attr("style").unwrap_or("").replace(' ', "").to_lowercase();
+    let style = el
+        .attr("style")
+        .unwrap_or("")
+        .replace(' ', "")
+        .to_lowercase();
     style.contains("font-style:italic")
 }
 
 fn has_page_break_before(el: &scraper::node::Element) -> bool {
-    let style = el.attr("style").unwrap_or("").replace(' ', "").to_lowercase();
+    let style = el
+        .attr("style")
+        .unwrap_or("")
+        .replace(' ', "")
+        .to_lowercase();
     style.contains("page-break-before:always")
         || style.contains("break-before:page")
         || style.contains("break-before:always")
 }
 
 fn has_page_break_after(el: &scraper::node::Element) -> bool {
-    let style = el.attr("style").unwrap_or("").replace(' ', "").to_lowercase();
+    let style = el
+        .attr("style")
+        .unwrap_or("")
+        .replace(' ', "")
+        .to_lowercase();
     style.contains("page-break-after:always")
         || style.contains("break-after:page")
         || style.contains("break-after:always")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -121,6 +121,17 @@ pub enum Commands {
     /// Example: longbridge tui
     Tui,
 
+    /// Run a local MCP server or show setup guide for the hosted MCP service
+    ///
+    /// longbridge mcp serve   Start a local stdio MCP server (for Claude Desktop, Cursor, etc.)
+    /// longbridge mcp guide   Show remote MCP setup guide
+    ///
+    /// Example: longbridge mcp serve
+    Mcp {
+        #[command(subcommand)]
+        cmd: McpCmd,
+    },
+
     /// Generate shell completion script
     ///
     /// Prints a shell completion script to stdout.
@@ -2127,6 +2138,25 @@ pub enum AuthCmd {
     Status,
 }
 
+#[derive(Subcommand)]
+pub enum McpCmd {
+    /// Start a local MCP server over stdio
+    ///
+    /// Exposes Longbridge market data and trading as MCP tools.
+    /// Configure your MCP client to run: longbridge mcp serve
+    ///
+    /// Example (Claude Desktop mcpServers):
+    ///   { "command": "longbridge", "args": ["mcp", "serve"] }
+    ///
+    /// Example: longbridge mcp serve
+    Serve,
+
+    /// Show setup guide for the Longbridge hosted MCP service
+    ///
+    /// Example: longbridge mcp guide
+    Guide,
+}
+
 pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Result<()> {
     match cmd {
         Commands::Quote { symbols } => quote::cmd_quote(symbols, format).await,
@@ -2675,7 +2705,8 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
         | Commands::Check
         | Commands::Update { .. }
         | Commands::Completion { .. }
-        | Commands::Init { .. } => {
+        | Commands::Init { .. }
+        | Commands::Mcp { .. } => {
             unreachable!()
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,7 +8,6 @@ pub mod check;
 pub mod completion;
 pub mod dca;
 pub mod fundamental;
-pub mod init;
 pub mod insider_trades;
 pub mod investors;
 pub mod news;
@@ -121,17 +120,6 @@ pub enum Commands {
     /// Example: longbridge tui
     Tui,
 
-    /// Run a local MCP server or show setup guide for the hosted MCP service
-    ///
-    /// longbridge mcp serve   Start a local stdio MCP server (for Claude Desktop, Cursor, etc.)
-    /// longbridge mcp guide   Show remote MCP setup guide
-    ///
-    /// Example: longbridge mcp serve
-    Mcp {
-        #[command(subcommand)]
-        cmd: McpCmd,
-    },
-
     /// Generate shell completion script
     ///
     /// Prints a shell completion script to stdout.
@@ -144,6 +132,18 @@ pub enum Commands {
     Completion {
         /// Target shell: bash, zsh, fish, elvish, or powershell
         shell: clap_complete::Shell,
+    },
+
+    /// Longbridge MCP (Model Context Protocol) commands
+    ///
+    /// Run a local MCP server or view the remote setup guide.
+    ///
+    /// Examples:
+    ///   longbridge mcp serve    Start local MCP server (stdio)
+    ///   longbridge mcp guide    Show remote MCP setup guide
+    Mcp {
+        #[command(subcommand)]
+        cmd: McpCmd,
     },
 
     // ── Quote ──────────────────────────────────────────────────────────────────
@@ -2142,16 +2142,22 @@ pub enum AuthCmd {
 pub enum McpCmd {
     /// Start a local MCP server over stdio
     ///
-    /// Exposes Longbridge market data and trading as MCP tools.
-    /// Configure your MCP client to run: longbridge mcp serve
+    /// Exposes Longbridge market data and trading as MCP tools accessible to
+    /// AI clients (Claude Desktop, Cursor, Codex CLI, Zed, Cherry Studio).
     ///
-    /// Example (Claude Desktop mcpServers):
+    /// Add to your MCP client config:
     ///   { "command": "longbridge", "args": ["mcp", "serve"] }
+    ///
+    /// Requires prior authentication: longbridge auth login
+    /// All output is via stdout (JSON-RPC); diagnostics go to stderr.
     ///
     /// Example: longbridge mcp serve
     Serve,
 
-    /// Show setup guide for the Longbridge hosted MCP service
+    /// Show Longbridge remote MCP service setup guide
+    ///
+    /// Prints endpoints and quick-start config for connecting AI tools to
+    /// Longbridge's hosted MCP service (no local auth required for remote mode).
     ///
     /// Example: longbridge mcp guide
     Guide,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,11 @@ pub mod cli;
 pub mod data;
 pub mod locale;
 pub mod logger;
-pub mod mcp;
 pub mod openapi;
 #[cfg_attr(target_family = "windows", path = "os/windows.rs")]
 #[cfg_attr(target_family = "unix", path = "os/unix.rs")]
 pub mod os;
+pub mod mcp;
 pub mod region;
 pub mod tui;
 pub mod update;
@@ -136,13 +136,6 @@ async fn main() {
             return;
         }
 
-        Some(cli::Commands::Init { channel_key }) => {
-            if let Err(e) = cli::init::cmd_init(&channel_key) {
-                eprintln!("Error: {e}");
-                std::process::exit(1);
-            }
-        }
-
         Some(cli::Commands::Check) => {
             if let Err(e) = cli::check::cmd_check(&cli.format).await {
                 print_cli_error(&e, false);
@@ -167,12 +160,13 @@ async fn main() {
             cmd: cli::AuthCmd::Login {
                 auth_code: true, ..
             },
-        }) => {
-            if let Err(e) = auth::auth_code_login().await {
+        }) => match openapi::init_contexts().await {
+            Ok(_) => println!("Successfully authenticated."),
+            Err(e) => {
                 eprintln!("Authentication failed: {e:#}");
                 std::process::exit(1);
             }
-        }
+        },
 
         Some(cli::Commands::Auth {
             cmd:
@@ -210,19 +204,70 @@ async fn main() {
             cli::completion::cmd_completion(shell);
         }
 
-        Some(cli::Commands::Mcp {
-            cmd: cli::McpCmd::Guide,
-        }) => {
-            mcp::print_guide();
+        Some(cli::Commands::Init { channel_key }) => match auth::save_channel(&channel_key) {
+            Ok(()) => println!("Channel key '{channel_key}' saved."),
+            Err(e) => {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        },
+
+        Some(cli::Commands::Mcp { cmd: cli::McpCmd::Guide }) => {
+            print!(
+                "\
+Longbridge MCP — Model Context Protocol
+========================================
+Connect AI tools to Longbridge market data, account info, and trading.
+
+Server Endpoints
+  Global:         https://openapi.longbridge.com/mcp
+  China Mainland: https://openapi.longbridge.cn/mcp
+
+Capabilities
+  • Market data  — real-time quotes, candlesticks, historical data
+  • Account info — assets, positions
+  • Trading      — place, modify, cancel orders (subject to account permissions)
+
+Authentication
+  OAuth 2.1 — authenticate once through your browser; credentials refresh
+  automatically. To revoke access, visit Longbridge account security settings.
+
+Quick Setup
+
+  Claude Code
+    claude mcp add --transport http longbridge https://openapi.longbridge.com/mcp
+    Then run /mcp in Claude Code to authenticate.
+
+  Cursor
+    Settings → MCP Servers → Add Remote MCP Server
+    Enter: https://openapi.longbridge.com/mcp
+
+  Codex
+    Settings → MCP Servers → Add Server
+    Name: longbridge  Type: Streamable HTTP
+    URL:  https://openapi.longbridge.com/mcp
+
+  Zed
+    Add to settings.json under mcpServers:
+      \"longbridge\": {{ \"url\": \"https://openapi.longbridge.com/mcp\" }}
+
+  Cherry Studio
+    Settings → MCP Servers → Add
+    URL: https://openapi.longbridge.com/mcp
+
+Full documentation: https://open.longbridge.com/docs/mcp
+
+Local MCP server: longbridge mcp serve
+"
+            );
         }
 
-        Some(cli::Commands::Mcp {
-            cmd: cli::McpCmd::Serve,
-        }) => {
+        Some(cli::Commands::Mcp { cmd: cli::McpCmd::Serve }) => {
             let (quote_receiver, _, _) = match openapi::init_contexts().await {
                 Ok(r) => r,
                 Err(e) => {
                     eprintln!("Authentication failed: {e}");
+                    eprintln!("Run 'longbridge auth login' first.");
                     std::process::exit(1);
                 }
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,11 @@ pub mod cli;
 pub mod data;
 pub mod locale;
 pub mod logger;
+pub mod mcp;
 pub mod openapi;
 #[cfg_attr(target_family = "windows", path = "os/windows.rs")]
 #[cfg_attr(target_family = "unix", path = "os/unix.rs")]
 pub mod os;
-pub mod mcp;
 pub mod region;
 pub mod tui;
 pub mod update;
@@ -212,7 +212,9 @@ async fn main() {
             }
         },
 
-        Some(cli::Commands::Mcp { cmd: cli::McpCmd::Guide }) => {
+        Some(cli::Commands::Mcp {
+            cmd: cli::McpCmd::Guide,
+        }) => {
             print!(
                 "\
 Longbridge MCP — Model Context Protocol
@@ -262,7 +264,9 @@ Local MCP server: longbridge mcp serve
             );
         }
 
-        Some(cli::Commands::Mcp { cmd: cli::McpCmd::Serve }) => {
+        Some(cli::Commands::Mcp {
+            cmd: cli::McpCmd::Serve,
+        }) => {
             let (quote_receiver, _, _) = match openapi::init_contexts().await {
                 Ok(r) => r,
                 Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ pub mod cli;
 pub mod data;
 pub mod locale;
 pub mod logger;
+pub mod mcp;
 pub mod openapi;
 #[cfg_attr(target_family = "windows", path = "os/windows.rs")]
 #[cfg_attr(target_family = "unix", path = "os/unix.rs")]
@@ -207,6 +208,29 @@ async fn main() {
 
         Some(cli::Commands::Completion { shell }) => {
             cli::completion::cmd_completion(shell);
+        }
+
+        Some(cli::Commands::Mcp {
+            cmd: cli::McpCmd::Guide,
+        }) => {
+            mcp::print_guide();
+        }
+
+        Some(cli::Commands::Mcp {
+            cmd: cli::McpCmd::Serve,
+        }) => {
+            let (quote_receiver, _, _) = match openapi::init_contexts().await {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("Authentication failed: {e}");
+                    std::process::exit(1);
+                }
+            };
+            if let Err(e) = mcp::serve(quote_receiver).await {
+                eprintln!("MCP server error: {e}");
+                std::process::exit(1);
+            }
+            return;
         }
 
         Some(cmd) => {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,64 @@
+pub mod protocol;
+pub mod server;
+pub mod tools;
+
+use anyhow::Result;
+
+pub async fn serve(
+    quote_stream: impl tokio_stream::Stream<Item = longbridge::quote::PushEvent>
+        + Send
+        + Unpin
+        + 'static,
+) -> Result<()> {
+    eprintln!("Longbridge MCP server starting (stdio transport)");
+    server::Server::new().run(quote_stream).await
+}
+
+pub fn print_guide() {
+    println!(
+        r#"Longbridge MCP Server Setup Guide
+==================================
+
+The Longbridge MCP server runs locally over stdio and connects your AI client
+(Claude Desktop, Cursor, Continue, etc.) to live market data and trading APIs.
+
+Prerequisites
+-------------
+1. Authenticate first (if you haven't already):
+   longbridge auth login
+
+2. Add the following to your MCP client configuration:
+
+Claude Desktop (~/.claude/claude_desktop_config.json):
+  {{
+    "mcpServers": {{
+      "longbridge": {{
+        "command": "longbridge",
+        "args": ["mcp", "serve"]
+      }}
+    }}
+  }}
+
+Cursor / Continue:
+  Add an MCP server with command: longbridge mcp serve
+
+Available Tools
+---------------
+  quote             Real-time quote for one or more symbols
+  depth             Level 2 order book (bid/ask depth)
+  trades            Recent trade ticks
+  intraday          Intraday price history
+  kline             OHLCV candlestick data (1m/5m/15m/30m/60m/day/week/month)
+  static_info       Static instrument metadata
+  positions         Current portfolio positions
+  account_balance   Cash balance by currency
+  orders            Today's orders
+  submit_order      Place a new order (requires confirmation)
+  cancel_order      Cancel an existing order (requires confirmation)
+  subscribe_quote   Subscribe to real-time quote push events
+  unsubscribe_quote Stop receiving quote push events
+
+For more information: https://open.longbridge.com
+"#
+    );
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -11,54 +11,8 @@ pub async fn serve(
         + 'static,
 ) -> Result<()> {
     eprintln!("Longbridge MCP server starting (stdio transport)");
+    eprintln!("Configure your MCP client with: longbridge mcp serve");
+    eprintln!("Requires prior authentication: longbridge auth login");
+
     server::Server::new().run(quote_stream).await
-}
-
-pub fn print_guide() {
-    println!(
-        r#"Longbridge MCP Server Setup Guide
-==================================
-
-The Longbridge MCP server runs locally over stdio and connects your AI client
-(Claude Desktop, Cursor, Continue, etc.) to live market data and trading APIs.
-
-Prerequisites
--------------
-1. Authenticate first (if you haven't already):
-   longbridge auth login
-
-2. Add the following to your MCP client configuration:
-
-Claude Desktop (~/.claude/claude_desktop_config.json):
-  {{
-    "mcpServers": {{
-      "longbridge": {{
-        "command": "longbridge",
-        "args": ["mcp", "serve"]
-      }}
-    }}
-  }}
-
-Cursor / Continue:
-  Add an MCP server with command: longbridge mcp serve
-
-Available Tools
----------------
-  quote             Real-time quote for one or more symbols
-  depth             Level 2 order book (bid/ask depth)
-  trades            Recent trade ticks
-  intraday          Intraday price history
-  kline             OHLCV candlestick data (1m/5m/15m/30m/60m/day/week/month)
-  static_info       Static instrument metadata
-  positions         Current portfolio positions
-  account_balance   Cash balance by currency
-  orders            Today's orders
-  submit_order      Place a new order (requires confirmation)
-  cancel_order      Cancel an existing order (requires confirmation)
-  subscribe_quote   Subscribe to real-time quote push events
-  unsubscribe_quote Stop receiving quote push events
-
-For more information: https://open.longbridge.com
-"#
-    );
 }

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -33,14 +33,22 @@ pub enum Outcome {
 
 impl Response {
     pub fn ok(id: Value, result: Value) -> Self {
-        Self { jsonrpc: "2.0", id, outcome: Outcome::Result(result) }
+        Self {
+            jsonrpc: "2.0",
+            id,
+            outcome: Outcome::Result(result),
+        }
     }
 
     pub fn err(id: Value, code: i64, message: String) -> Self {
         Self {
             jsonrpc: "2.0",
             id,
-            outcome: Outcome::Error(ErrorObject { code, message, data: None }),
+            outcome: Outcome::Error(ErrorObject {
+                code,
+                message,
+                data: None,
+            }),
         }
     }
 }

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 
 pub const PROTOCOL_VERSION: &str = "2024-11-05";
 
+// ── JSON-RPC 2.0 request ──────────────────────────────────────────────────────
+
 #[derive(Debug, Deserialize)]
 pub struct Request {
     #[allow(dead_code)]
@@ -11,6 +13,8 @@ pub struct Request {
     pub method: String,
     pub params: Option<Value>,
 }
+
+// ── JSON-RPC 2.0 response ─────────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
 pub struct Response {
@@ -29,22 +33,14 @@ pub enum Outcome {
 
 impl Response {
     pub fn ok(id: Value, result: Value) -> Self {
-        Self {
-            jsonrpc: "2.0",
-            id,
-            outcome: Outcome::Result(result),
-        }
+        Self { jsonrpc: "2.0", id, outcome: Outcome::Result(result) }
     }
 
     pub fn err(id: Value, code: i64, message: String) -> Self {
         Self {
             jsonrpc: "2.0",
             id,
-            outcome: Outcome::Error(ErrorObject {
-                code,
-                message,
-                data: None,
-            }),
+            outcome: Outcome::Error(ErrorObject { code, message, data: None }),
         }
     }
 }
@@ -56,6 +52,8 @@ pub struct ErrorObject {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Value>,
 }
+
+// ── JSON-RPC 2.0 notification ─────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
 pub struct Notification {
@@ -74,6 +72,8 @@ impl Notification {
     }
 }
 
+// ── MCP tool schema types ─────────────────────────────────────────────────────
+
 #[derive(Debug, Serialize, Clone)]
 pub struct Tool {
     pub name: &'static str,
@@ -81,6 +81,8 @@ pub struct Tool {
     #[serde(rename = "inputSchema")]
     pub input_schema: Value,
 }
+
+// ── MCP initialize result ─────────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
 pub struct InitializeResult {
@@ -102,6 +104,8 @@ pub struct ServerInfo {
     pub name: &'static str,
     pub version: String,
 }
+
+// ── Error codes ───────────────────────────────────────────────────────────────
 
 pub const ERR_PARSE: i64 = -32700;
 pub const ERR_INVALID_REQUEST: i64 = -32600;

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -1,0 +1,111 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const PROTOCOL_VERSION: &str = "2024-11-05";
+
+#[derive(Debug, Deserialize)]
+pub struct Request {
+    #[allow(dead_code)]
+    pub jsonrpc: String,
+    pub id: Option<Value>,
+    pub method: String,
+    pub params: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Response {
+    pub jsonrpc: &'static str,
+    pub id: Value,
+    #[serde(flatten)]
+    pub outcome: Outcome,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Outcome {
+    Result(Value),
+    Error(ErrorObject),
+}
+
+impl Response {
+    pub fn ok(id: Value, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            outcome: Outcome::Result(result),
+        }
+    }
+
+    pub fn err(id: Value, code: i64, message: String) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            outcome: Outcome::Error(ErrorObject {
+                code,
+                message,
+                data: None,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorObject {
+    pub code: i64,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Notification {
+    pub jsonrpc: &'static str,
+    pub method: &'static str,
+    pub params: Value,
+}
+
+impl Notification {
+    pub fn message(data: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            method: "notifications/message",
+            params: serde_json::json!({ "level": "info", "data": data }),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct Tool {
+    pub name: &'static str,
+    pub description: &'static str,
+    #[serde(rename = "inputSchema")]
+    pub input_schema: Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InitializeResult {
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: &'static str,
+    pub capabilities: Capabilities,
+    #[serde(rename = "serverInfo")]
+    pub server_info: ServerInfo,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Capabilities {
+    pub tools: Value,
+    pub logging: Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ServerInfo {
+    pub name: &'static str,
+    pub version: String,
+}
+
+pub const ERR_PARSE: i64 = -32700;
+pub const ERR_INVALID_REQUEST: i64 = -32600;
+pub const ERR_METHOD_NOT_FOUND: i64 = -32601;
+pub const ERR_INVALID_PARAMS: i64 = -32602;
+pub const ERR_NOT_INITIALIZED: i64 = -32002;
+pub const ERR_API: i64 = -32000;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,8 +5,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex;
 
 use crate::mcp::protocol::{
-    ERR_INVALID_REQUEST, ERR_METHOD_NOT_FOUND, ERR_NOT_INITIALIZED, ERR_PARSE,
-    PROTOCOL_VERSION,
+    ERR_INVALID_REQUEST, ERR_METHOD_NOT_FOUND, ERR_NOT_INITIALIZED, ERR_PARSE, PROTOCOL_VERSION,
 };
 use crate::mcp::{
     protocol::{Capabilities, InitializeResult, Notification, Request, Response, ServerInfo},
@@ -98,7 +97,11 @@ impl Server {
 
         // Validate JSON-RPC version
         if req.jsonrpc != "2.0" {
-            return Some(Response::err(id, ERR_INVALID_REQUEST, "jsonrpc must be '2.0'".into()));
+            return Some(Response::err(
+                id,
+                ERR_INVALID_REQUEST,
+                "jsonrpc must be '2.0'".into(),
+            ));
         }
 
         // Handle notifications (no id) — no response required
@@ -208,8 +211,8 @@ fn push_event_to_notification(event: longbridge::quote::PushEvent) -> Option<Not
         PushEventDetail::Depth(d) => json!({
             "type": "depth",
             "symbol": event.symbol,
-            "asks": d.asks.iter().map(|x| json!({"price": x.price.to_string(), "volume": x.volume})).collect::<Vec<_>>(),
-            "bids": d.bids.iter().map(|x| json!({"price": x.price.to_string(), "volume": x.volume})).collect::<Vec<_>>(),
+            "asks": d.asks.iter().map(|x| json!({"price": x.price.map(|p| p.to_string()).unwrap_or_default(), "volume": x.volume})).collect::<Vec<_>>(),
+            "bids": d.bids.iter().map(|x| json!({"price": x.price.map(|p| p.to_string()).unwrap_or_default(), "volume": x.volume})).collect::<Vec<_>>(),
         }),
         _ => return None,
     };

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,10 +5,13 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex;
 
 use crate::mcp::protocol::{
-    Capabilities, InitializeResult, Notification, Request, Response, ServerInfo,
-    ERR_INVALID_REQUEST, ERR_METHOD_NOT_FOUND, ERR_NOT_INITIALIZED, ERR_PARSE, PROTOCOL_VERSION,
+    ERR_INVALID_REQUEST, ERR_METHOD_NOT_FOUND, ERR_NOT_INITIALIZED, ERR_PARSE,
+    PROTOCOL_VERSION,
 };
-use crate::mcp::tools::ToolRegistry;
+use crate::mcp::{
+    protocol::{Capabilities, InitializeResult, Notification, Request, Response, ServerInfo},
+    tools::ToolRegistry,
+};
 
 pub struct Server {
     registry: ToolRegistry,
@@ -34,10 +37,12 @@ impl Server {
     ) -> Result<()> {
         let stdout = Arc::clone(&self.stdout);
 
+        // Spawn background task: forward WS push events as MCP notifications.
         tokio::spawn(async move {
             use tokio_stream::StreamExt;
             while let Some(event) = quote_stream.next().await {
-                if let Some(n) = push_event_to_notification(event) {
+                let notif = push_event_to_notification(event);
+                if let Some(n) = notif {
                     if let Ok(json) = serde_json::to_string(&n) {
                         let mut out = stdout.lock().await;
                         let _ = out.write_all(json.as_bytes()).await;
@@ -56,6 +61,7 @@ impl Server {
             line.clear();
             let n = reader.read_line(&mut line).await?;
             if n == 0 {
+                // EOF — client closed the connection
                 break;
             }
             let trimmed = line.trim();
@@ -63,7 +69,8 @@ impl Server {
                 continue;
             }
 
-            if let Some(resp) = self.handle_line(trimmed).await {
+            let response = self.handle_line(trimmed).await;
+            if let Some(resp) = response {
                 let json = serde_json::to_string(&resp)?;
                 let mut out = self.stdout.lock().await;
                 out.write_all(json.as_bytes()).await?;
@@ -89,16 +96,13 @@ impl Server {
 
         let id = req.id.clone().unwrap_or(Value::Null);
 
+        // Validate JSON-RPC version
         if req.jsonrpc != "2.0" {
-            return Some(Response::err(
-                id,
-                ERR_INVALID_REQUEST,
-                "jsonrpc must be '2.0'".into(),
-            ));
+            return Some(Response::err(id, ERR_INVALID_REQUEST, "jsonrpc must be '2.0'".into()));
         }
 
-        // Notifications have no id — no response needed
-        if req.id.is_none() {
+        // Handle notifications (no id) — no response required
+        if req.id.is_none() && req.method == "notifications/initialized" {
             return None;
         }
 
@@ -204,14 +208,8 @@ fn push_event_to_notification(event: longbridge::quote::PushEvent) -> Option<Not
         PushEventDetail::Depth(d) => json!({
             "type": "depth",
             "symbol": event.symbol,
-            "asks": d.asks.iter().map(|x| json!({
-                "price": x.price.map(|p| p.to_string()).unwrap_or_default(),
-                "volume": x.volume,
-            })).collect::<Vec<_>>(),
-            "bids": d.bids.iter().map(|x| json!({
-                "price": x.price.map(|p| p.to_string()).unwrap_or_default(),
-                "volume": x.volume,
-            })).collect::<Vec<_>>(),
+            "asks": d.asks.iter().map(|x| json!({"price": x.price.to_string(), "volume": x.volume})).collect::<Vec<_>>(),
+            "bids": d.bids.iter().map(|x| json!({"price": x.price.to_string(), "volume": x.volume})).collect::<Vec<_>>(),
         }),
         _ => return None,
     };

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,0 +1,220 @@
+use anyhow::Result;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+
+use crate::mcp::protocol::{
+    Capabilities, InitializeResult, Notification, Request, Response, ServerInfo,
+    ERR_INVALID_REQUEST, ERR_METHOD_NOT_FOUND, ERR_NOT_INITIALIZED, ERR_PARSE, PROTOCOL_VERSION,
+};
+use crate::mcp::tools::ToolRegistry;
+
+pub struct Server {
+    registry: ToolRegistry,
+    initialized: bool,
+    stdout: Arc<Mutex<tokio::io::Stdout>>,
+}
+
+impl Server {
+    pub fn new() -> Self {
+        Self {
+            registry: ToolRegistry::new(),
+            initialized: false,
+            stdout: Arc::new(Mutex::new(tokio::io::stdout())),
+        }
+    }
+
+    pub async fn run(
+        mut self,
+        mut quote_stream: impl tokio_stream::Stream<Item = longbridge::quote::PushEvent>
+            + Send
+            + Unpin
+            + 'static,
+    ) -> Result<()> {
+        let stdout = Arc::clone(&self.stdout);
+
+        tokio::spawn(async move {
+            use tokio_stream::StreamExt;
+            while let Some(event) = quote_stream.next().await {
+                if let Some(n) = push_event_to_notification(event) {
+                    if let Ok(json) = serde_json::to_string(&n) {
+                        let mut out = stdout.lock().await;
+                        let _ = out.write_all(json.as_bytes()).await;
+                        let _ = out.write_all(b"\n").await;
+                        let _ = out.flush().await;
+                    }
+                }
+            }
+        });
+
+        let stdin = tokio::io::stdin();
+        let mut reader = BufReader::new(stdin);
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            let n = reader.read_line(&mut line).await?;
+            if n == 0 {
+                break;
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            if let Some(resp) = self.handle_line(trimmed).await {
+                let json = serde_json::to_string(&resp)?;
+                let mut out = self.stdout.lock().await;
+                out.write_all(json.as_bytes()).await?;
+                out.write_all(b"\n").await?;
+                out.flush().await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_line(&mut self, line: &str) -> Option<Response> {
+        let req: Request = match serde_json::from_str(line) {
+            Ok(r) => r,
+            Err(e) => {
+                return Some(Response::err(
+                    Value::Null,
+                    ERR_PARSE,
+                    format!("parse error: {e}"),
+                ));
+            }
+        };
+
+        let id = req.id.clone().unwrap_or(Value::Null);
+
+        if req.jsonrpc != "2.0" {
+            return Some(Response::err(
+                id,
+                ERR_INVALID_REQUEST,
+                "jsonrpc must be '2.0'".into(),
+            ));
+        }
+
+        // Notifications have no id — no response needed
+        if req.id.is_none() {
+            return None;
+        }
+
+        match req.method.as_str() {
+            "initialize" => Some(self.handle_initialize(id, req.params)),
+            "ping" => Some(Response::ok(id, json!({}))),
+            method if !self.initialized => Some(Response::err(
+                id,
+                ERR_NOT_INITIALIZED,
+                format!("server not initialized, received: {method}"),
+            )),
+            "tools/list" => Some(self.handle_tools_list(id)),
+            "tools/call" => self.handle_tools_call(id, req.params).await,
+            method => Some(Response::err(
+                id,
+                ERR_METHOD_NOT_FOUND,
+                format!("method not found: {method}"),
+            )),
+        }
+    }
+
+    fn handle_initialize(&mut self, id: Value, _params: Option<Value>) -> Response {
+        self.initialized = true;
+        let result = InitializeResult {
+            protocol_version: PROTOCOL_VERSION,
+            capabilities: Capabilities {
+                tools: json!({}),
+                logging: json!({}),
+            },
+            server_info: ServerInfo {
+                name: "longbridge-mcp",
+                version: env!("CARGO_PKG_VERSION").to_owned(),
+            },
+        };
+        Response::ok(id, serde_json::to_value(result).unwrap_or(json!({})))
+    }
+
+    fn handle_tools_list(&self, id: Value) -> Response {
+        let tools: Vec<Value> = self
+            .registry
+            .list()
+            .iter()
+            .map(|t| {
+                json!({
+                    "name": t.name,
+                    "description": t.description,
+                    "inputSchema": t.input_schema,
+                })
+            })
+            .collect();
+        Response::ok(id, json!({ "tools": tools }))
+    }
+
+    async fn handle_tools_call(&self, id: Value, params: Option<Value>) -> Option<Response> {
+        let params = params.unwrap_or(Value::Null);
+        let name = match params.get("name").and_then(Value::as_str) {
+            Some(n) => n.to_owned(),
+            None => {
+                return Some(Response::err(
+                    id,
+                    crate::mcp::protocol::ERR_INVALID_PARAMS,
+                    "missing 'name' in tools/call params".into(),
+                ));
+            }
+        };
+        let args = params.get("arguments").cloned();
+
+        match self.registry.call(&name, args).await {
+            Ok(result) => Some(Response::ok(
+                id,
+                json!({
+                    "content": [{"type": "text", "text": result.to_string()}],
+                    "isError": false,
+                }),
+            )),
+            Err((code, message)) => Some(Response::ok(
+                id,
+                json!({
+                    "content": [{"type": "text", "text": message}],
+                    "isError": true,
+                    "_errorCode": code,
+                }),
+            )),
+        }
+    }
+}
+
+fn push_event_to_notification(event: longbridge::quote::PushEvent) -> Option<Notification> {
+    use longbridge::quote::PushEventDetail;
+
+    let data = match event.detail {
+        PushEventDetail::Quote(q) => json!({
+            "type": "quote",
+            "symbol": event.symbol,
+            "last_done": q.last_done.to_string(),
+            "open": q.open.to_string(),
+            "high": q.high.to_string(),
+            "low": q.low.to_string(),
+            "timestamp": q.timestamp.to_string(),
+            "volume": q.volume,
+            "turnover": q.turnover.to_string(),
+        }),
+        PushEventDetail::Depth(d) => json!({
+            "type": "depth",
+            "symbol": event.symbol,
+            "asks": d.asks.iter().map(|x| json!({
+                "price": x.price.map(|p| p.to_string()).unwrap_or_default(),
+                "volume": x.volume,
+            })).collect::<Vec<_>>(),
+            "bids": d.bids.iter().map(|x| json!({
+                "price": x.price.map(|p| p.to_string()).unwrap_or_default(),
+                "volume": x.volume,
+            })).collect::<Vec<_>>(),
+        }),
+        _ => return None,
+    };
+
+    Some(Notification::message(data))
+}

--- a/src/mcp/tools/account.rs
+++ b/src/mcp/tools/account.rs
@@ -32,6 +32,11 @@ pub fn tool_definitions() -> Vec<Tool> {
             input_schema: json!({
                 "type": "object",
                 "properties": {
+                    "status": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Filter by status: NotReported, ReportReject, FilledPart, FilledAll, WaitToCancel, PendingCancel, Rejected, Canceled, PartialWithdrawal"
+                    },
                     "symbol": {
                         "type": "string",
                         "description": "Filter by symbol, e.g. \"700.HK\""
@@ -43,23 +48,23 @@ pub fn tool_definitions() -> Vec<Tool> {
 }
 
 pub async fn handle_positions(_args: Value) -> Result<Value, (i64, String)> {
-    let ctx = crate::openapi::trade();
+    let ctx = crate::openapi::trade_limited();
     let resp = ctx.stock_positions(None).await.map_err(api_err)?;
 
     let positions: Vec<Value> = resp
         .channels
         .iter()
-        .flat_map(|ch| {
-            ch.positions.iter().map(|p| {
-                json!({
-                    "symbol": p.symbol,
-                    "symbol_name": p.symbol_name,
-                    "quantity": p.quantity.to_string(),
-                    "available_quantity": p.available_quantity.to_string(),
-                    "currency": p.currency,
-                })
+        .flat_map(|ch| ch.positions.iter().map(|p| {
+            json!({
+                "symbol": p.symbol,
+                "symbol_name": p.symbol_name,
+                "quantity": p.quantity.to_string(),
+                "available_quantity": p.available_quantity.to_string(),
+                "cost_price": p.cost_price.to_string(),
+                "market_value": p.market_value.to_string(),
+                "currency": p.currency,
             })
-        })
+        }))
         .collect();
 
     Ok(json!({ "positions": positions }))
@@ -67,7 +72,7 @@ pub async fn handle_positions(_args: Value) -> Result<Value, (i64, String)> {
 
 pub async fn handle_account_balance(args: Value) -> Result<Value, (i64, String)> {
     let currency = opt_string(&args, "currency");
-    let ctx = crate::openapi::trade();
+    let ctx = crate::openapi::trade_limited();
     let balances = ctx.account_balance(currency).await.map_err(api_err)?;
 
     let result: Vec<Value> = balances
@@ -91,15 +96,27 @@ pub async fn handle_account_balance(args: Value) -> Result<Value, (i64, String)>
 }
 
 pub async fn handle_orders(args: Value) -> Result<Value, (i64, String)> {
-    use longbridge::trade::GetTodayOrdersOptions;
+    use longbridge::trade::OrderStatus;
 
-    let mut opts = GetTodayOrdersOptions::new();
-    if let Some(s) = opt_string(&args, "symbol") {
-        opts = opts.symbol(s.to_owned());
-    }
+    let symbol = opt_string(&args, "symbol").map(str::to_owned);
+    let status_filter: Vec<OrderStatus> = args
+        .get("status")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .filter_map(|s| parse_order_status(s))
+                .collect()
+        })
+        .unwrap_or_default();
 
-    let ctx = crate::openapi::trade();
-    let orders = ctx.today_orders(opts).await.map_err(api_err)?;
+    let status_opt = if status_filter.is_empty() { None } else { Some(status_filter) };
+
+    let ctx = crate::openapi::trade_limited();
+    let orders = ctx
+        .today_orders(symbol.as_deref(), status_opt, None, None, None)
+        .await
+        .map_err(api_err)?;
 
     let result: Vec<Value> = orders
         .iter()
@@ -115,11 +132,27 @@ pub async fn handle_orders(args: Value) -> Result<Value, (i64, String)> {
                 "executed_price": o.executed_price.map(|p| p.to_string()),
                 "status": format!("{:?}", o.status),
                 "submitted_at": o.submitted_at.to_string(),
-                "updated_at": o.updated_at.map(|t| t.to_string()),
+                "updated_at": o.updated_at.to_string(),
                 "currency": o.currency,
             })
         })
         .collect();
 
     Ok(json!({ "orders": result }))
+}
+
+fn parse_order_status(s: &str) -> Option<longbridge::trade::OrderStatus> {
+    use longbridge::trade::OrderStatus;
+    match s {
+        "NotReported" => Some(OrderStatus::NotReported),
+        "ReportReject" => Some(OrderStatus::ReportReject),
+        "FilledPart" => Some(OrderStatus::PartialFilled),
+        "FilledAll" => Some(OrderStatus::Filled),
+        "WaitToCancel" => Some(OrderStatus::WaitToCancel),
+        "PendingCancel" => Some(OrderStatus::PendingCancel),
+        "Rejected" => Some(OrderStatus::Rejected),
+        "Canceled" => Some(OrderStatus::Canceled),
+        "PartialWithdrawal" => Some(OrderStatus::PartialWithdrawal),
+        _ => None,
+    }
 }

--- a/src/mcp/tools/account.rs
+++ b/src/mcp/tools/account.rs
@@ -28,15 +28,10 @@ pub fn tool_definitions() -> Vec<Tool> {
         },
         Tool {
             name: "orders",
-            description: "Get today's order list. Use status to filter by order state.",
+            description: "Get today's order list.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "status": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "Filter by status: NotReported, ReportReject, FilledPart, FilledAll, WaitToCancel, PendingCancel, Rejected, Canceled, PartialWithdrawal"
-                    },
                     "symbol": {
                         "type": "string",
                         "description": "Filter by symbol, e.g. \"700.HK\""
@@ -48,23 +43,23 @@ pub fn tool_definitions() -> Vec<Tool> {
 }
 
 pub async fn handle_positions(_args: Value) -> Result<Value, (i64, String)> {
-    let ctx = crate::openapi::trade_limited();
+    let ctx = crate::openapi::trade();
     let resp = ctx.stock_positions(None).await.map_err(api_err)?;
 
     let positions: Vec<Value> = resp
         .channels
         .iter()
-        .flat_map(|ch| ch.positions.iter().map(|p| {
-            json!({
-                "symbol": p.symbol,
-                "symbol_name": p.symbol_name,
-                "quantity": p.quantity.to_string(),
-                "available_quantity": p.available_quantity.to_string(),
-                "cost_price": p.cost_price.to_string(),
-                "market_value": p.market_value.to_string(),
-                "currency": p.currency,
+        .flat_map(|ch| {
+            ch.positions.iter().map(|p| {
+                json!({
+                    "symbol": p.symbol,
+                    "symbol_name": p.symbol_name,
+                    "quantity": p.quantity.to_string(),
+                    "available_quantity": p.available_quantity.to_string(),
+                    "currency": p.currency,
+                })
             })
-        }))
+        })
         .collect();
 
     Ok(json!({ "positions": positions }))
@@ -72,7 +67,7 @@ pub async fn handle_positions(_args: Value) -> Result<Value, (i64, String)> {
 
 pub async fn handle_account_balance(args: Value) -> Result<Value, (i64, String)> {
     let currency = opt_string(&args, "currency");
-    let ctx = crate::openapi::trade_limited();
+    let ctx = crate::openapi::trade();
     let balances = ctx.account_balance(currency).await.map_err(api_err)?;
 
     let result: Vec<Value> = balances
@@ -96,27 +91,15 @@ pub async fn handle_account_balance(args: Value) -> Result<Value, (i64, String)>
 }
 
 pub async fn handle_orders(args: Value) -> Result<Value, (i64, String)> {
-    use longbridge::trade::OrderStatus;
+    use longbridge::trade::GetTodayOrdersOptions;
 
-    let symbol = opt_string(&args, "symbol").map(str::to_owned);
-    let status_filter: Vec<OrderStatus> = args
-        .get("status")
-        .and_then(Value::as_array)
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str())
-                .filter_map(|s| parse_order_status(s))
-                .collect()
-        })
-        .unwrap_or_default();
+    let mut opts = GetTodayOrdersOptions::new();
+    if let Some(s) = opt_string(&args, "symbol") {
+        opts = opts.symbol(s.to_owned());
+    }
 
-    let status_opt = if status_filter.is_empty() { None } else { Some(status_filter) };
-
-    let ctx = crate::openapi::trade_limited();
-    let orders = ctx
-        .today_orders(symbol.as_deref(), status_opt, None, None, None)
-        .await
-        .map_err(api_err)?;
+    let ctx = crate::openapi::trade();
+    let orders = ctx.today_orders(opts).await.map_err(api_err)?;
 
     let result: Vec<Value> = orders
         .iter()
@@ -132,27 +115,11 @@ pub async fn handle_orders(args: Value) -> Result<Value, (i64, String)> {
                 "executed_price": o.executed_price.map(|p| p.to_string()),
                 "status": format!("{:?}", o.status),
                 "submitted_at": o.submitted_at.to_string(),
-                "updated_at": o.updated_at.to_string(),
+                "updated_at": o.updated_at.map(|t| t.to_string()),
                 "currency": o.currency,
             })
         })
         .collect();
 
     Ok(json!({ "orders": result }))
-}
-
-fn parse_order_status(s: &str) -> Option<longbridge::trade::OrderStatus> {
-    use longbridge::trade::OrderStatus;
-    match s {
-        "NotReported" => Some(OrderStatus::NotReported),
-        "ReportReject" => Some(OrderStatus::ReportReject),
-        "FilledPart" => Some(OrderStatus::PartialFilled),
-        "FilledAll" => Some(OrderStatus::Filled),
-        "WaitToCancel" => Some(OrderStatus::WaitToCancel),
-        "PendingCancel" => Some(OrderStatus::PendingCancel),
-        "Rejected" => Some(OrderStatus::Rejected),
-        "Canceled" => Some(OrderStatus::Canceled),
-        "PartialWithdrawal" => Some(OrderStatus::PartialWithdrawal),
-        _ => None,
-    }
 }

--- a/src/mcp/tools/account.rs
+++ b/src/mcp/tools/account.rs
@@ -1,0 +1,125 @@
+use serde_json::{json, Value};
+
+use super::{api_err, opt_string};
+use crate::mcp::protocol::Tool;
+
+pub fn tool_definitions() -> Vec<Tool> {
+    vec![
+        Tool {
+            name: "positions",
+            description: "Get current stock positions in the account.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {}
+            }),
+        },
+        Tool {
+            name: "account_balance",
+            description: "Get account balance and cash information.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "currency": {
+                        "type": "string",
+                        "description": "Filter by currency, e.g. \"HKD\", \"USD\". Omit for all."
+                    }
+                }
+            }),
+        },
+        Tool {
+            name: "orders",
+            description: "Get today's order list. Use status to filter by order state.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "symbol": {
+                        "type": "string",
+                        "description": "Filter by symbol, e.g. \"700.HK\""
+                    }
+                }
+            }),
+        },
+    ]
+}
+
+pub async fn handle_positions(_args: Value) -> Result<Value, (i64, String)> {
+    let ctx = crate::openapi::trade();
+    let resp = ctx.stock_positions(None).await.map_err(api_err)?;
+
+    let positions: Vec<Value> = resp
+        .channels
+        .iter()
+        .flat_map(|ch| {
+            ch.positions.iter().map(|p| {
+                json!({
+                    "symbol": p.symbol,
+                    "symbol_name": p.symbol_name,
+                    "quantity": p.quantity.to_string(),
+                    "available_quantity": p.available_quantity.to_string(),
+                    "currency": p.currency,
+                })
+            })
+        })
+        .collect();
+
+    Ok(json!({ "positions": positions }))
+}
+
+pub async fn handle_account_balance(args: Value) -> Result<Value, (i64, String)> {
+    let currency = opt_string(&args, "currency");
+    let ctx = crate::openapi::trade();
+    let balances = ctx.account_balance(currency).await.map_err(api_err)?;
+
+    let result: Vec<Value> = balances
+        .iter()
+        .map(|b| {
+            json!({
+                "currency": b.currency,
+                "total_cash": b.total_cash.to_string(),
+                "max_finance_amount": b.max_finance_amount.to_string(),
+                "remaining_finance_amount": b.remaining_finance_amount.to_string(),
+                "risk_level": b.risk_level,
+                "margin_call": b.margin_call.to_string(),
+                "net_assets": b.net_assets.to_string(),
+                "init_margin": b.init_margin.to_string(),
+                "maintenance_margin": b.maintenance_margin.to_string(),
+            })
+        })
+        .collect();
+
+    Ok(json!({ "balances": result }))
+}
+
+pub async fn handle_orders(args: Value) -> Result<Value, (i64, String)> {
+    use longbridge::trade::GetTodayOrdersOptions;
+
+    let mut opts = GetTodayOrdersOptions::new();
+    if let Some(s) = opt_string(&args, "symbol") {
+        opts = opts.symbol(s.to_owned());
+    }
+
+    let ctx = crate::openapi::trade();
+    let orders = ctx.today_orders(opts).await.map_err(api_err)?;
+
+    let result: Vec<Value> = orders
+        .iter()
+        .map(|o| {
+            json!({
+                "order_id": o.order_id,
+                "symbol": o.symbol,
+                "side": format!("{:?}", o.side),
+                "order_type": format!("{:?}", o.order_type),
+                "quantity": o.quantity.to_string(),
+                "executed_quantity": o.executed_quantity.to_string(),
+                "price": o.price.map(|p| p.to_string()),
+                "executed_price": o.executed_price.map(|p| p.to_string()),
+                "status": format!("{:?}", o.status),
+                "submitted_at": o.submitted_at.to_string(),
+                "updated_at": o.updated_at.map(|t| t.to_string()),
+                "currency": o.currency,
+            })
+        })
+        .collect();
+
+    Ok(json!({ "orders": result }))
+}

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -1,0 +1,83 @@
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::mcp::protocol::{Tool, ERR_INVALID_PARAMS, ERR_METHOD_NOT_FOUND};
+
+pub mod account;
+pub mod quote;
+pub mod subscribe;
+pub mod trade;
+
+pub struct ToolRegistry {
+    tools: Vec<Tool>,
+}
+
+impl ToolRegistry {
+    pub fn new() -> Self {
+        let mut tools = Vec::new();
+        tools.extend(quote::tool_definitions());
+        tools.extend(account::tool_definitions());
+        tools.extend(trade::tool_definitions());
+        tools.extend(subscribe::tool_definitions());
+        Self { tools }
+    }
+
+    pub fn list(&self) -> &[Tool] {
+        &self.tools
+    }
+
+    pub async fn call(&self, name: &str, params: Option<Value>) -> Result<Value, (i64, String)> {
+        let args = params.unwrap_or(Value::Object(Default::default()));
+
+        match name {
+            "quote" => quote::handle_quote(args).await,
+            "depth" => quote::handle_depth(args).await,
+            "trades" => quote::handle_trades(args).await,
+            "intraday" => quote::handle_intraday(args).await,
+            "kline" => quote::handle_kline(args).await,
+            "static_info" => quote::handle_static_info(args).await,
+            "positions" => account::handle_positions(args).await,
+            "account_balance" => account::handle_account_balance(args).await,
+            "orders" => account::handle_orders(args).await,
+            "submit_order" => trade::handle_submit_order(args).await,
+            "cancel_order" => trade::handle_cancel_order(args).await,
+            "subscribe_quote" => subscribe::handle_subscribe(args).await,
+            "unsubscribe_quote" => subscribe::handle_unsubscribe(args).await,
+            _ => Err((ERR_METHOD_NOT_FOUND, format!("unknown tool: {name}"))),
+        }
+    }
+}
+
+pub fn require_string(args: &Value, key: &str) -> Result<String, (i64, String)> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| (ERR_INVALID_PARAMS, format!("missing required param: {key}")))
+}
+
+pub fn require_strings(args: &Value, key: &str) -> Result<Vec<String>, (i64, String)> {
+    args.get(key)
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect()
+        })
+        .filter(|v: &Vec<String>| !v.is_empty())
+        .ok_or_else(|| (ERR_INVALID_PARAMS, format!("missing required param: {key}")))
+}
+
+pub fn opt_u32(args: &Value, key: &str, default: u32) -> u32 {
+    args.get(key)
+        .and_then(Value::as_u64)
+        .map(|v| v as u32)
+        .unwrap_or(default)
+}
+
+pub fn opt_string<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
+    args.get(key).and_then(Value::as_str)
+}
+
+pub fn api_err(e: impl std::fmt::Display) -> (i64, String) {
+    (crate::mcp::protocol::ERR_API, e.to_string())
+}

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -26,11 +26,7 @@ impl ToolRegistry {
         &self.tools
     }
 
-    pub async fn call(
-        &self,
-        name: &str,
-        params: Option<Value>,
-    ) -> Result<Value, (i64, String)> {
+    pub async fn call(&self, name: &str, params: Option<Value>) -> Result<Value, (i64, String)> {
         let args = params.unwrap_or(Value::Object(Default::default()));
 
         match name {
@@ -68,13 +64,20 @@ pub fn require_string(args: &Value, key: &str) -> Result<String, (i64, String)> 
 pub fn require_strings(args: &Value, key: &str) -> Result<Vec<String>, (i64, String)> {
     args.get(key)
         .and_then(Value::as_array)
-        .map(|arr| arr.iter().filter_map(|v| v.as_str().map(str::to_owned)).collect())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect()
+        })
         .filter(|v: &Vec<String>| !v.is_empty())
         .ok_or_else(|| (ERR_INVALID_PARAMS, format!("missing required param: {key}")))
 }
 
 pub fn opt_u32(args: &Value, key: &str, default: u32) -> u32 {
-    args.get(key).and_then(Value::as_u64).map(|v| v as u32).unwrap_or(default)
+    args.get(key)
+        .and_then(Value::as_u64)
+        .map(|v| v as u32)
+        .unwrap_or(default)
 }
 
 pub fn opt_string<'a>(args: &'a Value, key: &str) -> Option<&'a str> {

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -26,27 +26,37 @@ impl ToolRegistry {
         &self.tools
     }
 
-    pub async fn call(&self, name: &str, params: Option<Value>) -> Result<Value, (i64, String)> {
+    pub async fn call(
+        &self,
+        name: &str,
+        params: Option<Value>,
+    ) -> Result<Value, (i64, String)> {
         let args = params.unwrap_or(Value::Object(Default::default()));
 
         match name {
+            // Quote tools
             "quote" => quote::handle_quote(args).await,
             "depth" => quote::handle_depth(args).await,
             "trades" => quote::handle_trades(args).await,
             "intraday" => quote::handle_intraday(args).await,
             "kline" => quote::handle_kline(args).await,
             "static_info" => quote::handle_static_info(args).await,
+            // Account tools
             "positions" => account::handle_positions(args).await,
             "account_balance" => account::handle_account_balance(args).await,
             "orders" => account::handle_orders(args).await,
+            // Trade tools
             "submit_order" => trade::handle_submit_order(args).await,
             "cancel_order" => trade::handle_cancel_order(args).await,
+            // Subscribe tools
             "subscribe_quote" => subscribe::handle_subscribe(args).await,
             "unsubscribe_quote" => subscribe::handle_unsubscribe(args).await,
             _ => Err((ERR_METHOD_NOT_FOUND, format!("unknown tool: {name}"))),
         }
     }
 }
+
+// ── Param helpers ─────────────────────────────────────────────────────────────
 
 pub fn require_string(args: &Value, key: &str) -> Result<String, (i64, String)> {
     args.get(key)
@@ -58,20 +68,13 @@ pub fn require_string(args: &Value, key: &str) -> Result<String, (i64, String)> 
 pub fn require_strings(args: &Value, key: &str) -> Result<Vec<String>, (i64, String)> {
     args.get(key)
         .and_then(Value::as_array)
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(str::to_owned))
-                .collect()
-        })
+        .map(|arr| arr.iter().filter_map(|v| v.as_str().map(str::to_owned)).collect())
         .filter(|v: &Vec<String>| !v.is_empty())
         .ok_or_else(|| (ERR_INVALID_PARAMS, format!("missing required param: {key}")))
 }
 
 pub fn opt_u32(args: &Value, key: &str, default: u32) -> u32 {
-    args.get(key)
-        .and_then(Value::as_u64)
-        .map(|v| v as u32)
-        .unwrap_or(default)
+    args.get(key).and_then(Value::as_u64).map(|v| v as u32).unwrap_or(default)
 }
 
 pub fn opt_string<'a>(args: &'a Value, key: &str) -> Option<&'a str> {

--- a/src/mcp/tools/quote.rs
+++ b/src/mcp/tools/quote.rs
@@ -71,7 +71,7 @@ pub fn tool_definitions() -> Vec<Tool> {
                     "count": {"type": "integer", "description": "Number of candles (default 100)", "default": 100},
                     "adjust": {
                         "type": "string",
-                        "description": "Price adjustment: none, forward, backward",
+                        "description": "Price adjustment: none or forward",
                         "default": "none"
                     }
                 },
@@ -98,8 +98,8 @@ pub fn tool_definitions() -> Vec<Tool> {
 
 pub async fn handle_quote(args: Value) -> Result<Value, (i64, String)> {
     let symbols = require_strings(&args, "symbols")?;
-    let ctx = crate::openapi::quote_limited();
-    let quotes = ctx.quote(symbols).await.map_err(api_err)?;
+    let ctx = crate::openapi::quote();
+    let quotes = ctx.quote(&symbols).await.map_err(api_err)?;
 
     let result: Vec<Value> = quotes
         .iter()
@@ -123,8 +123,8 @@ pub async fn handle_quote(args: Value) -> Result<Value, (i64, String)> {
 
 pub async fn handle_depth(args: Value) -> Result<Value, (i64, String)> {
     let symbol = require_string(&args, "symbol")?;
-    let ctx = crate::openapi::quote_limited();
-    let depth = ctx.depth(&symbol).await.map_err(api_err)?;
+    let ctx = crate::openapi::quote();
+    let depth = ctx.depth(symbol.clone()).await.map_err(api_err)?;
 
     let map_levels = |levels: &[longbridge::quote::Depth]| -> Vec<Value> {
         levels
@@ -132,7 +132,7 @@ pub async fn handle_depth(args: Value) -> Result<Value, (i64, String)> {
             .map(|d| {
                 json!({
                     "position": d.position,
-                    "price": d.price.to_string(),
+                    "price": d.price.map(|p| p.to_string()).unwrap_or_default(),
                     "volume": d.volume,
                     "order_num": d.order_num,
                 })
@@ -141,7 +141,7 @@ pub async fn handle_depth(args: Value) -> Result<Value, (i64, String)> {
     };
 
     Ok(json!({
-        "symbol": depth.symbol,
+        "symbol": symbol,
         "asks": map_levels(&depth.asks),
         "bids": map_levels(&depth.bids),
     }))
@@ -149,8 +149,8 @@ pub async fn handle_depth(args: Value) -> Result<Value, (i64, String)> {
 
 pub async fn handle_trades(args: Value) -> Result<Value, (i64, String)> {
     let symbol = require_string(&args, "symbol")?;
-    let count = opt_u32(&args, "count", 50);
-    let ctx = crate::openapi::quote_limited();
+    let count = opt_u32(&args, "count", 50) as usize;
+    let ctx = crate::openapi::quote();
     let trades = ctx.trades(&symbol, count).await.map_err(api_err)?;
 
     let result: Vec<Value> = trades
@@ -171,9 +171,14 @@ pub async fn handle_trades(args: Value) -> Result<Value, (i64, String)> {
 }
 
 pub async fn handle_intraday(args: Value) -> Result<Value, (i64, String)> {
+    use longbridge::quote::TradeSessions;
+
     let symbol = require_string(&args, "symbol")?;
-    let ctx = crate::openapi::quote_limited();
-    let lines = ctx.intraday(&symbol).await.map_err(api_err)?;
+    let ctx = crate::openapi::quote();
+    let lines = ctx
+        .intraday(symbol, TradeSessions::Intraday)
+        .await
+        .map_err(api_err)?;
 
     let result: Vec<Value> = lines
         .iter()
@@ -192,18 +197,18 @@ pub async fn handle_intraday(args: Value) -> Result<Value, (i64, String)> {
 }
 
 pub async fn handle_kline(args: Value) -> Result<Value, (i64, String)> {
-    use longbridge::quote::{AdjustType, Period};
+    use longbridge::quote::{AdjustType, Period, TradeSessions};
 
     let symbol = require_string(&args, "symbol")?;
     let count = opt_u32(&args, "count", 100) as usize;
 
     let period_str = opt_string(&args, "period").unwrap_or("day");
     let period = match period_str {
-        "1m" | "minute" => Period::Min_1,
-        "5m" => Period::Min_5,
-        "15m" => Period::Min_15,
-        "30m" => Period::Min_30,
-        "1h" | "hour" => Period::Hour,
+        "1m" | "minute" => Period::OneMinute,
+        "5m" => Period::FiveMinute,
+        "15m" => Period::FifteenMinute,
+        "30m" => Period::ThirtyMinute,
+        "1h" | "hour" => Period::SixtyMinute,
         "week" | "w" => Period::Week,
         "month" | "1mo" | "m" => Period::Month,
         "year" | "y" => Period::Year,
@@ -212,13 +217,15 @@ pub async fn handle_kline(args: Value) -> Result<Value, (i64, String)> {
 
     let adjust_str = opt_string(&args, "adjust").unwrap_or("none");
     let adjust = match adjust_str {
-        "forward" => Some(AdjustType::ForwardAdj),
-        "backward" => Some(AdjustType::BackwardAdj),
-        _ => None,
+        "forward" => AdjustType::ForwardAdjust,
+        _ => AdjustType::NoAdjust,
     };
 
-    let ctx = crate::openapi::quote_limited();
-    let klines = ctx.candlesticks(&symbol, period, count, adjust).await.map_err(api_err)?;
+    let ctx = crate::openapi::quote();
+    let klines = ctx
+        .candlesticks(symbol, period, count, adjust, TradeSessions::Intraday)
+        .await
+        .map_err(api_err)?;
 
     let result: Vec<Value> = klines
         .iter()
@@ -240,8 +247,8 @@ pub async fn handle_kline(args: Value) -> Result<Value, (i64, String)> {
 
 pub async fn handle_static_info(args: Value) -> Result<Value, (i64, String)> {
     let symbols = require_strings(&args, "symbols")?;
-    let ctx = crate::openapi::quote_limited();
-    let infos = ctx.static_info(symbols).await.map_err(api_err)?;
+    let ctx = crate::openapi::quote();
+    let infos = ctx.static_info(&symbols).await.map_err(api_err)?;
 
     let result: Vec<Value> = infos
         .iter()

--- a/src/mcp/tools/quote.rs
+++ b/src/mcp/tools/quote.rs
@@ -71,7 +71,7 @@ pub fn tool_definitions() -> Vec<Tool> {
                     "count": {"type": "integer", "description": "Number of candles (default 100)", "default": 100},
                     "adjust": {
                         "type": "string",
-                        "description": "Price adjustment: none or forward",
+                        "description": "Price adjustment: none, forward, backward",
                         "default": "none"
                     }
                 },
@@ -98,8 +98,8 @@ pub fn tool_definitions() -> Vec<Tool> {
 
 pub async fn handle_quote(args: Value) -> Result<Value, (i64, String)> {
     let symbols = require_strings(&args, "symbols")?;
-    let ctx = crate::openapi::quote();
-    let quotes = ctx.quote(&symbols).await.map_err(api_err)?;
+    let ctx = crate::openapi::quote_limited();
+    let quotes = ctx.quote(symbols).await.map_err(api_err)?;
 
     let result: Vec<Value> = quotes
         .iter()
@@ -123,8 +123,8 @@ pub async fn handle_quote(args: Value) -> Result<Value, (i64, String)> {
 
 pub async fn handle_depth(args: Value) -> Result<Value, (i64, String)> {
     let symbol = require_string(&args, "symbol")?;
-    let ctx = crate::openapi::quote();
-    let depth = ctx.depth(symbol.clone()).await.map_err(api_err)?;
+    let ctx = crate::openapi::quote_limited();
+    let depth = ctx.depth(&symbol).await.map_err(api_err)?;
 
     let map_levels = |levels: &[longbridge::quote::Depth]| -> Vec<Value> {
         levels
@@ -132,7 +132,7 @@ pub async fn handle_depth(args: Value) -> Result<Value, (i64, String)> {
             .map(|d| {
                 json!({
                     "position": d.position,
-                    "price": d.price.map(|p| p.to_string()).unwrap_or_default(),
+                    "price": d.price.to_string(),
                     "volume": d.volume,
                     "order_num": d.order_num,
                 })
@@ -141,7 +141,7 @@ pub async fn handle_depth(args: Value) -> Result<Value, (i64, String)> {
     };
 
     Ok(json!({
-        "symbol": symbol,
+        "symbol": depth.symbol,
         "asks": map_levels(&depth.asks),
         "bids": map_levels(&depth.bids),
     }))
@@ -149,8 +149,8 @@ pub async fn handle_depth(args: Value) -> Result<Value, (i64, String)> {
 
 pub async fn handle_trades(args: Value) -> Result<Value, (i64, String)> {
     let symbol = require_string(&args, "symbol")?;
-    let count = opt_u32(&args, "count", 50) as usize;
-    let ctx = crate::openapi::quote();
+    let count = opt_u32(&args, "count", 50);
+    let ctx = crate::openapi::quote_limited();
     let trades = ctx.trades(&symbol, count).await.map_err(api_err)?;
 
     let result: Vec<Value> = trades
@@ -171,14 +171,9 @@ pub async fn handle_trades(args: Value) -> Result<Value, (i64, String)> {
 }
 
 pub async fn handle_intraday(args: Value) -> Result<Value, (i64, String)> {
-    use longbridge::quote::TradeSessions;
-
     let symbol = require_string(&args, "symbol")?;
-    let ctx = crate::openapi::quote();
-    let lines = ctx
-        .intraday(symbol, TradeSessions::Intraday)
-        .await
-        .map_err(api_err)?;
+    let ctx = crate::openapi::quote_limited();
+    let lines = ctx.intraday(&symbol).await.map_err(api_err)?;
 
     let result: Vec<Value> = lines
         .iter()
@@ -197,18 +192,18 @@ pub async fn handle_intraday(args: Value) -> Result<Value, (i64, String)> {
 }
 
 pub async fn handle_kline(args: Value) -> Result<Value, (i64, String)> {
-    use longbridge::quote::{AdjustType, Period, TradeSessions};
+    use longbridge::quote::{AdjustType, Period};
 
     let symbol = require_string(&args, "symbol")?;
     let count = opt_u32(&args, "count", 100) as usize;
 
     let period_str = opt_string(&args, "period").unwrap_or("day");
     let period = match period_str {
-        "1m" | "minute" => Period::OneMinute,
-        "5m" => Period::FiveMinute,
-        "15m" => Period::FifteenMinute,
-        "30m" => Period::ThirtyMinute,
-        "1h" | "hour" => Period::SixtyMinute,
+        "1m" | "minute" => Period::Min_1,
+        "5m" => Period::Min_5,
+        "15m" => Period::Min_15,
+        "30m" => Period::Min_30,
+        "1h" | "hour" => Period::Hour,
         "week" | "w" => Period::Week,
         "month" | "1mo" | "m" => Period::Month,
         "year" | "y" => Period::Year,
@@ -217,15 +212,13 @@ pub async fn handle_kline(args: Value) -> Result<Value, (i64, String)> {
 
     let adjust_str = opt_string(&args, "adjust").unwrap_or("none");
     let adjust = match adjust_str {
-        "forward" => AdjustType::ForwardAdjust,
-        _ => AdjustType::NoAdjust,
+        "forward" => Some(AdjustType::ForwardAdj),
+        "backward" => Some(AdjustType::BackwardAdj),
+        _ => None,
     };
 
-    let ctx = crate::openapi::quote();
-    let klines = ctx
-        .candlesticks(symbol, period, count, adjust, TradeSessions::Intraday)
-        .await
-        .map_err(api_err)?;
+    let ctx = crate::openapi::quote_limited();
+    let klines = ctx.candlesticks(&symbol, period, count, adjust).await.map_err(api_err)?;
 
     let result: Vec<Value> = klines
         .iter()
@@ -247,8 +240,8 @@ pub async fn handle_kline(args: Value) -> Result<Value, (i64, String)> {
 
 pub async fn handle_static_info(args: Value) -> Result<Value, (i64, String)> {
     let symbols = require_strings(&args, "symbols")?;
-    let ctx = crate::openapi::quote();
-    let infos = ctx.static_info(&symbols).await.map_err(api_err)?;
+    let ctx = crate::openapi::quote_limited();
+    let infos = ctx.static_info(symbols).await.map_err(api_err)?;
 
     let result: Vec<Value> = infos
         .iter()

--- a/src/mcp/tools/quote.rs
+++ b/src/mcp/tools/quote.rs
@@ -1,0 +1,270 @@
+use serde_json::{json, Value};
+
+use super::{api_err, opt_string, opt_u32, require_string, require_strings};
+use crate::mcp::protocol::Tool;
+
+pub fn tool_definitions() -> Vec<Tool> {
+    vec![
+        Tool {
+            name: "quote",
+            description: "Get real-time quotes for one or more symbols. \
+                Symbol format: CODE.MARKET (e.g. 700.HK, TSLA.US, 600519.SH).",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "symbols": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of symbols, e.g. [\"700.HK\", \"TSLA.US\"]",
+                        "minItems": 1
+                    }
+                },
+                "required": ["symbols"]
+            }),
+        },
+        Tool {
+            name: "depth",
+            description: "Get Level 2 bid/ask order book for a symbol.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "symbol": {"type": "string", "description": "Symbol, e.g. \"700.HK\""}
+                },
+                "required": ["symbol"]
+            }),
+        },
+        Tool {
+            name: "trades",
+            description: "Get recent tick-by-tick trades for a symbol.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "symbol": {"type": "string"},
+                    "count": {"type": "integer", "description": "Number of trades (default 50, max 1000)", "default": 50}
+                },
+                "required": ["symbol"]
+            }),
+        },
+        Tool {
+            name: "intraday",
+            description: "Get today's intraday minute-by-minute price and volume data.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "symbol": {"type": "string"}
+                },
+                "required": ["symbol"]
+            }),
+        },
+        Tool {
+            name: "kline",
+            description: "Get OHLCV candlestick data. Periods: 1m, 5m, 15m, 30m, 1h, day, week, month, year.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "symbol": {"type": "string"},
+                    "period": {
+                        "type": "string",
+                        "description": "Candlestick period: 1m 5m 15m 30m 1h day week month year",
+                        "default": "day"
+                    },
+                    "count": {"type": "integer", "description": "Number of candles (default 100)", "default": 100},
+                    "adjust": {
+                        "type": "string",
+                        "description": "Price adjustment: none or forward",
+                        "default": "none"
+                    }
+                },
+                "required": ["symbol"]
+            }),
+        },
+        Tool {
+            name: "static_info",
+            description: "Get static reference info for symbols: name, exchange, currency, lot size, total shares.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "symbols": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 1
+                    }
+                },
+                "required": ["symbols"]
+            }),
+        },
+    ]
+}
+
+pub async fn handle_quote(args: Value) -> Result<Value, (i64, String)> {
+    let symbols = require_strings(&args, "symbols")?;
+    let ctx = crate::openapi::quote();
+    let quotes = ctx.quote(&symbols).await.map_err(api_err)?;
+
+    let result: Vec<Value> = quotes
+        .iter()
+        .map(|q| {
+            json!({
+                "symbol": q.symbol,
+                "last_done": q.last_done.to_string(),
+                "prev_close": q.prev_close.to_string(),
+                "open": q.open.to_string(),
+                "high": q.high.to_string(),
+                "low": q.low.to_string(),
+                "volume": q.volume,
+                "turnover": q.turnover.to_string(),
+                "trade_status": format!("{:?}", q.trade_status),
+            })
+        })
+        .collect();
+
+    Ok(json!({ "quotes": result }))
+}
+
+pub async fn handle_depth(args: Value) -> Result<Value, (i64, String)> {
+    let symbol = require_string(&args, "symbol")?;
+    let ctx = crate::openapi::quote();
+    let depth = ctx.depth(symbol.clone()).await.map_err(api_err)?;
+
+    let map_levels = |levels: &[longbridge::quote::Depth]| -> Vec<Value> {
+        levels
+            .iter()
+            .map(|d| {
+                json!({
+                    "position": d.position,
+                    "price": d.price.map(|p| p.to_string()).unwrap_or_default(),
+                    "volume": d.volume,
+                    "order_num": d.order_num,
+                })
+            })
+            .collect()
+    };
+
+    Ok(json!({
+        "symbol": symbol,
+        "asks": map_levels(&depth.asks),
+        "bids": map_levels(&depth.bids),
+    }))
+}
+
+pub async fn handle_trades(args: Value) -> Result<Value, (i64, String)> {
+    let symbol = require_string(&args, "symbol")?;
+    let count = opt_u32(&args, "count", 50) as usize;
+    let ctx = crate::openapi::quote();
+    let trades = ctx.trades(&symbol, count).await.map_err(api_err)?;
+
+    let result: Vec<Value> = trades
+        .iter()
+        .map(|t| {
+            json!({
+                "price": t.price.to_string(),
+                "volume": t.volume,
+                "timestamp": t.timestamp.to_string(),
+                "trade_type": t.trade_type,
+                "direction": format!("{:?}", t.direction),
+                "trade_session": format!("{:?}", t.trade_session),
+            })
+        })
+        .collect();
+
+    Ok(json!({ "trades": result }))
+}
+
+pub async fn handle_intraday(args: Value) -> Result<Value, (i64, String)> {
+    use longbridge::quote::TradeSessions;
+
+    let symbol = require_string(&args, "symbol")?;
+    let ctx = crate::openapi::quote();
+    let lines = ctx
+        .intraday(symbol, TradeSessions::Intraday)
+        .await
+        .map_err(api_err)?;
+
+    let result: Vec<Value> = lines
+        .iter()
+        .map(|l| {
+            json!({
+                "timestamp": l.timestamp.to_string(),
+                "price": l.price.to_string(),
+                "volume": l.volume,
+                "turnover": l.turnover.to_string(),
+                "avg_price": l.avg_price.to_string(),
+            })
+        })
+        .collect();
+
+    Ok(json!({ "intraday": result }))
+}
+
+pub async fn handle_kline(args: Value) -> Result<Value, (i64, String)> {
+    use longbridge::quote::{AdjustType, Period, TradeSessions};
+
+    let symbol = require_string(&args, "symbol")?;
+    let count = opt_u32(&args, "count", 100) as usize;
+
+    let period_str = opt_string(&args, "period").unwrap_or("day");
+    let period = match period_str {
+        "1m" | "minute" => Period::OneMinute,
+        "5m" => Period::FiveMinute,
+        "15m" => Period::FifteenMinute,
+        "30m" => Period::ThirtyMinute,
+        "1h" | "hour" => Period::SixtyMinute,
+        "week" | "w" => Period::Week,
+        "month" | "1mo" | "m" => Period::Month,
+        "year" | "y" => Period::Year,
+        _ => Period::Day,
+    };
+
+    let adjust_str = opt_string(&args, "adjust").unwrap_or("none");
+    let adjust = match adjust_str {
+        "forward" => AdjustType::ForwardAdjust,
+        _ => AdjustType::NoAdjust,
+    };
+
+    let ctx = crate::openapi::quote();
+    let klines = ctx
+        .candlesticks(symbol, period, count, adjust, TradeSessions::Intraday)
+        .await
+        .map_err(api_err)?;
+
+    let result: Vec<Value> = klines
+        .iter()
+        .map(|k| {
+            json!({
+                "timestamp": k.timestamp.to_string(),
+                "open": k.open.to_string(),
+                "high": k.high.to_string(),
+                "low": k.low.to_string(),
+                "close": k.close.to_string(),
+                "volume": k.volume,
+                "turnover": k.turnover.to_string(),
+            })
+        })
+        .collect();
+
+    Ok(json!({ "klines": result }))
+}
+
+pub async fn handle_static_info(args: Value) -> Result<Value, (i64, String)> {
+    let symbols = require_strings(&args, "symbols")?;
+    let ctx = crate::openapi::quote();
+    let infos = ctx.static_info(&symbols).await.map_err(api_err)?;
+
+    let result: Vec<Value> = infos
+        .iter()
+        .map(|s| {
+            json!({
+                "symbol": s.symbol,
+                "name_cn": s.name_cn,
+                "name_en": s.name_en,
+                "exchange": s.exchange,
+                "currency": s.currency,
+                "lot_size": s.lot_size,
+                "total_shares": s.total_shares,
+                "circulating_shares": s.circulating_shares,
+            })
+        })
+        .collect();
+
+    Ok(json!({ "securities": result }))
+}

--- a/src/mcp/tools/subscribe.rs
+++ b/src/mcp/tools/subscribe.rs
@@ -1,0 +1,83 @@
+use serde_json::{json, Value};
+use std::sync::Mutex;
+
+use super::{api_err, require_strings};
+use crate::mcp::protocol::Tool;
+
+static SUBSCRIBED: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+pub fn tool_definitions() -> Vec<Tool> {
+    vec![
+        Tool {
+            name: "subscribe_quote",
+            description: "Subscribe to real-time quote updates for symbols. \
+                The server will push MCP notifications/message events as prices change. \
+                Use unsubscribe_quote to stop.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "symbols": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Symbols to subscribe, e.g. [\"700.HK\", \"TSLA.US\"]",
+                        "minItems": 1
+                    }
+                },
+                "required": ["symbols"]
+            }),
+        },
+        Tool {
+            name: "unsubscribe_quote",
+            description: "Stop receiving real-time quote notifications for the given symbols.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "symbols": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 1
+                    }
+                },
+                "required": ["symbols"]
+            }),
+        },
+    ]
+}
+
+pub async fn handle_subscribe(args: Value) -> Result<Value, (i64, String)> {
+    use longbridge::quote::SubFlags;
+
+    let symbols = require_strings(&args, "symbols")?;
+    let ctx = crate::openapi::quote();
+
+    ctx.subscribe(&symbols, SubFlags::QUOTE)
+        .await
+        .map_err(api_err)?;
+
+    if let Ok(mut guard) = SUBSCRIBED.lock() {
+        for s in &symbols {
+            if !guard.contains(s) {
+                guard.push(s.clone());
+            }
+        }
+    }
+
+    Ok(json!({ "subscribed": symbols }))
+}
+
+pub async fn handle_unsubscribe(args: Value) -> Result<Value, (i64, String)> {
+    use longbridge::quote::SubFlags;
+
+    let symbols = require_strings(&args, "symbols")?;
+    let ctx = crate::openapi::quote();
+
+    ctx.unsubscribe(&symbols, SubFlags::QUOTE)
+        .await
+        .map_err(api_err)?;
+
+    if let Ok(mut guard) = SUBSCRIBED.lock() {
+        guard.retain(|s| !symbols.contains(s));
+    }
+
+    Ok(json!({ "unsubscribed": symbols }))
+}

--- a/src/mcp/tools/subscribe.rs
+++ b/src/mcp/tools/subscribe.rs
@@ -50,7 +50,7 @@ pub async fn handle_subscribe(args: Value) -> Result<Value, (i64, String)> {
     let symbols = require_strings(&args, "symbols")?;
     let ctx = crate::openapi::quote();
 
-    ctx.subscribe(&symbols, SubFlags::QUOTE, true)
+    ctx.subscribe(&symbols, SubFlags::QUOTE)
         .await
         .map_err(api_err)?;
 

--- a/src/mcp/tools/subscribe.rs
+++ b/src/mcp/tools/subscribe.rs
@@ -50,7 +50,7 @@ pub async fn handle_subscribe(args: Value) -> Result<Value, (i64, String)> {
     let symbols = require_strings(&args, "symbols")?;
     let ctx = crate::openapi::quote();
 
-    ctx.subscribe(&symbols, SubFlags::QUOTE)
+    ctx.subscribe(&symbols, SubFlags::QUOTE, true)
         .await
         .map_err(api_err)?;
 

--- a/src/mcp/tools/trade.rs
+++ b/src/mcp/tools/trade.rs
@@ -1,0 +1,110 @@
+use serde_json::{json, Value};
+
+use super::{api_err, require_string};
+use crate::mcp::protocol::{Tool, ERR_INVALID_PARAMS};
+
+pub fn tool_definitions() -> Vec<Tool> {
+    vec![
+        Tool {
+            name: "submit_order",
+            description: "CAUTION: This tool submits a real order to the exchange. \
+                Confirm with the user before calling. \
+                Supported order types: LO (limit), MO (market), ELO (enhanced limit).",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "symbol": {"type": "string", "description": "Symbol, e.g. \"700.HK\""},
+                    "side": {"type": "string", "enum": ["buy", "sell"]},
+                    "order_type": {
+                        "type": "string",
+                        "description": "LO (limit order), MO (market order), ELO (enhanced limit)",
+                        "default": "LO"
+                    },
+                    "quantity": {"type": "string", "description": "Number of shares as a string, e.g. \"100\""},
+                    "price": {"type": "string", "description": "Limit price as a string (required for LO/ELO)"},
+                    "time_in_force": {
+                        "type": "string",
+                        "description": "Day (day order) or GTC (good till cancelled)",
+                        "default": "Day"
+                    },
+                    "remark": {"type": "string", "description": "Optional order note (max 64 chars)"}
+                },
+                "required": ["symbol", "side", "quantity"]
+            }),
+        },
+        Tool {
+            name: "cancel_order",
+            description:
+                "CAUTION: This tool cancels a real order. Confirm with the user before calling.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "order_id": {"type": "string", "description": "Order ID to cancel"}
+                },
+                "required": ["order_id"]
+            }),
+        },
+    ]
+}
+
+pub async fn handle_submit_order(args: Value) -> Result<Value, (i64, String)> {
+    use longbridge::trade::{OrderSide, OrderType, SubmitOrderOptions, TimeInForceType};
+    use rust_decimal::Decimal;
+    use std::str::FromStr;
+
+    let symbol = require_string(&args, "symbol")?;
+    let side_str = require_string(&args, "side")?;
+    let qty_str = require_string(&args, "quantity")?;
+
+    let side = match side_str.to_lowercase().as_str() {
+        "buy" => OrderSide::Buy,
+        "sell" => OrderSide::Sell,
+        _ => return Err((ERR_INVALID_PARAMS, "side must be 'buy' or 'sell'".into())),
+    };
+
+    let quantity =
+        Decimal::from_str(&qty_str).map_err(|_| (ERR_INVALID_PARAMS, "invalid quantity".into()))?;
+
+    let order_type_str = args
+        .get("order_type")
+        .and_then(Value::as_str)
+        .unwrap_or("LO");
+    let order_type = match order_type_str.to_uppercase().as_str() {
+        "MO" => OrderType::MO,
+        "ELO" => OrderType::ELO,
+        _ => OrderType::LO,
+    };
+
+    let tif_str = args
+        .get("time_in_force")
+        .and_then(Value::as_str)
+        .unwrap_or("Day");
+    let tif = match tif_str {
+        "GTC" => TimeInForceType::GoodTilCanceled,
+        _ => TimeInForceType::Day,
+    };
+
+    let mut opts = SubmitOrderOptions::new(symbol, order_type, side, quantity, tif);
+
+    if let Some(price_str) = args.get("price").and_then(Value::as_str) {
+        let price = Decimal::from_str(price_str)
+            .map_err(|_| (ERR_INVALID_PARAMS, "invalid price".into()))?;
+        opts = opts.submitted_price(price);
+    }
+
+    if let Some(remark) = args.get("remark").and_then(Value::as_str) {
+        opts = opts.remark(remark.to_owned());
+    }
+
+    let ctx = crate::openapi::trade();
+    let resp = ctx.submit_order(opts).await.map_err(api_err)?;
+
+    Ok(json!({ "order_id": resp.order_id }))
+}
+
+pub async fn handle_cancel_order(args: Value) -> Result<Value, (i64, String)> {
+    let order_id = require_string(&args, "order_id")?;
+    let ctx = crate::openapi::trade();
+    ctx.cancel_order(order_id.clone()).await.map_err(api_err)?;
+    Ok(json!({ "cancelled": true, "order_id": order_id }))
+}

--- a/src/mcp/tools/trade.rs
+++ b/src/mcp/tools/trade.rs
@@ -34,8 +34,7 @@ pub fn tool_definitions() -> Vec<Tool> {
         },
         Tool {
             name: "cancel_order",
-            description:
-                "CAUTION: This tool cancels a real order. Confirm with the user before calling.",
+            description: "CAUTION: This tool cancels a real order. Confirm with the user before calling.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -75,10 +74,7 @@ pub async fn handle_submit_order(args: Value) -> Result<Value, (i64, String)> {
         _ => OrderType::LO,
     };
 
-    let tif_str = args
-        .get("time_in_force")
-        .and_then(Value::as_str)
-        .unwrap_or("Day");
+    let tif_str = args.get("time_in_force").and_then(Value::as_str).unwrap_or("Day");
     let tif = match tif_str {
         "GTC" => TimeInForceType::GoodTilCanceled,
         _ => TimeInForceType::Day,
@@ -96,7 +92,7 @@ pub async fn handle_submit_order(args: Value) -> Result<Value, (i64, String)> {
         opts = opts.remark(remark.to_owned());
     }
 
-    let ctx = crate::openapi::trade();
+    let ctx = crate::openapi::trade_limited();
     let resp = ctx.submit_order(opts).await.map_err(api_err)?;
 
     Ok(json!({ "order_id": resp.order_id }))
@@ -104,7 +100,7 @@ pub async fn handle_submit_order(args: Value) -> Result<Value, (i64, String)> {
 
 pub async fn handle_cancel_order(args: Value) -> Result<Value, (i64, String)> {
     let order_id = require_string(&args, "order_id")?;
-    let ctx = crate::openapi::trade();
-    ctx.cancel_order(order_id.clone()).await.map_err(api_err)?;
+    let ctx = crate::openapi::trade_limited();
+    ctx.cancel_order(&order_id).await.map_err(api_err)?;
     Ok(json!({ "cancelled": true, "order_id": order_id }))
 }

--- a/src/mcp/tools/trade.rs
+++ b/src/mcp/tools/trade.rs
@@ -34,7 +34,8 @@ pub fn tool_definitions() -> Vec<Tool> {
         },
         Tool {
             name: "cancel_order",
-            description: "CAUTION: This tool cancels a real order. Confirm with the user before calling.",
+            description:
+                "CAUTION: This tool cancels a real order. Confirm with the user before calling.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -74,7 +75,10 @@ pub async fn handle_submit_order(args: Value) -> Result<Value, (i64, String)> {
         _ => OrderType::LO,
     };
 
-    let tif_str = args.get("time_in_force").and_then(Value::as_str).unwrap_or("Day");
+    let tif_str = args
+        .get("time_in_force")
+        .and_then(Value::as_str)
+        .unwrap_or("Day");
     let tif = match tif_str {
         "GTC" => TimeInForceType::GoodTilCanceled,
         _ => TimeInForceType::Day,
@@ -92,7 +96,7 @@ pub async fn handle_submit_order(args: Value) -> Result<Value, (i64, String)> {
         opts = opts.remark(remark.to_owned());
     }
 
-    let ctx = crate::openapi::trade_limited();
+    let ctx = crate::openapi::trade();
     let resp = ctx.submit_order(opts).await.map_err(api_err)?;
 
     Ok(json!({ "order_id": resp.order_id }))
@@ -100,7 +104,7 @@ pub async fn handle_submit_order(args: Value) -> Result<Value, (i64, String)> {
 
 pub async fn handle_cancel_order(args: Value) -> Result<Value, (i64, String)> {
     let order_id = require_string(&args, "order_id")?;
-    let ctx = crate::openapi::trade_limited();
+    let ctx = crate::openapi::trade();
     ctx.cancel_order(&order_id).await.map_err(api_err)?;
     Ok(json!({ "cancelled": true, "order_id": order_id }))
 }


### PR DESCRIPTION
## Summary

- 新增 `longbridge mcp serve` — 本地 stdio MCP Server，符合 Model Context Protocol 规范
- 新增 `longbridge mcp guide` — 打印托管 MCP 服务接入指引
- 实现 13 个 MCP tool：`quote`, `depth`, `trades`, `intraday`, `kline`, `static_info`, `positions`, `account_balance`, `orders`, `submit_order`, `cancel_order`, `subscribe_quote`, `unsubscribe_quote`
- 实时行情通过 `notifications/message` 推送给 MCP client
- 更新 README.md 的 COMMANDS_START/END 块

## Test plan

- [ ] `longbridge mcp serve` 启动后通过 stdin/stdout 收发 JSON-RPC 2.0 消息
- [ ] `tools/list` 返回全部 13 个 tool
- [ ] `tools/call` 返回 `{ content: [{ type: "text", text: "..." }], isError: bool }`
- [ ] `longbridge mcp guide` 打印远程 MCP 服务指引
- [ ] `cargo check` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)