### PR TITLE
cli: Remove `security-list` command

### DIFF
--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -4,7 +4,7 @@ use longbridge::quote::{
     AdjustType, CalcIndex, Candlestick, CapitalDistributionResponse, CapitalFlowLine,
     HistoryMarketTemperatureResponse, IssuerInfo, MarketTemperature, MarketTradingDays,
     MarketTradingSession, OptionQuote, ParticipantInfo, Period, RequestUpdateWatchlistGroup,
-    Security, SecurityBrokers, SecurityCalcIndex, SecurityDepth, SecurityQuote, SecurityStaticInfo,
+    SecurityBrokers, SecurityCalcIndex, SecurityDepth, SecurityQuote, SecurityStaticInfo,
     StrikePriceInfo, Subscription, Trade, WarrantInfo, WarrantQuote, WatchlistGroup,
 };
 use longbridge::trade::{
@@ -71,7 +71,6 @@ pub trait QuoteApi: Send + Sync {
         begin: Date,
         end: Date,
     ) -> Result<MarketTradingDays>;
-    async fn security_list(&self, market: Market) -> Result<Vec<Security>>;
     async fn participants(&self) -> Result<Vec<ParticipantInfo>>;
     async fn subscriptions(&self) -> Result<Vec<Subscription>>;
     async fn option_quote(&self, symbols: Vec<String>) -> Result<Vec<OptionQuote>>;
@@ -255,10 +254,6 @@ impl QuoteApi for LbQuoteApi {
         end: Date,
     ) -> Result<MarketTradingDays> {
         Ok(self.ctx.trading_days(market, begin, end).await?)
-    }
-
-    async fn security_list(&self, market: Market) -> Result<Vec<Security>> {
-        Ok(self.ctx.security_list(market, None).await?)
     }
 
     async fn participants(&self) -> Result<Vec<ParticipantInfo>> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -324,20 +324,6 @@ pub enum Commands {
         cmd: TradingCmd,
     },
 
-    /// List of US overnight-eligible securities
-    ///
-    /// Returns securities that can be traded in the US overnight session.
-    /// Only the US market is supported (Longbridge API limitation).
-    /// Example: longbridge security-list US
-    SecurityList {
-        /// Market: only US is supported (overnight category)
-        #[arg(default_value = "US")]
-        market: String,
-        /// NOTE: currently unused — the SDK only exposes the Overnight category.
-        #[arg(long, default_value = "main", hide = true)]
-        category: String,
-    },
-
     /// Market maker (participant) broker IDs and names
     ///
     /// Use these IDs to interpret results from the `brokers` command.
@@ -2774,9 +2760,6 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                 quote::cmd_trading_days(&market, start, end, format).await
             }
         },
-        Commands::SecurityList { market, category } => {
-            quote::cmd_security_list(&market, &category, format).await
-        }
         Commands::Participants => quote::cmd_participants(format).await,
         Commands::Subscriptions => quote::cmd_subscriptions(format).await,
         Commands::Option { cmd } => match cmd {
@@ -3715,16 +3698,6 @@ mod tests {
             assert_eq!(market, "HK");
         } else {
             panic!("expected Trading Days command");
-        }
-    }
-
-    #[test]
-    fn test_security_list_subcommand() {
-        let cli = parse(&["longbridge", "security-list", "US"]).unwrap();
-        if let Some(Commands::SecurityList { market, .. }) = cli.command {
-            assert_eq!(market, "US");
-        } else {
-            panic!("expected SecurityList command");
         }
     }
 

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use longbridge::quote::{
-    AdjustType, CalcIndex, Period, PrePostQuote, SecurityListCategory, TradeSession, TradeSessions,
+    AdjustType, CalcIndex, Period, PrePostQuote, TradeSession, TradeSessions,
 };
 use longbridge::Market;
 use time::Date;
@@ -222,11 +222,6 @@ fn parse_market(s: &str) -> Result<longbridge::Market> {
         "SG" => Ok(longbridge::Market::SG),
         _ => bail!("Unknown market '{s}'. Use: HK US CN SG"),
     }
-}
-
-fn parse_security_list_category(_s: &str) -> SecurityListCategory {
-    // Currently only Overnight is supported; expand as the SDK exposes more variants
-    SecurityListCategory::Overnight
 }
 
 pub async fn cmd_quote(symbols: Vec<String>, format: &OutputFormat) -> Result<()> {
@@ -1025,30 +1020,6 @@ pub async fn cmd_trading_days(
     Ok(())
 }
 
-pub async fn cmd_security_list(market: &str, category: &str, format: &OutputFormat) -> Result<()> {
-    if !matches!(market.to_uppercase().as_str(), "US") {
-        bail!("Only US market is supported for security-list (Longbridge API only exposes the Overnight category)");
-    }
-    let ctx = crate::openapi::quote();
-    let m = parse_market(market)?;
-    let cat = parse_security_list_category(category);
-    let securities = ctx.security_list(m, cat).await?;
-
-    let headers = &["Symbol", "Name"];
-    let rows = securities
-        .iter()
-        .map(|s| {
-            vec![
-                s.symbol.clone(),
-                locale_name(&s.name_en, &s.name_cn).to_owned(),
-            ]
-        })
-        .collect();
-
-    print_table(headers, rows, format);
-    Ok(())
-}
-
 pub async fn cmd_participants(format: &OutputFormat) -> Result<()> {
     let ctx = crate::openapi::quote();
     let participants = ctx.participants().await?;
@@ -1774,25 +1745,6 @@ pub async fn run_trading_days(
     Ok(())
 }
 
-pub async fn run_security_list(
-    api: &dyn QuoteApi,
-    market: Market,
-    format: &OutputFormat,
-) -> Result<()> {
-    let securities = api.security_list(market).await?;
-    let headers = &["Symbol", "Name"];
-    let rows = securities
-        .iter()
-        .map(|s| {
-            vec![
-                s.symbol.clone(),
-                locale_name(&s.name_en, &s.name_cn).to_owned(),
-            ]
-        })
-        .collect();
-    print_table(headers, rows, format);
-    Ok(())
-}
 
 pub async fn run_participants(api: &dyn QuoteApi, format: &OutputFormat) -> Result<()> {
     let participants = api.participants().await?;
@@ -3092,18 +3044,6 @@ mod tests {
             .times(1)
             .returning(|| Ok(vec![]));
         run_trading_session(&mock, &OutputFormat::Pretty)
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_run_security_list_dispatches() {
-        let mut mock = MockQuoteApi::new();
-        mock.expect_security_list()
-            .with(mockall::predicate::eq(longbridge::Market::HK))
-            .times(1)
-            .returning(|_| Ok(vec![]));
-        run_security_list(&mock, longbridge::Market::HK, &OutputFormat::Pretty)
             .await
             .unwrap();
     }


### PR DESCRIPTION
## Summary

- Removes the `security-list` CLI command — the underlying `security_list` SDK API is designed for overnight-session subscription workflows, not one-shot CLI queries, so the command has no practical use as a standalone tool.

## Changes

- `src/cli/mod.rs` — removed `SecurityList` variant, match arm, and test
- `src/cli/quote.rs` — removed `cmd_security_list`, `run_security_list`, `parse_security_list_category`, unused `SecurityListCategory` import, and test
- `src/cli/api.rs` — removed `security_list` trait method, implementation, and unused `Security` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)