### PR TITLE
cli: Fix US index symbol support and harden `constituent` sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ longbridge calc-index TSLA.US --fields pe,pb,eps     # Calculated financial inde
 longbridge capital TSLA.US                          # Capital distribution snapshot (large/medium/small inflow and outflow)
 longbridge capital TSLA.US --flow                   # Intraday capital flow time series (large/medium/small money in vs out)
 longbridge market-temp [HK|US|CN|SG]                # Market sentiment temperature index (0–100, higher = more bullish)
+longbridge constituent .SPX.US [--sort market-cap]  # Index constituent stocks (US indexes need a leading dot, e.g. .DJI.US, .SPX.US)
 longbridge trading session                          # Trading session schedule (open/close times) for all markets
 longbridge trading days HK                          # Trading days and half-trading days for a market
 longbridge security-list HK                         # Full list of securities available in a market

--- a/src/cli/investors.rs
+++ b/src/cli/investors.rs
@@ -143,12 +143,9 @@ fn read_u32_le(data: &[u8], offset: usize) -> u32 {
 #[allow(clippy::indexing_slicing)]
 fn find_eocd(data: &[u8]) -> Option<usize> {
     let sig = [0x50u8, 0x4B, 0x05, 0x06];
-    for i in (0..data.len().saturating_sub(21)).rev() {
-        if data[i..i + 4] == sig {
-            return Some(i);
-        }
-    }
-    None
+    (0..data.len().saturating_sub(21))
+        .rev()
+        .find(|&i| data[i..i + 4] == sig)
 }
 
 // Parses the ZIP central directory; returns filename → (local_offset_abs, comp_size, comp_method).

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -786,20 +786,24 @@ pub enum Commands {
 
     /// Index or ETF constituent stocks
     ///
+    /// US index symbols require a leading dot (e.g. .DJI.US, .SPX.US, .IXIC.US).
+    /// HK indexes use the plain code (e.g. HSI.HK).
+    ///
     /// Example: longbridge constituent HSI.HK
+    /// Example: longbridge constituent .SPX.US --sort market-cap --order asc
     /// Example: longbridge constituent HSI.HK --limit 20 --sort change
     Constituent {
-        /// Index symbol in <CODE>.<MARKET> format (e.g. HSI.HK, DJI.US)
+        /// Index symbol in <CODE>.<MARKET> format (e.g. HSI.HK, .DJI.US, .SPX.US)
         symbol: String,
         /// Number of results to return
         #[arg(long, default_value = "50")]
         limit: i32,
-        /// Sort indicator: change, price, turnover, inflow, turnover-rate, market-cap
-        #[arg(long, default_value = "change")]
-        sort: String,
-        /// Sort order: desc | asc
-        #[arg(long, default_value = "desc")]
-        order: String,
+        /// Sort indicator
+        #[arg(long, value_enum, default_value_t = ConstituentSort::Change)]
+        sort: ConstituentSort,
+        /// Sort order
+        #[arg(long, value_enum, default_value_t = ConstituentOrder::Desc)]
+        order: ConstituentOrder,
     },
 
     /// Market open/close status for each exchange
@@ -1942,6 +1946,53 @@ pub enum ExportFormat {
     Csv,
     #[value(name = "md")]
     Md,
+}
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum ConstituentSort {
+    #[value(name = "change")]
+    Change,
+    #[value(name = "price")]
+    Price,
+    #[value(name = "turnover")]
+    Turnover,
+    #[value(name = "inflow")]
+    Inflow,
+    #[value(name = "turnover-rate", alias = "turnover_rate")]
+    TurnoverRate,
+    #[value(name = "market-cap", alias = "market_cap")]
+    MarketCap,
+}
+
+impl ConstituentSort {
+    /// Indicator code expected by `/v1/quote/index-constituents`.
+    pub fn as_indicator(&self) -> &'static str {
+        match self {
+            Self::Change => "1",
+            Self::Price => "2",
+            Self::Turnover => "3",
+            Self::Inflow => "4",
+            Self::TurnoverRate => "5",
+            Self::MarketCap => "6",
+        }
+    }
+}
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum ConstituentOrder {
+    #[value(name = "desc")]
+    Desc,
+    #[value(name = "asc")]
+    Asc,
+}
+
+impl ConstituentOrder {
+    pub fn as_indicator(&self) -> &'static str {
+        match self {
+            Self::Desc => "0",
+            Self::Asc => "1",
+        }
+    }
 }
 
 #[derive(Subcommand)]

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2115,12 +2115,11 @@ fn print_json(data: &Value) {
 }
 
 /// Convert index symbol to IX/ prefix `counter_id` (e.g. `HSI.HK` → `IX/HK/HSI`,
-/// `.DJI.US` → `IX/US/DJI`).
+/// `.DJI.US` → `IX/US/.DJI`).
 fn index_symbol_to_counter_id(symbol: &str) -> String {
     if let Some((code, market)) = symbol.rsplit_once('.') {
         let market = market.to_uppercase();
-        // Strip leading dot from code (e.g. `.DJI.US` → code part is `.DJI`, strip to `DJI`)
-        let code = code.trim_start_matches('.');
+        // Preserve the leading dot — US index counter_ids include it (e.g. `.DJI.US` → `IX/US/.DJI`)
         format!("IX/{market}/{code}")
     } else {
         symbol.to_string()
@@ -2189,21 +2188,12 @@ pub async fn cmd_history_intraday(
 pub async fn cmd_constituent(
     symbol: String,
     limit: i32,
-    sort: &str,
-    order: &str,
+    sort: &crate::cli::ConstituentSort,
+    order: &crate::cli::ConstituentOrder,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
     let cid = index_symbol_to_counter_id(&symbol);
-    let indicator = match sort {
-        "price" => "2",
-        "turnover" => "3",
-        "inflow" => "4",
-        "turnover_rate" => "5",
-        "market_cap" => "6",
-        _ => "1", // change% default
-    };
-    let order_val = if order == "asc" { "1" } else { "0" };
     let limit_str = limit.to_string();
     let data = http_get(
         "/v1/quote/index-constituents",
@@ -2211,8 +2201,8 @@ pub async fn cmd_constituent(
             ("counter_id", cid.as_str()),
             ("offset", "0"),
             ("limit", limit_str.as_str()),
-            ("indicator", indicator),
-            ("order", order_val),
+            ("indicator", sort.as_indicator()),
+            ("order", order.as_indicator()),
         ],
         verbose,
     )

--- a/src/utils/counter.rs
+++ b/src/utils/counter.rs
@@ -13,36 +13,35 @@ fn us_etf_set() -> &'static HashSet<&'static str> {
     })
 }
 
-/// Convert a `counter_id` (e.g. `ST/US/TSLA`, `ETF/US/SPY`, `IX/US/DJI`, `ST/HK/700`) back to
+/// Convert a `counter_id` (e.g. `ST/US/TSLA`, `ETF/US/SPY`, `IX/US/.DJI`, `ST/HK/700`) back to
 /// a display symbol (e.g. `TSLA.US`, `SPY.US`, `.DJI.US`, `700.HK`).
 ///
-/// US index `counter_ids` (`IX/US/...`) map to leading-dot symbols (e.g. `.DJI.US`).
+/// US index `counter_ids` (`IX/US/...`) preserve the leading dot in the code part
+/// (e.g. `IX/US/.DJI` → `.DJI.US`).
 pub fn counter_id_to_symbol(counter_id: &str) -> String {
     let parts: Vec<&str> = counter_id.splitn(3, '/').collect();
     if parts.len() == 3 {
-        let (prefix, market, code) = (parts[0], parts[1], parts[2]);
-        if prefix == "IX" && market == "US" {
-            format!(".{code}.{market}")
-        } else {
-            format!("{code}.{market}")
-        }
+        let (_prefix, market, code) = (parts[0], parts[1], parts[2]);
+        format!("{code}.{market}")
     } else {
         counter_id.to_string()
     }
 }
 
 /// Convert a user-supplied symbol (e.g. `TSLA.US`, `700.HK`, `.DJI.US`) to a `counter_id`
-/// (e.g. `ST/US/TSLA`, `ST/HK/700`, `ETF/US/SPY`, `IX/US/DJI`).
+/// (e.g. `ST/US/TSLA`, `ST/HK/700`, `ETF/US/SPY`, `IX/US/.DJI`).
 ///
 /// Leading-dot symbols (e.g. `.DJI.US`, `.VIX.US`) are US market indexes and map to
-/// the `IX/` prefix.  US symbols are checked against the embedded ETF list; matching
-/// symbols use the `ETF/` prefix.  All other symbols default to `ST/`.
+/// the `IX/` prefix, preserving the dot in the code part (e.g. `.DJI.US` → `IX/US/.DJI`).
+/// US symbols are checked against the embedded ETF list; matching symbols use the `ETF/`
+/// prefix.  All other symbols default to `ST/`.
 pub fn symbol_to_counter_id(symbol: &str) -> String {
     if let Some((code, market)) = symbol.rsplit_once('.') {
         let market = market.to_uppercase();
-        // Leading-dot symbols are US market indexes (e.g. `.DJI.US` → `IX/US/DJI`)
-        if let Some(ix_code) = code.strip_prefix('.') {
-            return format!("IX/{market}/{ix_code}");
+        // Leading-dot symbols are US market indexes; the dot is part of the counter_id
+        // (e.g. `.DJI.US` → `IX/US/.DJI`)
+        if code.starts_with('.') {
+            return format!("IX/{market}/{code}");
         }
         // Strip leading zeros from numeric codes (e.g. `00700` → `700`)
         let code = if code.chars().all(|c| c.is_ascii_digit()) {
@@ -107,22 +106,27 @@ mod tests {
 
     #[test]
     fn ix_us_dji() {
-        assert_eq!(symbol_to_counter_id(".DJI.US"), "IX/US/DJI");
+        assert_eq!(symbol_to_counter_id(".DJI.US"), "IX/US/.DJI");
     }
 
     #[test]
     fn ix_us_vix() {
-        assert_eq!(symbol_to_counter_id(".VIX.US"), "IX/US/VIX");
+        assert_eq!(symbol_to_counter_id(".VIX.US"), "IX/US/.VIX");
     }
 
     #[test]
     fn ix_us_ixic() {
-        assert_eq!(symbol_to_counter_id(".IXIC.US"), "IX/US/IXIC");
+        assert_eq!(symbol_to_counter_id(".IXIC.US"), "IX/US/.IXIC");
+    }
+
+    #[test]
+    fn ix_us_spx() {
+        assert_eq!(symbol_to_counter_id(".SPX.US"), "IX/US/.SPX");
     }
 
     #[test]
     fn counter_id_ix_us_to_symbol() {
-        assert_eq!(counter_id_to_symbol("IX/US/DJI"), ".DJI.US");
+        assert_eq!(counter_id_to_symbol("IX/US/.DJI"), ".DJI.US");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `longbridge constituent .SPX.US` (and any other US index) previously returned no data: `symbol_to_counter_id` / `index_symbol_to_counter_id` stripped the leading dot, so requests went out as `IX/US/SPX` instead of the API's required `IX/US/.SPX`. The reverse `counter_id_to_symbol` re-added a dot for display, which masked the bug for code paths that bypassed counter_id conversion (e.g. SDK subscriptions used by the TUI) but left the HTTP `index-constituents` endpoint broken.
- Both directions now preserve the dot end-to-end (`.DJI.US ⇄ IX/US/.DJI`, `.SPX.US ⇄ IX/US/.SPX`).
- `constituent --sort market-cap` / `--sort turnover-rate` silently fell through to the default (`change%`) because the match arms used underscores. Replaced the loose `String` args with `ValueEnum`s (`ConstituentSort`, `ConstituentOrder`); clap now validates input, rejects unknown values with a clear error, and shows `[possible values: change, price, turnover, inflow, turnover-rate, market-cap]` in `--help`. Underscore forms are accepted as aliases.
- README: added the previously-undocumented `constituent` command under Quotes, with a note about the US leading-dot convention.
- Drive-by: rewrote `find_eocd` in `src/cli/investors.rs` to use `Iterator::find` to fix a pre-existing `cargo clippy` error.

## Test plan

- [x] `cargo test utils::counter` — 15 unit tests pass, including new `ix_us_spx` and updated `.DJI.US → IX/US/.DJI` expectations
- [x] `cargo clippy` — passes with no errors
- [x] `longbridge constituent .SPX.US --sort market-cap --order asc` returns the 503 S&P 500 constituents
- [x] `longbridge constituent HSI.HK` still works (HK indexes unchanged)
- [x] `longbridge constituent .SPX.US --sort bogus` rejects with `error: invalid value 'bogus' for '--sort <SORT>'`
- [x] `longbridge constituent .SPX.US --sort market_cap` (underscore alias) accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)