### PR TITLE
cli: Fix `finance-calendar` auto-pagination for `--symbol` queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 docs/
 .claude/worktrees/
+.worktrees/

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -133,10 +133,16 @@ fn read_token_state() -> Result<TokenState> {
     let data: serde_json::Value = serde_json::from_str(&contents)?;
 
     let logged_in_at = data["logged_in_at"].as_u64().or_else(|| {
-        data["refresh_token"].as_str().and_then(|t| jwt_field(t, "iat"))
+        data["refresh_token"]
+            .as_str()
+            .and_then(|t| jwt_field(t, "iat"))
     });
     let expires_at = data["expires_at"].as_u64().unwrap_or(0);
-    let access_token_exp = if expires_at > 0 { Some(expires_at) } else { None };
+    let access_token_exp = if expires_at > 0 {
+        Some(expires_at)
+    } else {
+        None
+    };
     let refresh_token_exp = data["refresh_token"].as_str().and_then(jwt_exp);
 
     if expires_at == 0 {
@@ -418,7 +424,12 @@ pub async fn cmd_auth_status(format: &OutputFormat, market: &str) -> Result<()> 
             };
             println!("Token");
             if token.detail.is_empty() {
-                println!("{:<W$} {color}{status_str}{RESET}", "Status", W = W, color = status_color);
+                println!(
+                    "{:<W$} {color}{status_str}{RESET}",
+                    "Status",
+                    W = W,
+                    color = status_color
+                );
             } else {
                 println!(
                     "{:<W$} {color}{status_str}{RESET}  {}",

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -1088,13 +1088,7 @@ pub async fn cmd_finance_calendar(
     verbose: bool,
 ) -> Result<()> {
     let today = time::OffsetDateTime::now_utc().date();
-    let start = start.unwrap_or_else(|| {
-        if symbols.is_empty() {
-            format!("{today}")
-        } else {
-            format!("{}", today.saturating_sub(time::Duration::days(90)))
-        }
-    });
+    let start = start.unwrap_or_else(|| format!("{today}"));
 
     // V2 rule: ["report"] must be expanded to ["report", "financial"]
     let mut types: Vec<&str> = vec![event_type.as_str()];
@@ -1112,28 +1106,82 @@ pub async fn cmd_finance_calendar(
     let offset_str = offset.to_string();
     let star_strs: Vec<String> = star.iter().map(ToString::to_string).collect();
 
-    let mut params: Vec<(&str, &str)> = vec![
-        ("date", start.as_str()),
-        ("count", count_str.as_str()),
-        ("offset", offset_str.as_str()),
-        ("next", next.as_str()),
-    ];
-    for t in &types {
-        params.push(("types[]", t));
-    }
-    for c in &cids {
-        params.push(("counter_ids[]", c.as_str()));
-    }
-    for m in &markets {
-        params.push(("markets[]", m.as_str()));
-    }
-    for s in &star_strs {
-        params.push(("star[]", s.as_str()));
-    }
-    if let Some(ref end) = end {
-        params.push(("date_end", end.as_str()));
+    // Build base params shared across all pages (date will be overridden per page).
+    let build_params = |date: &str| -> Vec<(String, String)> {
+        let mut p: Vec<(String, String)> = vec![
+            ("date".into(), date.into()),
+            ("count".into(), count_str.clone()),
+            ("offset".into(), offset_str.clone()),
+            ("next".into(), next.clone()),
+        ];
+        for t in &types {
+            p.push(("types[]".into(), (*t).into()));
+        }
+        for c in &cids {
+            p.push(("counter_ids[]".into(), c.clone()));
+        }
+        for m in &markets {
+            p.push(("markets[]".into(), m.clone()));
+        }
+        for s in &star_strs {
+            p.push(("star[]".into(), s.clone()));
+        }
+        if let Some(ref e) = end {
+            p.push(("date_end".into(), e.clone()));
+        }
+        p
+    };
+
+    // Symbol-mode: auto-paginate via next_date until count individual events collected.
+    // Market-wide queries (no symbol) are paginated on-demand by the caller via --offset.
+    if !cids.is_empty() {
+        let mut current_date = start.clone();
+        let mut total_infos: u32 = 0;
+        let mut all_list: Vec<Value> = Vec::new();
+
+        loop {
+            let owned = build_params(&current_date);
+            let params: Vec<(&str, &str)> = owned
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            let resp = super::api::http_get("/v1/quote/finance_calendar", &params, verbose).await?;
+
+            let page_infos: u32 = resp["list"]
+                .as_array()
+                .unwrap_or(&vec![])
+                .iter()
+                .map(|g| g["infos"].as_array().map_or(0, |v| v.len() as u32))
+                .sum();
+
+            match format {
+                OutputFormat::Pretty => print_finance_calendar(&resp),
+                OutputFormat::Json => {
+                    if let Some(items) = resp["list"].as_array() {
+                        all_list.extend(items.iter().cloned());
+                    }
+                }
+            }
+
+            total_infos += page_infos;
+            let next_date = resp["next_date"].as_str().unwrap_or("").to_string();
+            if next_date.is_empty() || total_infos >= count {
+                break;
+            }
+            current_date = next_date;
+        }
+
+        if matches!(format, OutputFormat::Json) {
+            print_json(&serde_json::json!({ "list": all_list }));
+        }
+        return Ok(());
     }
 
+    let owned = build_params(&start);
+    let params: Vec<(&str, &str)> = owned
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
     let resp = super::api::http_get("/v1/quote/finance_calendar", &params, verbose).await?;
 
     match format {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -439,7 +439,7 @@ pub enum Commands {
 
     /// Finance calendar: upcoming events by type (V2)
     ///
-    /// Default start date: today (no --symbol) or 3 months ago (with --symbol).
+    /// Default start date: today. Use --start for historical queries (e.g. --start 2023-01-01).
     /// Types: financial, report, dividend, ipo, macrodata, closed
     /// Note: "report" automatically includes "financial" per V2 rules.
     /// Example: longbridge finance-calendar financial

--- a/src/tui/views/navbar.rs
+++ b/src/tui/views/navbar.rs
@@ -42,7 +42,10 @@ pub fn render(frame: &mut Frame, rect: Rect, state: AppState) {
     let account_channel = ACCOUNT_CHANNEL.read().expect("poison").clone();
     let mut spans: Vec<Span> = Vec::new();
     if account_channel.as_deref() == Some("lb_papertrading") {
-        spans.push(Span::styled(t!("account.type.paper").to_string(), styles::bmp()));
+        spans.push(Span::styled(
+            t!("account.type.paper").to_string(),
+            styles::bmp(),
+        ));
         spans.push(Span::styled(" | ", dark_gray_style));
     }
     spans.extend([


### PR DESCRIPTION
## Summary

- When `--symbol` is specified, the `finance-calendar` API returns ~3 events per page with a `next_date` cursor. Previously only the first page was fetched, so queries like `finance-calendar dividend --symbol QQQ.US` returned only 1 record even though much more data was available.
- Now auto-paginates via `next_date` until `--count` events are collected (default 100).
- Default start date is now **today** for all queries (matches H5 web behavior). Use `--start YYYY-MM-DD` for historical lookback.

## Test plan

- [ ] `longbridge finance-calendar dividend --symbol QQQ.US` — should show upcoming dividend events from today
- [ ] `longbridge finance-calendar dividend --symbol QQQ.US --start 2021-01-01` — should show ~20+ historical records with auto-pagination
- [ ] `longbridge finance-calendar financial` (no symbol) — unchanged behavior, starts from today

🤖 Generated with [Claude Code](https://claude.com/claude-code)