### PR TITLE
cli: Add `x-cli-args` header to API requests for BI analytics

### DIFF
--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -127,19 +127,21 @@ pub async fn init_contexts() -> Result<(
         effective_http_url = "https://openapi.longbridge.com";
     }
 
-    // Extract x-cli-cmd: first positional (non-flag) arg; skip --format / --lang values.
-    let cli_cmd = {
+    // Extract x-cli-cmd and x-cli-args from process arguments.
+    // x-cli-cmd: the first positional (subcommand) arg.
+    // x-cli-args: all remaining args after the subcommand.
+    let (cli_cmd, cli_args) = {
         let mut iter = std::env::args().skip(1);
-        let mut found = String::new();
-        while let Some(arg) = iter.next() {
-            if arg == "--format" || arg == "--lang" {
-                iter.next();
-            } else if !arg.starts_with('-') {
-                found = arg;
-                break;
+        let mut cmd = String::new();
+        let mut args: Vec<String> = Vec::new();
+        for arg in iter.by_ref() {
+            if cmd.is_empty() && !arg.starts_with('-') {
+                cmd = arg;
+            } else if !arg.is_empty() {
+                args.push(arg);
             }
         }
-        found
+        (cmd, args.join(" "))
     };
 
     let user_agent = concat!("longbridge-cli/", env!("CARGO_PKG_VERSION"));
@@ -148,6 +150,9 @@ pub async fn init_contexts() -> Result<(
     config_builder = config_builder.header("user-agent", user_agent);
     if !cli_cmd.is_empty() {
         config_builder = config_builder.header("x-cli-cmd", &cli_cmd);
+    }
+    if !cli_args.is_empty() {
+        config_builder = config_builder.header("x-cli-args", &cli_args);
     }
 
     let config = Arc::new(config_builder);
@@ -167,6 +172,9 @@ pub async fn init_contexts() -> Result<(
     http_client = http_client.header("user-agent", user_agent);
     if !cli_cmd.is_empty() {
         http_client = http_client.header("x-cli-cmd", cli_cmd.as_str());
+    }
+    if !cli_args.is_empty() {
+        http_client = http_client.header("x-cli-args", cli_args.as_str());
     }
 
     HTTP_CLIENT


### PR DESCRIPTION
## Summary

- Adds a new `x-cli-args` header to all API requests, containing all arguments after the subcommand (symbols, flags, options — including `--format`, `--lang`, etc.)
- Complements the existing `x-cli-cmd` header, giving server-side logs the full command + args for BI usage analysis
- Both headers are injected into the SDK `Config` (WebSocket upgrade requests) and the standalone `HttpClient` (REST calls)

## Example

```
longbridge quote 700.HK AAPL.US --format json
```

Results in:
```
X-Cli-Cmd: quote
X-Cli-Args: 700.HK AAPL.US --format json
```

## Test plan

- [x] Verified with local mock HTTP server: `X-Cli-Cmd` and `X-Cli-Args` headers appear correctly on the first API request

🤖 Generated with [Claude Code](https://claude.com/claude-code)