### PR TITLE
cli: Fix `update` command permission errors and add `--force` flag

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -116,6 +116,9 @@ pub enum Commands {
         /// Show release notes instead of updating
         #[arg(long)]
         release_notes: bool,
+        /// Force update even if already on the latest version
+        #[arg(short, long)]
+        force: bool,
     },
 
     /// Launch the interactive full-screen TUI (terminal UI)

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,13 +149,13 @@ async fn main() {
             }
         }
 
-        Some(cli::Commands::Update { release_notes }) => {
+        Some(cli::Commands::Update { release_notes, force }) => {
             if release_notes {
                 if let Err(e) = update::cmd_release_notes().await {
                     eprintln!("Error: {e}");
                     std::process::exit(1);
                 }
-            } else if let Err(e) = update::cmd_update(verbose).await {
+            } else if let Err(e) = update::cmd_update(verbose, force).await {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             }

--- a/src/update.rs
+++ b/src/update.rs
@@ -222,6 +222,25 @@ async fn download_to_file(url: &str, dest: &std::path::Path) -> anyhow::Result<(
 }
 
 #[cfg(unix)]
+fn sudo_mv(src: &std::path::Path, dest: &std::path::Path) -> anyhow::Result<()> {
+    eprintln!("Permission denied — retrying with sudo...");
+    let status = std::process::Command::new("sudo")
+        .arg("mv")
+        .arg(src)
+        .arg(dest)
+        .status()
+        .map_err(|e| anyhow::anyhow!("Failed to run sudo: {e}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "sudo mv failed (exit code: {}).\nYou can also run: sudo longbridge update",
+            status.code().unwrap_or(-1)
+        )
+    }
+}
+
+#[cfg(unix)]
 fn extract_and_replace(
     archive_path: &std::path::Path,
     target_exe: &std::path::Path,
@@ -262,27 +281,22 @@ fn extract_and_replace(
     // 1) copy the new binary into the target directory under a temporary name
     // 2) atomically rename it over the running executable
     // This avoids writing directly to a running binary (ETXTBUSY).
-    let staged_path = tempfile::Builder::new()
+    let staged_result = tempfile::Builder::new()
         .prefix(".longbridge-update-")
-        .tempfile_in(target_dir)
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::PermissionDenied {
-                anyhow::anyhow!(
-                    "Permission denied writing to {}.\nTry: sudo longbridge update",
-                    target_dir.display()
-                )
-            } else {
-                e.into()
-            }
-        })?
-        .into_temp_path();
+        .tempfile_in(target_dir);
+
+    let staged_path = match staged_result {
+        Ok(f) => f.into_temp_path(),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            return sudo_mv(&extracted, target_exe);
+        }
+        Err(e) => return Err(e.into()),
+    };
 
     if let Err(e) = std::fs::copy(&extracted, &staged_path) {
         if e.kind() == std::io::ErrorKind::PermissionDenied {
-            anyhow::bail!(
-                "Permission denied writing to {}.\nTry: sudo longbridge update",
-                target_dir.display()
-            );
+            drop(staged_path);
+            return sudo_mv(&extracted, target_exe);
         }
         return Err(e.into());
     }
@@ -290,10 +304,8 @@ fn extract_and_replace(
 
     if let Err(e) = std::fs::rename(&staged_path, target_exe) {
         if e.kind() == std::io::ErrorKind::PermissionDenied {
-            anyhow::bail!(
-                "Permission denied writing to {}.\nTry: sudo longbridge update",
-                target_dir.display()
-            );
+            drop(staged_path);
+            return sudo_mv(&extracted, target_exe);
         }
         return Err(e.into());
     }
@@ -369,7 +381,7 @@ pub fn cleanup_old_binary() {
 }
 
 /// Download the latest release and replace the current binary in place.
-pub async fn cmd_update(verbose: bool) -> anyhow::Result<()> {
+pub async fn cmd_update(verbose: bool, force: bool) -> anyhow::Result<()> {
     // 1. Resolve current binary path
     let current_exe = std::env::current_exe()?.canonicalize()?;
 
@@ -381,7 +393,7 @@ pub async fn cmd_update(verbose: bool) -> anyhow::Result<()> {
     let latest = fetch_latest_version_for_update().await?;
 
     // 3. Check if already up to date
-    if !is_newer(CURRENT_VERSION, &latest) {
+    if !force && !is_newer(CURRENT_VERSION, &latest) {
         eprintln!("Already up to date (v{CURRENT_VERSION}).");
         return Ok(());
     }


### PR DESCRIPTION
## Summary

- When `longbridge update` encounters `PermissionDenied` (e.g. binary installed in `/usr/local/bin`), it now automatically retries the file replacement via `sudo mv` — the user sees a password prompt in-terminal instead of a cryptic error
- Adds `-f` / `--force` flag to skip the version check and force a reinstall, useful for verifying the update/install flow without bumping the version

## Test plan

- [ ] Run `longbridge update` with binary in `/usr/local/bin` — should prompt for sudo instead of erroring
- [ ] Run `longbridge update -f` when already on latest — should download and reinstall instead of printing "Already up to date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)