### PR TITLE
auth: Resolve `account_channel` from access token JWT

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -58,6 +58,50 @@ fn invite_code_file_path() -> Result<PathBuf> {
         .join("invite-code"))
 }
 
+/// Default `account_channel` used when no token is present or the JWT
+/// cannot be decoded. Matches the historical hardcoded value across the CLI/TUI.
+pub const DEFAULT_ACCOUNT_CHANNEL: &str = "lb";
+
+/// Decode a JWT payload (no signature verification) as a JSON value.
+fn decode_jwt_payload(token: &str) -> Option<serde_json::Value> {
+    use base64::Engine as _;
+    let payload = token.split('.').nth(1)?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    serde_json::from_slice(&decoded).ok()
+}
+
+/// Read the logged-in user's `account_channel` from the local access token.
+///
+/// Longbridge tokens carry `sub` as a JSON-encoded string with fields like
+/// `client_id`, `member_id`, and `account_channel` (`"lb"`,
+/// `"lb_papertrading"`, etc.). Several APIs require this to match the
+/// token's own channel — e.g. `/v1/quote/my-quotes` returns 401004 when
+/// the request `account_channel` does not match.
+///
+/// Returns `None` if the token file is missing/unparseable or the JWT
+/// lacks the field. Use [`account_channel_or_default`] to get a usable
+/// string with a `"lb"` fallback.
+pub fn account_channel() -> Option<String> {
+    let path = token_file_path().ok()?;
+    let contents = fs::read_to_string(path).ok()?;
+    let data: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    let token = data["access_token"].as_str()?;
+    let claims = decode_jwt_payload(token)?;
+    let sub_str = claims["sub"].as_str()?;
+    let sub: serde_json::Value = serde_json::from_str(sub_str).ok()?;
+    sub["account_channel"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+}
+
+/// [`account_channel`] with a fallback to [`DEFAULT_ACCOUNT_CHANNEL`].
+pub fn account_channel_or_default() -> String {
+    account_channel().unwrap_or_else(|| DEFAULT_ACCOUNT_CHANNEL.to_owned())
+}
+
 /// Persist the invite code to disk.
 pub fn save_invite_code(invite_code: &str) -> Result<()> {
     let path = invite_code_file_path()?;

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -71,47 +71,6 @@ fn jwt_exp(token: &str) -> Option<u64> {
     jwt_field(token, "exp")
 }
 
-/// Extract the user's `account_channel` from the access token JWT.
-///
-/// Longbridge tokens carry `sub` as a JSON-encoded string containing
-/// `account_channel` (e.g. `"lb"`, `"lb_papertrading"`, etc.). The channel
-/// is required by `/v1/quote/my-quotes` and must match the token's own
-/// channel — otherwise the server returns 401004.
-fn jwt_account_channel(token: &str) -> Option<String> {
-    use base64::Engine as _;
-    let payload = token.split('.').nth(1)?;
-    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(payload)
-        .ok()?;
-    let v: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
-    let sub_str = v["sub"].as_str()?;
-    let sub: serde_json::Value = serde_json::from_str(sub_str).ok()?;
-    sub["account_channel"]
-        .as_str()
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned)
-}
-
-/// Read the logged-in user's `account_channel` from the local token file.
-/// Falls back to `"lb"` when the file is missing/unparseable, which is the
-/// channel used by the rest of the CLI/TUI when no real account info is loaded.
-fn read_account_channel() -> String {
-    let default = "lb".to_owned();
-    let Ok(path) = crate::auth::token_file_path() else {
-        return default;
-    };
-    let Ok(contents) = std::fs::read_to_string(&path) else {
-        return default;
-    };
-    let Ok(data) = serde_json::from_str::<serde_json::Value>(&contents) else {
-        return default;
-    };
-    data["access_token"]
-        .as_str()
-        .and_then(jwt_account_channel)
-        .unwrap_or(default)
-}
-
 fn read_token_state() -> Result<TokenState> {
     let token_path = crate::auth::token_file_path()?;
     let now = SystemTime::now()
@@ -328,7 +287,7 @@ async fn fetch_account_channel_from_positions() -> Option<String> {
 }
 
 async fn fetch_account_info(market: &str) -> Result<AccountInfo> {
-    let account_channel = read_account_channel();
+    let account_channel = crate::auth::account_channel_or_default();
     let (member_id, level_center, statement_info, account_channel) = tokio::join!(
         crate::openapi::quote().member_id(),
         fetch_my_quotes(market, &account_channel),

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -345,7 +345,8 @@ pub async fn cmd_auth_status(format: &OutputFormat) -> Result<()> {
 
                 // ── Quote Mall QR code ───────────────────────────────────────────
                 println!();
-                let _ = super::my_quote::print_mall_qr("lb");
+                let channel = crate::auth::account_channel_or_default();
+                let _ = super::my_quote::print_mall_qr(&channel);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,10 @@ async fn main() {
             }
         }
 
-        Some(cli::Commands::Update { release_notes, force }) => {
+        Some(cli::Commands::Update {
+            release_notes,
+            force,
+        }) => {
             if release_notes {
                 if let Err(e) = update::cmd_release_notes().await {
                     eprintln!("Error: {e}");

--- a/src/openapi/account.rs
+++ b/src/openapi/account.rs
@@ -27,9 +27,11 @@ pub async fn fetch_account_list() -> Result<AccountList> {
         }
     }
 
-    // Create a default account
+    // Resolve the channel from the access token JWT (`lb`, `lb_papertrading`,
+    // etc.) so paper-trading and other non-default channels surface accurately
+    // to the TUI / CLI without an extra HTTP roundtrip.
     let account = Account {
-        account_channel: "lb".to_string(),
+        account_channel: crate::auth::account_channel_or_default(),
         aaid: String::new(),
         account_name: "Default Account".to_string(),
         account_type: "CashAccount".to_string(),


### PR DESCRIPTION
## Summary

The CLI/TUI previously hardcoded `account_channel: "lb"` in multiple places:

- `openapi::account::fetch_account_list()` — feeds the TUI's global `USER` state
- `cli::auth::cmd_auth_status` — quote mall QR code link
- (Indirectly) `tui::app::USER.account_channel`, populated from the above

Paper-trading users (`lb_papertrading`) and any future channel variants get a
mismatched value. APIs that validate the field — notably `/v1/quote/my-quotes`
introduced in #167 — return `401004` even with a fresh, server-valid token.

## Fix

Add a single source of truth in `crate::auth`:

| API | Behavior |
|-----|----------|
| `auth::account_channel() -> Option<String>` | Decodes the locally stored access token's `sub` JSON and returns the user's actual channel. `None` when no token / unparseable. |
| `auth::account_channel_or_default() -> String` | Convenience wrapper that falls back to `"lb"`. |
| `auth::DEFAULT_ACCOUNT_CHANNEL` | The historical default `"lb"`, exposed as a constant. |

The two existing hardcode sites now call the helper. No extra HTTP roundtrip
— the channel is already in the access token issued during OAuth login.

## Why JWT and not `/v3/account/list`?

The JWT's `sub` claim already carries `account_channel` for every user; the
`/v3/account/list` endpoint requires an additional roundtrip and the same
information. Reading the JWT keeps `auth status` and TUI startup latency
unchanged.

## Test plan

- [x] `cargo build --bin longbridge` passes
- [x] `cargo clippy --bin longbridge` clean for the touched files
- [x] `longbridge auth status` against a paper-trading account: `Account` line shows `[M]` and the `print_mall_qr` URL contains `account_channel=lb_papertrading`
- [x] `longbridge auth status` against a regular `"lb"` account: behavior unchanged

## Relation to #167

Independent. #167 (`level_center` → `my-quotes`) needs the correct channel to
work for paper-trading users; this PR makes that channel correct everywhere
in the codebase. Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)