### PR TITLE
cli: Improve `auth status` display and fix token lifecycle

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -94,6 +94,8 @@ pub fn open_browser(url: &str) -> bool {
 }
 
 /// Write a token JSON blob to the SDK token file path.
+///
+/// Preserves the existing `logged_in_at` field on refresh; sets it to now on initial login.
 fn save_token(client_id: &str, token_resp: &serde_json::Value) -> Result<()> {
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -102,25 +104,52 @@ fn save_token(client_id: &str, token_resp: &serde_json::Value) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("No access_token in token response"))?;
     let expires_in = token_resp["expires_in"].as_u64().unwrap_or(3600);
     let refresh_token = token_resp["refresh_token"].as_str();
-    let expires_at = SystemTime::now()
+    let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
-        .as_secs()
-        + expires_in;
+        .as_secs();
+    let expires_at = now + expires_in;
+
+    let token_path = token_file_path()?;
+    let logged_in_at = fs::read_to_string(&token_path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .and_then(|v| v["logged_in_at"].as_u64())
+        .unwrap_or(now);
 
     let token = serde_json::json!({
         "client_id": client_id,
         "access_token": access_token,
         "refresh_token": refresh_token,
         "expires_at": expires_at,
+        "logged_in_at": logged_in_at,
     });
 
-    let token_path = token_file_path()?;
     if let Some(parent) = token_path.parent() {
         fs::create_dir_all(parent).context("Failed to create token directory")?;
     }
     fs::write(&token_path, serde_json::to_string_pretty(&token).unwrap())
         .context("Failed to write token file")?;
+    Ok(())
+}
+
+/// Patch the token file written by the SDK's `OAuthBuilder` to add `logged_in_at` if missing.
+fn patch_token_logged_in_at() -> Result<()> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let token_path = token_file_path()?;
+    let contents = fs::read_to_string(&token_path)?;
+    let mut data: serde_json::Value = serde_json::from_str(&contents)?;
+
+    if data["logged_in_at"].is_null() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        data["logged_in_at"] = serde_json::Value::from(now);
+        fs::write(&token_path, serde_json::to_string_pretty(&data).unwrap())
+            .context("Failed to patch token file")?;
+    }
     Ok(())
 }
 
@@ -245,10 +274,8 @@ pub async fn device_login(verbose: bool) -> Result<()> {
 ///
 /// - Not expired → returns `Ok(())` immediately (no network call).
 /// - Expired, refresh succeeds → writes new token to disk, returns `Ok(())`.
-/// - Expired, server says invalid/expired refresh token → clears token file,
-///   returns an error directing the user to re-authenticate.
-/// - Expired, network/transient error → returns an error asking the user to
-///   retry (token file is **not** cleared; the refresh token is still valid).
+/// - Expired, refresh fails → returns an error; token file is **never** deleted
+///   so `auth status` shows "expired" rather than "not found".
 pub async fn refresh_if_expired() -> Result<()> {
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -264,12 +291,15 @@ pub async fn refresh_if_expired() -> Result<()> {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    if data["expires_at"].as_u64().unwrap_or(0) > now {
+    let expires_at = data["expires_at"].as_u64().unwrap_or(0);
+    if expires_at == 0 {
+        return Ok(()); // no expiry info — let OAuthBuilder handle it
+    }
+    if expires_at > now {
         return Ok(()); // still valid
     }
 
     let Some(refresh_token) = data["refresh_token"].as_str().filter(|s| !s.is_empty()) else {
-        let _ = clear_token();
         return Err(anyhow::anyhow!(
             "No refresh token found. Please run 'longbridge auth login' to re-authenticate."
         ));
@@ -317,7 +347,6 @@ pub async fn refresh_if_expired() -> Result<()> {
     let error = err_resp["error"].as_str().unwrap_or("unknown");
 
     if error == "invalid_grant" {
-        let _ = clear_token();
         return Err(anyhow::anyhow!(
             "Refresh token has expired. Please run 'longbridge auth login' to re-authenticate."
         ));
@@ -357,6 +386,7 @@ pub async fn auth_code_login() -> Result<()> {
 
     match oauth_result {
         Ok(_) => {
+            let _ = patch_token_logged_in_at();
             println!("Successfully authenticated.");
             Ok(())
         }

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -56,15 +56,19 @@ struct TokenState {
     logged_in_at: Option<u64>,
 }
 
-/// Decode the `exp` field from a JWT payload without verifying the signature.
-fn jwt_exp(token: &str) -> Option<u64> {
+/// Decode a numeric field from a JWT payload without verifying the signature.
+fn jwt_field(token: &str, field: &str) -> Option<u64> {
     use base64::Engine as _;
     let payload = token.split('.').nth(1)?;
     let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(payload)
         .ok()?;
     let v: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
-    v["exp"].as_u64()
+    v[field].as_u64()
+}
+
+fn jwt_exp(token: &str) -> Option<u64> {
+    jwt_field(token, "exp")
 }
 
 /// Extract the user's `account_channel` from the access token JWT.
@@ -128,13 +132,7 @@ fn read_token_state() -> Result<TokenState> {
     let contents = std::fs::read_to_string(&token_path)?;
     let data: serde_json::Value = serde_json::from_str(&contents)?;
 
-    let logged_in_at = data["logged_in_at"].as_u64().or_else(|| {
-        std::fs::metadata(&token_path)
-            .and_then(|m| m.modified())
-            .ok()
-            .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
-            .map(|d| d.as_secs())
-    });
+    let logged_in_at = data["refresh_token"].as_str().and_then(|t| jwt_field(t, "iat"));
     let expires_at = data["expires_at"].as_u64().unwrap_or(0);
     let access_token_exp = if expires_at > 0 { Some(expires_at) } else { None };
     let refresh_token_exp = data["refresh_token"].as_str().and_then(jwt_exp);

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -132,7 +132,9 @@ fn read_token_state() -> Result<TokenState> {
     let contents = std::fs::read_to_string(&token_path)?;
     let data: serde_json::Value = serde_json::from_str(&contents)?;
 
-    let logged_in_at = data["refresh_token"].as_str().and_then(|t| jwt_field(t, "iat"));
+    let logged_in_at = data["logged_in_at"].as_u64().or_else(|| {
+        data["refresh_token"].as_str().and_then(|t| jwt_field(t, "iat"))
+    });
     let expires_at = data["expires_at"].as_u64().unwrap_or(0);
     let access_token_exp = if expires_at > 0 { Some(expires_at) } else { None };
     let refresh_token_exp = data["refresh_token"].as_str().and_then(jwt_exp);

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -1,5 +1,5 @@
 use std::time::{SystemTime, UNIX_EPOCH};
-use time::OffsetDateTime;
+use time::{OffsetDateTime, UtcOffset};
 
 use anyhow::Result;
 use longbridge::asset::{GetStatementListOptions, GetStatementOptions, StatementType};
@@ -18,7 +18,15 @@ const RESET: &str = "\x1b[0m";
 
 /// Format a duration in seconds as a human-readable string (e.g. "2h 14m", "45m", "30s").
 fn format_duration(secs: u64) -> String {
-    if secs >= 3600 {
+    if secs >= 86400 {
+        let d = secs / 86400;
+        let h = (secs % 86400) / 3600;
+        if h == 0 {
+            format!("{d}d")
+        } else {
+            format!("{d}d {h}h")
+        }
+    } else if secs >= 3600 {
         let h = secs / 3600;
         let m = (secs % 3600) / 60;
         if m == 0 {
@@ -42,6 +50,8 @@ fn format_duration(secs: u64) -> String {
 struct TokenState {
     status: &'static str,
     detail: String,
+    access_token_exp: Option<u64>,
+    refresh_token_exp: Option<u64>,
     /// Unix timestamp of when the token file was last written (login time).
     logged_in_at: Option<u64>,
 }
@@ -109,24 +119,32 @@ fn read_token_state() -> Result<TokenState> {
         return Ok(TokenState {
             status: "not_found",
             detail: format!("run {DIM}longbridge auth login{RESET} to authenticate"),
+            access_token_exp: None,
+            refresh_token_exp: None,
             logged_in_at: None,
         });
     }
 
-    let logged_in_at = std::fs::metadata(&token_path)
-        .and_then(|m| m.modified())
-        .ok()
-        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs());
-
     let contents = std::fs::read_to_string(&token_path)?;
     let data: serde_json::Value = serde_json::from_str(&contents)?;
+
+    let logged_in_at = data["logged_in_at"].as_u64().or_else(|| {
+        std::fs::metadata(&token_path)
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+    });
     let expires_at = data["expires_at"].as_u64().unwrap_or(0);
+    let access_token_exp = if expires_at > 0 { Some(expires_at) } else { None };
+    let refresh_token_exp = data["refresh_token"].as_str().and_then(jwt_exp);
 
     if expires_at == 0 {
         return Ok(TokenState {
             status: "present",
             detail: String::new(),
+            access_token_exp,
+            refresh_token_exp,
             logged_in_at,
         });
     }
@@ -134,16 +152,15 @@ fn read_token_state() -> Result<TokenState> {
     if expires_at > now {
         return Ok(TokenState {
             status: "valid",
-            detail: format!("expires in {}", format_duration(expires_at - now)),
+            detail: String::new(),
+            access_token_exp,
+            refresh_token_exp,
             logged_in_at,
         });
     }
 
     // Access token is expired — check if the refresh token is still usable.
-    let refresh_token_valid = data["refresh_token"]
-        .as_str()
-        .and_then(jwt_exp)
-        .is_some_and(|exp| exp > now);
+    let refresh_token_valid = refresh_token_exp.is_some_and(|exp| exp > now);
 
     if refresh_token_valid {
         Ok(TokenState {
@@ -152,6 +169,8 @@ fn read_token_state() -> Result<TokenState> {
                 "access token expired {} ago, will auto-refresh on next command",
                 format_duration(now - expires_at)
             ),
+            access_token_exp,
+            refresh_token_exp,
             logged_in_at,
         })
     } else {
@@ -161,6 +180,8 @@ fn read_token_state() -> Result<TokenState> {
                 "{} ago — run {DIM}longbridge auth login{RESET} to re-authenticate",
                 format_duration(now - expires_at)
             ),
+            access_token_exp,
+            refresh_token_exp,
             logged_in_at,
         })
     }
@@ -386,7 +407,7 @@ pub async fn cmd_auth_status(format: &OutputFormat, market: &str) -> Result<()> 
         }
 
         OutputFormat::Pretty => {
-            const W: usize = 12; // key column width
+            const W: usize = 13; // key column width
 
             // ── Token ──────────────────────────────────────────────────────────
             let (status_str, status_color) = match token.status {
@@ -396,15 +417,53 @@ pub async fn cmd_auth_status(format: &OutputFormat, market: &str) -> Result<()> 
                 _ => ("valid", GREEN),
             };
             println!("Token");
-            println!(
-                "{:<W$} {color}{status_str}{RESET}  {}",
-                "Status",
-                token.detail,
-                W = W,
-                color = status_color,
-            );
+            if token.detail.is_empty() {
+                println!("{:<W$} {color}{status_str}{RESET}", "Status", W = W, color = status_color);
+            } else {
+                println!(
+                    "{:<W$} {color}{status_str}{RESET}  {}",
+                    "Status",
+                    token.detail,
+                    W = W,
+                    color = status_color,
+                );
+            }
+            let local_offset = UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC);
+            let fmt_exp = |ts: u64| -> String {
+                let Ok(dt) = OffsetDateTime::from_unix_timestamp(ts.cast_signed())
+                    .map(|utc| utc.to_offset(local_offset))
+                else {
+                    return String::new();
+                };
+                let now_secs = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                let rel = if ts > now_secs {
+                    format!("in {}", format_duration(ts - now_secs))
+                } else {
+                    format!("{} ago", format_duration(now_secs - ts))
+                };
+                format!(
+                    "{}-{:02}-{:02} {:02}:{:02}  {DIM}({}){RESET}",
+                    dt.year(),
+                    dt.month() as u8,
+                    dt.day(),
+                    dt.hour(),
+                    dt.minute(),
+                    rel,
+                )
+            };
+            if let Some(exp) = token.access_token_exp {
+                println!("{:<W$} {}", "AccessToken", fmt_exp(exp), W = W);
+            }
+            if let Some(exp) = token.refresh_token_exp {
+                println!("{:<W$} {}", "RefreshToken", fmt_exp(exp), W = W);
+            }
             if let Some(ts) = token.logged_in_at {
-                if let Ok(dt) = OffsetDateTime::from_unix_timestamp(ts.cast_signed()) {
+                if let Ok(dt) = OffsetDateTime::from_unix_timestamp(ts.cast_signed())
+                    .map(|utc| utc.to_offset(local_offset))
+                {
                     println!(
                         "{:<W$} {}-{:02}-{:02} {:02}:{:02}",
                         "Logged In",


### PR DESCRIPTION
## Summary

- `auth status` now shows `AccessToken` and `RefreshToken` expiry rows with local timezone and relative time (e.g. `in 38m`, `in 29d 23h`)
- Removed the redundant "expires in" suffix from the `Status` line
- `logged_in_at` is now persisted in the token file itself, so it survives token refresh without drifting to the refresh time
- Token file is **never deleted** on refresh failure — previously an `invalid_grant` or missing refresh token would silently wipe the file, showing confusing "not found" on next run; now shows "expired" instead
- Auto-refresh is skipped for token files without `expires_at` (SDK-written format), preventing false-positive deletions
- `format_duration` extended to support days for long-lived refresh tokens (30d)

## Test plan

- [ ] `longbridge auth status` shows `AccessToken` and `RefreshToken` rows in local time
- [ ] `Logged In` shows the original login time even after token auto-refresh
- [ ] Simulating an expired refresh token no longer deletes the token file

🤖 Generated with [Claude Code](https://claude.com/claude-code)