### PR TITLE
cli: Strip leading zeros from numeric symbols and note HK-only for `operating`

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -752,10 +752,10 @@ pub enum Commands {
         cmd: Option<IndustryValuationCmd>,
     },
 
-    /// Operating reviews and financial indicators by report period
+    /// Operating reviews and financial indicators by report period (HK stocks only)
     ///
-    /// Example: longbridge operating AAPL.US
-    /// Example: longbridge operating AAPL.US --report q1
+    /// Example: longbridge operating 700.HK
+    /// Example: longbridge operating 700.HK --report q1
     Operating {
         /// Symbol in <CODE>.<MARKET> format
         symbol: String,

--- a/src/utils/counter.rs
+++ b/src/utils/counter.rs
@@ -44,6 +44,12 @@ pub fn symbol_to_counter_id(symbol: &str) -> String {
         if let Some(ix_code) = code.strip_prefix('.') {
             return format!("IX/{market}/{ix_code}");
         }
+        // Strip leading zeros from numeric codes (e.g. `00700` → `700`)
+        let code = if code.chars().all(|c| c.is_ascii_digit()) {
+            code.trim_start_matches('0')
+        } else {
+            code
+        };
         let etf_candidate = format!("ETF/{market}/{code}");
         if us_etf_set().contains(etf_candidate.as_str()) {
             etf_candidate
@@ -67,6 +73,16 @@ mod tests {
     #[test]
     fn stock_hk() {
         assert_eq!(symbol_to_counter_id("700.HK"), "ST/HK/700");
+    }
+
+    #[test]
+    fn stock_hk_leading_zeros() {
+        assert_eq!(symbol_to_counter_id("00700.HK"), "ST/HK/700");
+    }
+
+    #[test]
+    fn stock_hk_leading_zeros_short() {
+        assert_eq!(symbol_to_counter_id("09988.HK"), "ST/HK/9988");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `symbol_to_counter_id` now strips leading zeros from all-digit codes, so user input like `00700.HK` or `09988.HK` correctly resolves to `ST/HK/700` / `ST/HK/9988` instead of passing the padded form to the API
- `operating` command description updated to note it only has HK stock data; examples changed from `AAPL.US` to `700.HK`

## Test plan

- [ ] `cargo test` — 2 new unit tests cover `00700.HK → ST/HK/700` and `09988.HK → ST/HK/9988`
- [ ] Manual: `longbridge quote 00700.HK` should return the same result as `longbridge quote 700.HK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)