### PR TITLE
cli: Remove `LONGPORT_HTTP_URL` env fallback

### DIFF
--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -112,10 +112,7 @@ pub async fn init_contexts() -> Result<(
         http_client_config = http_client_config.http_url(crate::region::HTTP_URL_TEST);
         effective_http_url = crate::region::HTTP_URL_TEST;
     } else if crate::region::is_cn_cached()
-        && (cfg!(not(debug_assertions))
-            || std::env::var("LONGBRIDGE_HTTP_URL")
-                .or_else(|_| std::env::var("LONGPORT_HTTP_URL"))
-                .is_err())
+        && (cfg!(not(debug_assertions)) || std::env::var("LONGBRIDGE_HTTP_URL").is_err())
     {
         // If last geotest indicated China Mainland, use CN endpoints directly.
         // In debug builds, skip if LONGBRIDGE_HTTP_URL is set (allows local mock server testing).


### PR DESCRIPTION
## Summary

Ref #190

- Remove the `LONGPORT_HTTP_URL` fallback in the CN region endpoint detection logic
- Only `LONGBRIDGE_HTTP_URL` is now recognized for debug-build endpoint override

🤖 Generated with [Claude Code](https://claude.com/claude-code)