### PR TITLE
cli: Add pagination and `--year` filter to `dividend` command

### DIFF
--- a/crates/sec2md/src/lib.rs
+++ b/crates/sec2md/src/lib.rs
@@ -147,9 +147,8 @@ fn walk(elem: ElementRef<'_>, conv: &mut Converter) {
         "h4" | "h5" | "h6" => heading(elem, conv, "#### "),
 
         // Block containers.
-        "p" | "div" | "section" | "article" | "header" | "footer" | "main" | "aside"
-        | "nav" | "blockquote" | "pre" | "address" | "figure" | "figcaption"
-        | "details" | "summary" => {
+        "p" | "div" | "section" | "article" | "header" | "footer" | "main" | "aside" | "nav"
+        | "blockquote" | "pre" | "address" | "figure" | "figcaption" | "details" | "summary" => {
             conv.begin_block();
             walk_children(elem, conv);
             conv.end_block();
@@ -227,8 +226,8 @@ fn walk(elem: ElementRef<'_>, conv: &mut Converter) {
         }
 
         // Inline containers: handle style-based bold/italic.
-        "span" | "a" | "label" | "sup" | "sub" | "u" | "s" | "del" | "mark" | "cite"
-        | "abbr" | "code" | "samp" | "kbd" | "var" | "time" | "data" => {
+        "span" | "a" | "label" | "sup" | "sub" | "u" | "s" | "del" | "mark" | "cite" | "abbr"
+        | "code" | "samp" | "kbd" | "var" | "time" | "data" => {
             let bold = is_bold_style(el);
             let italic = is_italic_style(el);
             if bold || italic {
@@ -358,7 +357,6 @@ fn html_escape(s: &str) -> String {
         .replace('>', "&gt;")
 }
 
-
 // ---------------------------------------------------------------------------
 // Text collection (for tables, bold, etc.)
 // ---------------------------------------------------------------------------
@@ -417,7 +415,11 @@ fn collect_text_rec(elem: ElementRef<'_>, parts: &mut Vec<String>) {
 // ---------------------------------------------------------------------------
 
 fn is_hidden(el: &scraper::node::Element) -> bool {
-    let style = el.attr("style").unwrap_or("").replace(' ', "").to_lowercase();
+    let style = el
+        .attr("style")
+        .unwrap_or("")
+        .replace(' ', "")
+        .to_lowercase();
     style.contains("display:none")
 }
 
@@ -461,31 +463,46 @@ fn is_xbrl_inline(tag: &str) -> bool {
     let local = tag.rfind(':').map_or(tag, |i| &tag[i + 1..]);
     matches!(
         local,
-        "nonnumeric" | "nonfraction" | "continuation" | "fraction" | "numerator"
-            | "denominator"
+        "nonnumeric" | "nonfraction" | "continuation" | "fraction" | "numerator" | "denominator"
     ) || tag.starts_with("ixt:")
         || tag.starts_with("ixt-sec:")
 }
 
 fn is_bold_style(el: &scraper::node::Element) -> bool {
-    let style = el.attr("style").unwrap_or("").replace(' ', "").to_lowercase();
+    let style = el
+        .attr("style")
+        .unwrap_or("")
+        .replace(' ', "")
+        .to_lowercase();
     style.contains("font-weight:bold") || style.contains("font-weight:700")
 }
 
 fn is_italic_style(el: &scraper::node::Element) -> bool {
-    let style = el.attr("style").unwrap_or("").replace(' ', "").to_lowercase();
+    let style = el
+        .attr("style")
+        .unwrap_or("")
+        .replace(' ', "")
+        .to_lowercase();
     style.contains("font-style:italic")
 }
 
 fn has_page_break_before(el: &scraper::node::Element) -> bool {
-    let style = el.attr("style").unwrap_or("").replace(' ', "").to_lowercase();
+    let style = el
+        .attr("style")
+        .unwrap_or("")
+        .replace(' ', "")
+        .to_lowercase();
     style.contains("page-break-before:always")
         || style.contains("break-before:page")
         || style.contains("break-before:always")
 }
 
 fn has_page_break_after(el: &scraper::node::Element) -> bool {
-    let style = el.attr("style").unwrap_or("").replace(' ', "").to_lowercase();
+    let style = el
+        .attr("style")
+        .unwrap_or("")
+        .replace(' ', "")
+        .to_lowercase();
     style.contains("page-break-after:always")
         || style.contains("break-after:page")
         || style.contains("break-after:always")

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -466,14 +466,25 @@ fn print_dividends(value: &Value) {
 }
 
 /// Fetch dividend history for a symbol.
-pub async fn cmd_dividend(symbol: String, format: &OutputFormat, verbose: bool) -> Result<()> {
+pub async fn cmd_dividend(
+    symbol: String,
+    page: u32,
+    year: Option<u32>,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
     let cid = symbol_to_counter_id(&symbol);
-    let data = http_get(
-        "/v1/quote/dividends",
-        &[("counter_id", cid.as_str())],
-        verbose,
-    )
-    .await?;
+    let page_str = page.to_string();
+    let year_str = year.map(|y| y.to_string());
+    let mut params = vec![
+        ("counter_id", cid.as_str()),
+        ("size", "50"),
+        ("page", &page_str),
+    ];
+    if let Some(ref y) = year_str {
+        params.push(("year", y.as_str()));
+    }
+    let data = http_get("/v1/quote/dividends", &params, verbose).await?;
     match format {
         OutputFormat::Json => print_json(&data),
         OutputFormat::Pretty => print_dividends(&data),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -394,10 +394,18 @@ pub enum Commands {
     /// Dividend history and distribution details for a symbol
     ///
     /// Example: longbridge dividend AAPL.US
+    /// Example: longbridge dividend AAPL.US --page 2
+    /// Example: longbridge dividend AAPL.US --year 2025
     /// Example: longbridge dividend detail AAPL.US
     Dividend {
         /// Symbol in <CODE>.<MARKET> format (omit when using a subcommand)
         symbol: Option<String>,
+        /// Page number (default: 1)
+        #[arg(long, default_value = "1")]
+        page: u32,
+        /// Filter by year (e.g. 2025)
+        #[arg(long)]
+        year: Option<u32>,
         #[command(subcommand)]
         cmd: Option<DividendCmd>,
     },
@@ -2248,7 +2256,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                 fundamental::cmd_institution_rating(sym, format, verbose).await
             }
         },
-        Commands::Dividend { symbol, cmd } => match cmd {
+        Commands::Dividend { symbol, page, year, cmd } => match cmd {
             Some(DividendCmd::Detail { symbol: s }) => {
                 fundamental::cmd_dividend_detail(s, format, verbose).await
             }
@@ -2256,7 +2264,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                 let sym = symbol.ok_or_else(|| {
                     anyhow::anyhow!("Symbol required. Usage: longbridge dividend <SYMBOL>")
                 })?;
-                fundamental::cmd_dividend(sym, format, verbose).await
+                fundamental::cmd_dividend(sym, page, year, format, verbose).await
             }
         },
         Commands::ForecastEps { symbol } => {


### PR DESCRIPTION
## Summary

- `dividend <SYMBOL>` now fetches 50 records per page (via `size=50`) instead of the server default of 30
- Added `--page N` to paginate through stocks with large dividend histories (e.g. SBR.US has 514 records)
- Added `--year YYYY` to filter results by year (server-side filter, goes live tomorrow)

## Usage

```
longbridge dividend SBR.US              # page 1, all years
longbridge dividend SBR.US --page 2     # page 2
longbridge dividend SBR.US --year 2020  # filter to 2020
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)