### PR TITLE
cli: Fix `institution-rating --history` output formatting

### DIFF
--- a/src/cli/asset.rs
+++ b/src/cli/asset.rs
@@ -2,9 +2,7 @@ use anyhow::Result;
 use serde_json::Value;
 
 use super::api::http_get;
-use super::output::{
-    fmt_datetime, parse_datetime_end, parse_datetime_start, print_table,
-};
+use super::output::{fmt_datetime, parse_datetime_end, parse_datetime_start, print_table};
 use super::OutputFormat;
 
 fn print_json(value: &Value) {
@@ -531,4 +529,3 @@ pub async fn cmd_short_margin(format: &OutputFormat, verbose: bool) -> Result<()
     }
     Ok(())
 }
-

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -2347,6 +2347,7 @@ pub async fn cmd_analyst_estimates(
 
 pub async fn cmd_institution_rating_history(
     symbol: String,
+    count: usize,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
@@ -2359,7 +2360,7 @@ pub async fn cmd_institution_rating_history(
     .await?;
     match format {
         OutputFormat::Json => print_json(&data),
-        OutputFormat::Pretty => print_institution_rating_history(&data),
+        OutputFormat::Pretty => print_institution_rating_history(&data, count),
     }
     Ok(())
 }
@@ -2374,7 +2375,7 @@ fn fmt_ts_val(v: &Value) -> String {
     s.parse::<i64>().map_or_else(|_| s, format_date)
 }
 
-fn print_institution_rating_history(data: &Value) {
+fn print_institution_rating_history(data: &Value, count: usize) {
     let empty: Vec<Value> = Vec::new();
     let target_list = data
         .get("target_history")
@@ -2386,9 +2387,21 @@ fn print_institution_rating_history(data: &Value) {
         .unwrap_or(&empty);
 
     if !target_list.is_empty() {
-        println!("Target price history:");
+        let recent_target = if target_list.len() > count {
+            &target_list[target_list.len() - count..]
+        } else {
+            target_list
+        };
+        if target_list.len() > count {
+            println!(
+                "Target price history (most recent {count} of {}):",
+                target_list.len()
+            );
+        } else {
+            println!("Target price history:");
+        }
         let headers = ["date", "close", "low_target", "high_target"];
-        let rows: Vec<Vec<String>> = target_list
+        let rows: Vec<Vec<String>> = recent_target
             .iter()
             .map(|item| {
                 vec![
@@ -2403,21 +2416,30 @@ fn print_institution_rating_history(data: &Value) {
     }
 
     if !eval_list.is_empty() {
-        const EVAL_LIMIT: usize = 20;
-        let recent = if eval_list.len() > EVAL_LIMIT {
-            &eval_list[eval_list.len() - EVAL_LIMIT..]
+        let recent = if eval_list.len() > count {
+            &eval_list[eval_list.len() - count..]
         } else {
             eval_list
         };
-        if eval_list.len() > EVAL_LIMIT {
+        if eval_list.len() > count {
             println!(
-                "\nRating history (most recent {EVAL_LIMIT} of {}):",
+                "\nRating history (most recent {count} of {}):",
                 eval_list.len()
             );
         } else {
             println!("\nRating history:");
         }
-        let headers = ["start_date", "end_date", "total", "over", "buy", "hold", "sell", "under", "no_opinion"];
+        let headers = [
+            "start_date",
+            "end_date",
+            "total",
+            "over",
+            "buy",
+            "hold",
+            "sell",
+            "under",
+            "no_opinion",
+        ];
         let rows: Vec<Vec<String>> = recent
             .iter()
             .map(|item| {

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -2359,33 +2359,87 @@ pub async fn cmd_institution_rating_history(
     .await?;
     match format {
         OutputFormat::Json => print_json(&data),
-        OutputFormat::Pretty => {
-            let target_empty = data
-                .get("target_history")
-                .and_then(|v| v.as_array())
-                .is_none_or(Vec::is_empty);
-            let eval_empty = data
-                .get("evaluate_history")
-                .and_then(|v| v.as_array())
-                .is_none_or(Vec::is_empty);
-            if !target_empty {
-                if let Some(target) = data.get("target_history") {
-                    println!("Target price history:");
-                    print_kv(target);
-                }
-            }
-            if !eval_empty {
-                if let Some(eval) = data.get("evaluate_history") {
-                    println!("\nRating history:");
-                    print_kv(eval);
-                }
-            }
-            if target_empty && eval_empty {
-                println!("No rating history found.");
-            }
-        }
+        OutputFormat::Pretty => print_institution_rating_history(&data),
     }
     Ok(())
+}
+
+fn fmt_price(v: &Value) -> String {
+    let s = val_str(v);
+    s.parse::<f64>().map_or_else(|_| s, |f| format!("{f:.2}"))
+}
+
+fn fmt_ts_val(v: &Value) -> String {
+    let s = val_str(v);
+    s.parse::<i64>().map_or_else(|_| s, format_date)
+}
+
+fn print_institution_rating_history(data: &Value) {
+    let empty: Vec<Value> = Vec::new();
+    let target_list = data
+        .get("target_history")
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty);
+    let eval_list = data
+        .get("evaluate_history")
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty);
+
+    if !target_list.is_empty() {
+        println!("Target price history:");
+        let headers = ["date", "close", "low_target", "high_target"];
+        let rows: Vec<Vec<String>> = target_list
+            .iter()
+            .map(|item| {
+                vec![
+                    fmt_ts_val(&item["timestamp"]),
+                    val_str(&item["close"]),
+                    fmt_price(&item["low_target_price"]),
+                    fmt_price(&item["high_target_price"]),
+                ]
+            })
+            .collect();
+        super::output::print_table(&headers, rows, &OutputFormat::Pretty);
+    }
+
+    if !eval_list.is_empty() {
+        const EVAL_LIMIT: usize = 20;
+        let recent = if eval_list.len() > EVAL_LIMIT {
+            &eval_list[eval_list.len() - EVAL_LIMIT..]
+        } else {
+            eval_list
+        };
+        if eval_list.len() > EVAL_LIMIT {
+            println!(
+                "\nRating history (most recent {EVAL_LIMIT} of {}):",
+                eval_list.len()
+            );
+        } else {
+            println!("\nRating history:");
+        }
+        let headers = ["start_date", "end_date", "total", "over", "buy", "hold", "sell", "under", "no_opinion"];
+        let rows: Vec<Vec<String>> = recent
+            .iter()
+            .map(|item| {
+                vec![
+                    fmt_ts_val(&item["start_date"]),
+                    fmt_ts_val(&item["end_date"]),
+                    val_str(&item["total"]),
+                    val_str(&item["over"]),
+                    val_str(&item["buy"]),
+                    val_str(&item["hold"]),
+                    val_str(&item["sell"]),
+                    val_str(&item["under"]),
+                    val_str(&item["no_opinion"]),
+                ]
+            })
+            .collect();
+        super::output::print_table(&headers, rows, &OutputFormat::Pretty);
+    }
+
+    if target_list.is_empty() && eval_list.is_empty() {
+        println!("No rating history found.");
+    }
 }
 
 // ── institution rating industry rank ────────────────────────────────────────

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -416,9 +416,9 @@ pub enum Commands {
         /// Page number for --industry-rank results (default: 1)
         #[arg(long, default_value = "1")]
         page: u32,
-        /// Page size for --industry-rank results (default: 20)
-        #[arg(long, default_value = "20")]
-        limit: u32,
+        /// Number of records to show (default: 20); applies to --history and --industry-rank
+        #[arg(long, alias = "limit", default_value = "20")]
+        count: u32,
     },
 
     /// Dividend history and distribution details for a symbol
@@ -2610,7 +2610,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             history,
             industry_rank,
             page,
-            limit,
+            count,
         } => {
             if industry_rank {
                 let sym = symbol.ok_or_else(|| {
@@ -2619,7 +2619,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                     )
                 })?;
                 fundamental::cmd_institution_rating_industry_rank(
-                    sym, page, limit, format, verbose,
+                    sym, page, count, format, verbose,
                 )
                 .await
             } else if history {
@@ -2628,7 +2628,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                         "Symbol required. Usage: longbridge institution-rating <SYMBOL> --history"
                     )
                 })?;
-                fundamental::cmd_institution_rating_history(sym, format, verbose).await
+                fundamental::cmd_institution_rating_history(sym, count as usize, format, verbose).await
             } else {
                 match cmd {
                     Some(InstitutionRatingCmd::Detail { symbol: s }) => {


### PR DESCRIPTION
## Summary

- Format Unix timestamps in `target_history` and `evaluate_history` as `YYYY-MM-DD` dates
- Round `high_target_price` / `low_target_price` to 2 decimal places (was rendering full arbitrary-precision decimals)
- Replace raw `print_kv` dump with proper `print_table` layout using logical column ordering
- Cap `evaluate_history` display to the most recent 20 records (API returns 1000+ daily rows)

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)