### PR TITLE
cli: Add shareholder top/detail, short-positions HK+trades, screener, compare, top-movers

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ longbridge valuation-rank AAPL.US [--start 20240101] [--end 20241231] # Industry
 longbridge analyst-estimates AAPL.US                                 # Analyst consensus EPS estimates
 longbridge fund-holder AAPL.US [--count 20]                          # Funds and ETFs holding this stock
 longbridge shareholder AAPL.US [--range all|inc|dec] [--sort chg]    # Institutional shareholders with QoQ change tracking
+longbridge shareholder AAPL.US --top                                  # Top 20 major shareholders (includes individuals and insiders, multi-period)
+longbridge shareholder AAPL.US --object-id <ID>                       # Holding and trade detail for a specific shareholder (use ID from --top output)
+longbridge compare AAPL.US                                            # Multi-stock valuation comparison vs server-selected industry peers
+longbridge compare 9988.HK 700.HK 9999.HK [--currency HKD]           # Compare specific stocks side by side (price, market cap, PE/PB/PS, ROE, ROA, div yield, and more)
 longbridge corp-action 700.HK [--all]                                 # Corporate actions (splits, dividends, rights, etc.) — default 30, --all for full history
 longbridge business-segments AAPL.US [--history] [--report qf|saf|af] [--cate <cate>]  # Revenue segment breakdown (current snapshot or historical trends)
 longbridge industry-rank --market US|HK|CN|SG [--indicator leading-gainer|...|net-profit-growth]  # Industry ranking list; output symbols feed into industry-peers
@@ -243,6 +247,9 @@ longbridge ipo withdraw <order_id>                                  # Withdraw I
 ### Market Data
 
 ```bash
+longbridge rank                                                      # List available popularity ranking tab keys
+longbridge rank --key ib_hot_all-us [--count 20]                     # Stocks ranked by composite heat score (trading activity, media, community, volatility)
+longbridge top-movers [--market HK|US|CN|SG] [--sort hot|time|chg]  # Stocks with abnormal price moves paired with correlated news and reason summaries
 longbridge exchange-rate                                             # Exchange rates for all markets
 longbridge finance-calendar financial [--symbol AAPL.US]             # Earnings guidance announcements from today onward
 longbridge finance-calendar report [--symbol AAPL.US]                # Earnings report release dates from today onward
@@ -361,6 +368,20 @@ longbridge dca set-reminder 6                                 # Set reminder hou
 ```bash
 longbridge short-positions AAPL.US                            # US stock short selling data (short interest, ratio, days to cover)
 longbridge short-positions TSLA.US --count 50                 # Return last 50 short interest records
+longbridge short-trades AAPL.US                               # Daily short sale volume (FINRA/NASDAQ for US; HKEX for HK)
+longbridge short-trades 700.HK [--count 50]                   # HK: amount, balance, total amount, rate, close per trading day
+```
+
+### Stock Screener
+
+```bash
+longbridge screener strategies                                # List recommended stock-selection strategies
+longbridge screener strategies --all                          # List all platform strategies
+longbridge screener strategies --mine                         # List user-created strategies
+longbridge screener strategies --id <ID>                      # Show groups and indicators for a specific strategy
+longbridge screener search --strategy-id <ID>                 # Run a saved strategy and return matching stocks
+longbridge screener search --market HK --filter filter_marketcap:100:1000 --filter filter_divyld:3:  # Custom filter (key:min:max, omit bound to leave open)
+longbridge screener indicators                                # List all available filter indicators with IDs, keys, and default value ranges
 ```
 
 <!-- COMMANDS_END -->

--- a/README.md
+++ b/README.md
@@ -366,8 +366,9 @@ longbridge dca set-reminder 6                                 # Set reminder hou
 ### Short Selling
 
 ```bash
-longbridge short-positions AAPL.US                            # US stock short selling data (short interest, ratio, days to cover)
-longbridge short-positions TSLA.US --count 50                 # Return last 50 short interest records
+longbridge short-positions AAPL.US                            # US: bi-weekly FINRA short interest (short interest, rate, days to cover)
+longbridge short-positions 700.HK                             # HK: daily HKEX disclosed short positions (open short shares, balance, cost, rate)
+longbridge short-positions TSLA.US --count 50                 # Return last 50 records
 longbridge short-trades AAPL.US                               # Daily short sale volume (FINRA/NASDAQ for US; HKEX for HK)
 longbridge short-trades 700.HK [--count 50]                   # HK: amount, balance, total amount, rate, close per trading day
 ```

--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,7 @@ fn generate_special_counter_ids() {
     let mut file = std::fs::File::create(&dest).unwrap();
     writeln!(
         file,
-        "static SPECIAL_COUNTER_IDS: phf::Set<&'static str> = {};",
+        "pub static SPECIAL_COUNTER_IDS: phf::Set<&'static str> = {};",
         set.build()
     )
     .unwrap();

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -989,22 +989,37 @@ pub async fn cmd_shareholders_top(
                     Some(a) if !a.is_empty() => a,
                     _ => continue,
                 };
-                let headers = ["object_id", "name", "title", "shares_held", "percent%", "changed", "filing_date"];
-                let rows: Vec<Vec<String>> = holders.iter().map(|h| {
-                    let shares: i64 = val_str(&h["shares_held"]).parse().unwrap_or(0);
-                    let changed: i64 = val_str(&h["shares_changed"]).parse().unwrap_or(0);
-                    let pct = val_str(&h["percent_shares_held"]).parse::<f64>()
-                        .map_or_else(|_| val_str(&h["percent_shares_held"]), |v| format!("{v:.2}"));
-                    vec![
-                        val_str(&h["object_id"]),
-                        val_str(&h["name"]),
-                        val_str(&h["title"]),
-                        shares.to_string(),
-                        pct,
-                        changed.to_string(),
-                        val_str(&h["filing_date"]),
-                    ]
-                }).collect();
+                let headers = [
+                    "object_id",
+                    "name",
+                    "title",
+                    "shares_held",
+                    "percent%",
+                    "changed",
+                    "filing_date",
+                ];
+                let rows: Vec<Vec<String>> = holders
+                    .iter()
+                    .map(|h| {
+                        let shares: i64 = val_str(&h["shares_held"]).parse().unwrap_or(0);
+                        let changed: i64 = val_str(&h["shares_changed"]).parse().unwrap_or(0);
+                        let pct = val_str(&h["percent_shares_held"])
+                            .parse::<f64>()
+                            .map_or_else(
+                                |_| val_str(&h["percent_shares_held"]),
+                                |v| format!("{v:.2}"),
+                            );
+                        vec![
+                            val_str(&h["object_id"]),
+                            val_str(&h["name"]),
+                            val_str(&h["title"]),
+                            shares.to_string(),
+                            pct,
+                            changed.to_string(),
+                            val_str(&h["filing_date"]),
+                        ]
+                    })
+                    .collect();
                 super::output::print_table(&headers, rows, format);
                 println!();
             }
@@ -1043,12 +1058,24 @@ pub async fn cmd_shareholder_detail(
                 if !summary.is_empty() {
                     println!("── Holding Summary ─────────────────────────────────────");
                     let headers = ["period", "accum_buy", "accum_sell", "price", "price_chg%"];
-                    let rows: Vec<Vec<String>> = summary.iter().map(|s| {
-                        let pct = val_str(&s["percent_stock_price_changed"]).parse::<f64>()
-                            .map_or_else(|_| val_str(&s["percent_stock_price_changed"]), |v| format!("{v:+.2}%"));
-                        vec![val_str(&s["period"]), val_str(&s["accum_buy"]),
-                             val_str(&s["accum_sell"]), val_str(&s["stock_price"]), pct]
-                    }).collect();
+                    let rows: Vec<Vec<String>> = summary
+                        .iter()
+                        .map(|s| {
+                            let pct = val_str(&s["percent_stock_price_changed"])
+                                .parse::<f64>()
+                                .map_or_else(
+                                    |_| val_str(&s["percent_stock_price_changed"]),
+                                    |v| format!("{v:+.2}%"),
+                                );
+                            vec![
+                                val_str(&s["period"]),
+                                val_str(&s["accum_buy"]),
+                                val_str(&s["accum_sell"]),
+                                val_str(&s["stock_price"]),
+                                pct,
+                            ]
+                        })
+                        .collect();
                     super::output::print_table(&headers, rows, format);
                     println!();
                 }
@@ -1058,14 +1085,33 @@ pub async fn cmd_shareholder_detail(
                 if let Some(latest) = tradings.first() {
                     if let Some(details) = latest["trading_details"].as_array() {
                         if !details.is_empty() {
-                            println!("── Recent Trades (Period: {}) ──────────────────────────", val_str(&latest["period"]));
-                            let headers = ["date", "type", "shares", "price", "security_type", "filing_date"];
-                            let rows: Vec<Vec<String>> = details.iter().map(|d| {
-                                let shares: i64 = val_str(&d["trading_shares"]).parse().unwrap_or(0);
-                                vec![val_str(&d["trading_date"]), val_str(&d["trading_type"]),
-                                     shares.to_string(), val_str(&d["trading_price"]),
-                                     val_str(&d["security_type"]), val_str(&d["filing_date"])]
-                            }).collect();
+                            println!(
+                                "── Recent Trades (Period: {}) ──────────────────────────",
+                                val_str(&latest["period"])
+                            );
+                            let headers = [
+                                "date",
+                                "type",
+                                "shares",
+                                "price",
+                                "security_type",
+                                "filing_date",
+                            ];
+                            let rows: Vec<Vec<String>> = details
+                                .iter()
+                                .map(|d| {
+                                    let shares: i64 =
+                                        val_str(&d["trading_shares"]).parse().unwrap_or(0);
+                                    vec![
+                                        val_str(&d["trading_date"]),
+                                        val_str(&d["trading_type"]),
+                                        shares.to_string(),
+                                        val_str(&d["trading_price"]),
+                                        val_str(&d["security_type"]),
+                                        val_str(&d["filing_date"]),
+                                    ]
+                                })
+                                .collect();
                             super::output::print_table(&headers, rows, format);
                         }
                     }
@@ -2897,7 +2943,6 @@ fn print_industry_rank(data: &Value) {
     super::output::print_table(&headers, rows, &OutputFormat::Pretty);
 }
 
-
 // ── compare ────────────────────────────────────────────────────────────────────
 
 pub async fn cmd_compare(
@@ -2908,18 +2953,15 @@ pub async fn cmd_compare(
     verbose: bool,
 ) -> Result<()> {
     let base_cid = symbol_to_counter_id(base);
-    let comparison_ids: Vec<String> = others.iter().map(|s| symbol_to_counter_id(s)).collect();
-    let comparison_str = comparison_ids.join(",");
-    let data = http_get(
-        "/v1/quote/compare/valuation",
-        &[
-            ("counter_id", base_cid.as_str()),
-            ("currency", currency),
-            ("comparison_counter_ids", comparison_str.as_str()),
-        ],
-        verbose,
-    )
-    .await?;
+    let comp_cids: Vec<String> = others.iter().map(|s| symbol_to_counter_id(s)).collect();
+    // iOS serializes comparison_counter_ids as a JSON array string via yy_modelToJSONString
+    let comp_json = serde_json::to_string(&comp_cids).unwrap_or_default();
+    let mut params: Vec<(&str, &str)> =
+        vec![("counter_id", base_cid.as_str()), ("currency", currency)];
+    if !comp_cids.is_empty() {
+        params.push(("comparison_counter_ids", comp_json.as_str()));
+    }
+    let data = http_get("/v1/quote/compare/valuation", &params, verbose).await?;
     match format {
         OutputFormat::Json => print_json(&data),
         OutputFormat::Pretty => {
@@ -2930,8 +2972,11 @@ pub async fn cmd_compare(
                     return Ok(());
                 }
             };
-            let symbols: Vec<String> = list.iter().map(|s| val_str(&s["counter_id"])).collect();
-            let names: Vec<String>   = list.iter().map(|s| val_str(&s["name"])).collect();
+            let symbols: Vec<String> = list
+                .iter()
+                .map(|s| crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"])))
+                .collect();
+            let names: Vec<String> = list.iter().map(|s| val_str(&s["name"])).collect();
             let sym_refs: Vec<&str> = symbols.iter().map(String::as_str).collect();
             let mut headers = vec!["Metric"];
             headers.extend_from_slice(&sym_refs);
@@ -2940,8 +2985,30 @@ pub async fn cmd_compare(
             let mut name_row = vec!["Name".to_string()];
             name_row.extend(names);
             rows.push(name_row);
-            // Scalar metric rows
-            for (label, key) in &[("Close", "price_close"), ("Market Cap", "market_value"), ("PE (TTM)", "pe")] {
+            // Scalar metric rows — all available fields
+            for (label, key) in &[
+                ("Close", "price_close"),
+                ("Market Cap", "market_value"),
+                ("Volume", "volume"),
+                ("Turnover", "turnover"),
+                ("EPS (TTM)", "eps"),
+                ("BPS", "bps"),
+                ("Sales PS", "sales_ps"),
+                ("DPS", "dps"),
+                ("5Y Avg DPS", "five_y_avg_dps"),
+                ("Div Yield", "div_yld"),
+                ("Div Payout", "div_payout_ratio"),
+                ("PE (TTM)", "pe"),
+                ("ROE", "roe"),
+                ("ROA", "roa"),
+                ("Net Margin", "net_margin"),
+                ("Net Income", "net_income"),
+                ("Sales", "sales"),
+                ("Assets", "assets"),
+                ("Liabilities", "liabilities"),
+                ("Liab/Assets", "liabilities_assets"),
+                ("Leverage", "leverage"),
+            ] {
                 let mut row = vec![label.to_string()];
                 row.extend(list.iter().map(|s| val_str(&s[*key])));
                 rows.push(row);

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -901,7 +901,7 @@ fn print_fund_holders(data: &Value) {
 
 // ── shareholders ─────────────────────────────────────────────────────────────
 
-fn print_shareholders(data: &Value) {
+fn print_shareholders(data: &Value, limit: usize) {
     let items = match data.get("shareholder_list").and_then(|v| v.as_array()) {
         Some(a) if !a.is_empty() => a,
         _ => {
@@ -910,8 +910,13 @@ fn print_shareholders(data: &Value) {
         }
     };
 
-    let total = data["total"].as_i64().unwrap_or(0);
-    println!("Total shareholders: {total}\n");
+    let total = items.len();
+    let showing = total.min(limit);
+    if showing < total {
+        println!("Showing {showing} of {total} shareholders\n");
+    } else {
+        println!("Total shareholders: {total}\n");
+    }
 
     let headers = [
         "shareholder",
@@ -922,6 +927,7 @@ fn print_shareholders(data: &Value) {
     ];
     let rows: Vec<Vec<String>> = items
         .iter()
+        .take(limit)
         .map(|item| {
             // Related public stock symbol (institution may itself be listed)
             let symbol = item["stocks"]
@@ -1191,23 +1197,21 @@ pub async fn cmd_shareholders(
     verbose: bool,
 ) -> Result<()> {
     let cid = symbol_to_counter_id(&symbol);
-    let count_str = count.to_string();
     let data = http_get(
         "/v1/quote/shareholders",
         &[
             ("counter_id", cid.as_str()),
-            ("position", "entry"),
+            ("position", "detail"),
             ("range", range.as_str()),
             ("sort_field", sort_field.as_str()),
             ("sort_order", sort_order.as_str()),
-            ("count", count_str.as_str()),
         ],
         verbose,
     )
     .await?;
     match format {
         OutputFormat::Json => print_json(&data),
-        OutputFormat::Pretty => print_shareholders(&data),
+        OutputFormat::Pretty => print_shareholders(&data, count as usize),
     }
     Ok(())
 }

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -960,6 +960,122 @@ fn print_shareholders(data: &Value) {
 }
 
 /// Fetch institutional shareholders for a symbol.
+pub async fn cmd_shareholders_top(
+    symbol: String,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    let cid = symbol_to_counter_id(&symbol);
+    let data = http_get(
+        "/v1/quote/shareholders/top",
+        &[("counter_id", cid.as_str())],
+        verbose,
+    )
+    .await?;
+    match format {
+        OutputFormat::Json => print_json(&data),
+        OutputFormat::Pretty => {
+            let info = match data.get("info").and_then(|v| v.as_array()) {
+                Some(a) if !a.is_empty() => a,
+                _ => {
+                    println!("No Top20 shareholder data found for {symbol}.");
+                    return Ok(());
+                }
+            };
+            for period_entry in info {
+                let period = val_str(&period_entry["period"]);
+                println!("{symbol} — Period: {period}\n");
+                let holders = match period_entry["share_holders"].as_array() {
+                    Some(a) if !a.is_empty() => a,
+                    _ => continue,
+                };
+                let headers = ["object_id", "name", "title", "shares_held", "percent%", "changed", "filing_date"];
+                let rows: Vec<Vec<String>> = holders.iter().map(|h| {
+                    let shares: i64 = val_str(&h["shares_held"]).parse().unwrap_or(0);
+                    let changed: i64 = val_str(&h["shares_changed"]).parse().unwrap_or(0);
+                    let pct = val_str(&h["percent_shares_held"]).parse::<f64>()
+                        .map_or_else(|_| val_str(&h["percent_shares_held"]), |v| format!("{v:.2}"));
+                    vec![
+                        val_str(&h["object_id"]),
+                        val_str(&h["name"]),
+                        val_str(&h["title"]),
+                        shares.to_string(),
+                        pct,
+                        changed.to_string(),
+                        val_str(&h["filing_date"]),
+                    ]
+                }).collect();
+                super::output::print_table(&headers, rows, format);
+                println!();
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn cmd_shareholder_detail(
+    symbol: String,
+    object_id: i64,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    let cid = symbol_to_counter_id(&symbol);
+    let oid = object_id.to_string();
+    let data = http_get(
+        "/v1/quote/shareholders/holding",
+        &[("counter_id", cid.as_str()), ("object_id", oid.as_str())],
+        verbose,
+    )
+    .await?;
+    match format {
+        OutputFormat::Json => print_json(&data),
+        OutputFormat::Pretty => {
+            let name = val_str(&data["name"]);
+            let title = val_str(&data["title"]);
+            let owner_source = val_str(&data["owner_source"]);
+            println!("{name}  [{owner_source}]");
+            if title != "-" && !title.is_empty() {
+                println!("{title}");
+            }
+            println!();
+            // Holding summary
+            if let Some(summary) = data["holding_summary"].as_array() {
+                if !summary.is_empty() {
+                    println!("── Holding Summary ─────────────────────────────────────");
+                    let headers = ["period", "accum_buy", "accum_sell", "price", "price_chg%"];
+                    let rows: Vec<Vec<String>> = summary.iter().map(|s| {
+                        let pct = val_str(&s["percent_stock_price_changed"]).parse::<f64>()
+                            .map_or_else(|_| val_str(&s["percent_stock_price_changed"]), |v| format!("{v:+.2}%"));
+                        vec![val_str(&s["period"]), val_str(&s["accum_buy"]),
+                             val_str(&s["accum_sell"]), val_str(&s["stock_price"]), pct]
+                    }).collect();
+                    super::output::print_table(&headers, rows, format);
+                    println!();
+                }
+            }
+            // Recent trades
+            if let Some(tradings) = data["tradings"].as_array() {
+                if let Some(latest) = tradings.first() {
+                    if let Some(details) = latest["trading_details"].as_array() {
+                        if !details.is_empty() {
+                            println!("── Recent Trades (Period: {}) ──────────────────────────", val_str(&latest["period"]));
+                            let headers = ["date", "type", "shares", "price", "security_type", "filing_date"];
+                            let rows: Vec<Vec<String>> = details.iter().map(|d| {
+                                let shares: i64 = val_str(&d["trading_shares"]).parse().unwrap_or(0);
+                                vec![val_str(&d["trading_date"]), val_str(&d["trading_type"]),
+                                     shares.to_string(), val_str(&d["trading_price"]),
+                                     val_str(&d["security_type"]), val_str(&d["filing_date"])]
+                            }).collect();
+                            super::output::print_table(&headers, rows, format);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 pub async fn cmd_shareholders(
     symbol: String,
     range: String,

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -8,7 +8,7 @@ use super::OutputFormat;
 
 use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
 use crate::utils::datetime::format_date;
-use crate::utils::number::{format_financial_value, format_volume};
+use crate::utils::number::format_financial_value;
 use crate::utils::text::strip_html;
 
 async fn http_get(path: &str, params: &[(&str, &str)], verbose: bool) -> Result<Value> {
@@ -951,8 +951,12 @@ fn print_shareholders(data: &Value, limit: usize) {
                     if f == 0.0 {
                         return "-".to_string();
                     }
-                    let sign = if f > 0.0 { "+" } else { "-" };
-                    format!("{sign}{}", format_volume(f.abs() as u64))
+                    let formatted = format_financial_value(&f.to_string(), false);
+                    if f > 0.0 {
+                        format!("+{formatted}")
+                    } else {
+                        formatted
+                    }
                 })
                 .unwrap_or(chg_raw);
 
@@ -1013,9 +1017,9 @@ pub async fn cmd_shareholders_top(
                 let mut deduped: Vec<&Value> = Vec::new();
                 for h in raw_holders {
                     let oid = val_str(&h["object_id"]);
-                    let date = val_str(&h["filing_date"]);
+                    let filing_date = val_str(&h["filing_date"]);
                     if let Some(&idx) = seen.get(&oid) {
-                        if date > val_str(&deduped[idx]["filing_date"]) {
+                        if filing_date > val_str(&deduped[idx]["filing_date"]) {
                             deduped[idx] = h;
                         }
                     } else {
@@ -1048,11 +1052,7 @@ pub async fn cmd_shareholders_top(
                 let rows: Vec<Vec<String>> = holders
                     .iter()
                     .map(|h| {
-                        let shares_raw = val_str(&h["shares_held"]);
-                        let shares = shares_raw
-                            .parse::<f64>()
-                            .map(|f| format_volume(f as u64))
-                            .unwrap_or(shares_raw);
+                        let shares = format_financial_value(&val_str(&h["shares_held"]), false);
                         let changed_raw = val_str(&h["shares_changed"]);
                         let changed = changed_raw.parse::<f64>().map_or_else(
                             |_| changed_raw,
@@ -1060,8 +1060,12 @@ pub async fn cmd_shareholders_top(
                                 if f == 0.0 {
                                     return "-".to_string();
                                 }
-                                let sign = if f > 0.0 { "+" } else { "-" };
-                                format!("{sign}{}", format_volume(f.abs() as u64))
+                                let formatted = format_financial_value(&f.to_string(), false);
+                                if f > 0.0 {
+                                    format!("+{formatted}")
+                                } else {
+                                    formatted
+                                }
                             },
                         );
                         let pct = val_str(&h["percent_shares_held"]);
@@ -1127,7 +1131,7 @@ pub async fn cmd_shareholder_detail(
                                         if f == 0.0 {
                                             "-".to_string()
                                         } else {
-                                            format_volume(f as u64)
+                                            format_financial_value(&f.to_string(), false)
                                         }
                                     })
                                     .unwrap_or(raw)

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -3055,7 +3055,25 @@ pub async fn cmd_compare(
             let mut name_row = vec!["Name".to_string()];
             name_row.extend(names);
             rows.push(name_row);
-            // Scalar metric rows — all available fields
+            let fmt_val = |key: &str, raw: String| -> String {
+                if raw == "-" || raw.is_empty() {
+                    return raw;
+                }
+                match key {
+                    "market_value" | "net_income" | "sales" | "assets" | "liabilities"
+                    | "volume" => format_financial_value(&raw, false),
+                    "div_yld" | "div_payout_ratio" => raw
+                        .parse::<f64>()
+                        .map(|f| format!("{:.2}%", f * 100.0))
+                        .unwrap_or(raw),
+                    "roe" | "roa" | "net_margin" | "liabilities_assets" | "turnover" => raw
+                        .parse::<f64>()
+                        .map(|f| format!("{f:.2}%"))
+                        .unwrap_or(raw),
+                    _ => raw.parse::<f64>().map(|f| format!("{f:.2}")).unwrap_or(raw),
+                }
+            };
+            // Scalar metric rows
             for (label, key) in &[
                 ("Close", "price_close"),
                 ("Market Cap", "market_value"),
@@ -3080,7 +3098,7 @@ pub async fn cmd_compare(
                 ("Leverage", "leverage"),
             ] {
                 let mut row = vec![label.to_string()];
-                row.extend(list.iter().map(|s| val_str(&s[*key])));
+                row.extend(list.iter().map(|s| fmt_val(key, val_str(&s[*key]))));
                 rows.push(row);
             }
             // PB/PS from history (latest entry)
@@ -3090,7 +3108,7 @@ pub async fn cmd_compare(
                     let v = stock["history"]
                         .as_array()
                         .and_then(|h| h.last())
-                        .map_or_else(|| "-".to_string(), |e| val_str(&e[key]));
+                        .map_or_else(|| "-".to_string(), |e| fmt_val(key, val_str(&e[key])));
                     row.push(v);
                 }
                 rows.push(row);

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -2911,7 +2911,7 @@ pub async fn cmd_compare(
     let comparison_ids: Vec<String> = others.iter().map(|s| symbol_to_counter_id(s)).collect();
     let comparison_str = comparison_ids.join(",");
     let data = http_get(
-        "/v1/stock-info/industry-valuation-comparison",
+        "/v1/quote/compare/valuation",
         &[
             ("counter_id", base_cid.as_str()),
             ("currency", currency),

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -2897,6 +2897,73 @@ fn print_industry_rank(data: &Value) {
     super::output::print_table(&headers, rows, &OutputFormat::Pretty);
 }
 
+
+// ── compare ────────────────────────────────────────────────────────────────────
+
+pub async fn cmd_compare(
+    base: &str,
+    others: &[String],
+    currency: &str,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    let base_cid = symbol_to_counter_id(base);
+    let comparison_ids: Vec<String> = others.iter().map(|s| symbol_to_counter_id(s)).collect();
+    let comparison_str = comparison_ids.join(",");
+    let data = http_get(
+        "/v1/stock-info/industry-valuation-comparison",
+        &[
+            ("counter_id", base_cid.as_str()),
+            ("currency", currency),
+            ("comparison_counter_ids", comparison_str.as_str()),
+        ],
+        verbose,
+    )
+    .await?;
+    match format {
+        OutputFormat::Json => print_json(&data),
+        OutputFormat::Pretty => {
+            let list = match data.get("list").and_then(|v| v.as_array()) {
+                Some(a) if !a.is_empty() => a,
+                _ => {
+                    println!("No comparison data found.");
+                    return Ok(());
+                }
+            };
+            let symbols: Vec<String> = list.iter().map(|s| val_str(&s["counter_id"])).collect();
+            let names: Vec<String>   = list.iter().map(|s| val_str(&s["name"])).collect();
+            let sym_refs: Vec<&str> = symbols.iter().map(String::as_str).collect();
+            let mut headers = vec!["Metric"];
+            headers.extend_from_slice(&sym_refs);
+            let mut rows: Vec<Vec<String>> = Vec::new();
+            // Name row
+            let mut name_row = vec!["Name".to_string()];
+            name_row.extend(names);
+            rows.push(name_row);
+            // Scalar metric rows
+            for (label, key) in &[("Close", "price_close"), ("Market Cap", "market_value"), ("PE (TTM)", "pe")] {
+                let mut row = vec![label.to_string()];
+                row.extend(list.iter().map(|s| val_str(&s[*key])));
+                rows.push(row);
+            }
+            // PB/PS from history (latest entry)
+            for (label, key) in [("PB", "pb"), ("PS", "ps")] {
+                let mut row = vec![label.to_string()];
+                for stock in list {
+                    let v = stock["history"]
+                        .as_array()
+                        .and_then(|h| h.last())
+                        .map_or_else(|| "-".to_string(), |e| val_str(&e[key]));
+                    row.push(v);
+                }
+                rows.push(row);
+            }
+            super::output::print_table(&headers, rows, format);
+        }
+    }
+    Ok(())
+}
+
 // ── industry peers ─────────────────────────────────────────────────────────────
 
 pub async fn cmd_industry_peers(

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -8,7 +8,7 @@ use super::OutputFormat;
 
 use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
 use crate::utils::datetime::format_date;
-use crate::utils::number::format_financial_value;
+use crate::utils::number::{format_financial_value, format_volume};
 use crate::utils::text::strip_html;
 
 async fn http_get(path: &str, params: &[(&str, &str)], verbose: bool) -> Result<Value> {
@@ -942,8 +942,11 @@ fn print_shareholders(data: &Value) {
             let chg = chg_raw
                 .parse::<f64>()
                 .map(|f| {
-                    let sign = if f > 0.0 { "+" } else { "" };
-                    format!("{sign}{}", format_financial_value(&f.to_string(), false))
+                    if f == 0.0 {
+                        return "-".to_string();
+                    }
+                    let sign = if f > 0.0 { "+" } else { "-" };
+                    format!("{sign}{}", format_volume(f.abs() as u64))
                 })
                 .unwrap_or(chg_raw);
 
@@ -962,6 +965,7 @@ fn print_shareholders(data: &Value) {
 /// Fetch institutional shareholders for a symbol.
 pub async fn cmd_shareholders_top(
     symbol: String,
+    periods: u32,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
@@ -982,42 +986,85 @@ pub async fn cmd_shareholders_top(
                     return Ok(());
                 }
             };
-            for period_entry in info {
+            let display_count = periods as usize;
+            // The first entry is an aggregate snapshot ("Latest") that duplicates the most
+            // recent quarter. Show only it when periods==1; skip it when showing multiple.
+            let iter: Box<dyn Iterator<Item = &Value>> = if periods == 1 {
+                Box::new(info.iter().take(1))
+            } else {
+                Box::new(info.iter().skip(1).take(display_count))
+            };
+            for period_entry in iter {
                 let period = val_str(&period_entry["period"]);
                 println!("{symbol} — Period: {period}\n");
-                let holders = match period_entry["share_holders"].as_array() {
+                let raw_holders = match period_entry["share_holders"].as_array() {
                     Some(a) if !a.is_empty() => a,
                     _ => continue,
                 };
-                let headers = [
-                    "object_id",
-                    "name",
-                    "title",
-                    "shares_held",
-                    "percent%",
-                    "changed",
-                    "filing_date",
-                ];
+                // Deduplicate by object_id, keeping the entry with the latest filing_date.
+                let mut seen: std::collections::HashMap<String, usize> =
+                    std::collections::HashMap::new();
+                let mut deduped: Vec<&Value> = Vec::new();
+                for h in raw_holders {
+                    let oid = val_str(&h["object_id"]);
+                    let date = val_str(&h["filing_date"]);
+                    if let Some(&idx) = seen.get(&oid) {
+                        if date > val_str(&deduped[idx]["filing_date"]) {
+                            deduped[idx] = h;
+                        }
+                    } else {
+                        seen.insert(oid, deduped.len());
+                        deduped.push(h);
+                    }
+                }
+                let holders: &[&Value] = &deduped;
+                let has_title = holders.iter().any(|h| !val_str(&h["title"]).is_empty());
+                let headers: Vec<&str> = if has_title {
+                    vec![
+                        "object_id",
+                        "name",
+                        "title",
+                        "shares_held",
+                        "percent%",
+                        "changed",
+                        "filing_date",
+                    ]
+                } else {
+                    vec![
+                        "object_id",
+                        "name",
+                        "shares_held",
+                        "percent%",
+                        "changed",
+                        "filing_date",
+                    ]
+                };
                 let rows: Vec<Vec<String>> = holders
                     .iter()
                     .map(|h| {
-                        let shares: i64 = val_str(&h["shares_held"]).parse().unwrap_or(0);
-                        let changed: i64 = val_str(&h["shares_changed"]).parse().unwrap_or(0);
-                        let pct = val_str(&h["percent_shares_held"])
+                        let shares_raw = val_str(&h["shares_held"]);
+                        let shares = shares_raw
                             .parse::<f64>()
-                            .map_or_else(
-                                |_| val_str(&h["percent_shares_held"]),
-                                |v| format!("{v:.2}"),
-                            );
-                        vec![
-                            val_str(&h["object_id"]),
-                            val_str(&h["name"]),
-                            val_str(&h["title"]),
-                            shares.to_string(),
-                            pct,
-                            changed.to_string(),
-                            val_str(&h["filing_date"]),
-                        ]
+                            .map(|f| format_volume(f as u64))
+                            .unwrap_or(shares_raw);
+                        let changed_raw = val_str(&h["shares_changed"]);
+                        let changed = changed_raw.parse::<f64>().map_or_else(
+                            |_| changed_raw,
+                            |f| {
+                                if f == 0.0 {
+                                    return "-".to_string();
+                                }
+                                let sign = if f > 0.0 { "+" } else { "-" };
+                                format!("{sign}{}", format_volume(f.abs() as u64))
+                            },
+                        );
+                        let pct = val_str(&h["percent_shares_held"]);
+                        let mut row = vec![val_str(&h["object_id"]), val_str(&h["name"])];
+                        if has_title {
+                            row.push(val_str(&h["title"]));
+                        }
+                        row.extend([shares, pct, changed, val_str(&h["filing_date"])]);
+                        row
                     })
                     .collect();
                 super::output::print_table(&headers, rows, format);
@@ -1067,10 +1114,22 @@ pub async fn cmd_shareholder_detail(
                                     |_| val_str(&s["percent_stock_price_changed"]),
                                     |v| format!("{v:+.2}%"),
                                 );
+                            let fmt_vol = |key: &str| {
+                                let raw = val_str(&s[key]);
+                                raw.parse::<f64>()
+                                    .map(|f| {
+                                        if f == 0.0 {
+                                            "-".to_string()
+                                        } else {
+                                            format_volume(f as u64)
+                                        }
+                                    })
+                                    .unwrap_or(raw)
+                            };
                             vec![
                                 val_str(&s["period"]),
-                                val_str(&s["accum_buy"]),
-                                val_str(&s["accum_sell"]),
+                                fmt_vol("accum_buy"),
+                                fmt_vol("accum_sell"),
                                 val_str(&s["stock_price"]),
                                 pct,
                             ]
@@ -1127,10 +1186,12 @@ pub async fn cmd_shareholders(
     range: String,
     sort_field: String,
     sort_order: String,
+    count: u32,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
     let cid = symbol_to_counter_id(&symbol);
+    let count_str = count.to_string();
     let data = http_get(
         "/v1/quote/shareholders",
         &[
@@ -1139,6 +1200,7 @@ pub async fn cmd_shareholders(
             ("range", range.as_str()),
             ("sort_field", sort_field.as_str()),
             ("sort_order", sort_order.as_str()),
+            ("count", count_str.as_str()),
         ],
         verbose,
     )

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1704,13 +1704,11 @@ pub enum ScreenerCmd {
     /// Default: platform recommended strategies (use ID with `screener search`).
     /// --mine:  your saved strategies.
     /// --all:   all strategies (recommended + user).
-    /// --id N:  show the full filter conditions of a single strategy.
     ///
     /// The `id` field in the output is passed to `screener search --strategy-id`.
     ///
     /// Example: longbridge screener strategies
     /// Example: longbridge screener strategies --mine
-    /// Example: longbridge screener strategies --id 42
     Strategies {
         /// Show user's saved strategies
         #[arg(long)]
@@ -1718,9 +1716,6 @@ pub enum ScreenerCmd {
         /// Show all strategies (recommended + user)
         #[arg(long)]
         all: bool,
-        /// Show the filter conditions of a single strategy by its ID
-        #[arg(long, value_name = "ID")]
-        id: Option<i64>,
     },
 
     /// Find stocks matching a strategy or custom indicator conditions
@@ -3498,8 +3493,8 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             quote::cmd_top_movers(market, sort.as_api_value(), count, format, verbose).await
         }
         Commands::Screener { cmd } => match cmd {
-            ScreenerCmd::Strategies { mine, all, id } => {
-                screener::cmd_screener_strategies(mine, all, id, format, verbose).await
+            ScreenerCmd::Strategies { mine, all } => {
+                screener::cmd_screener_strategies(mine, all, format, verbose).await
             }
             ScreenerCmd::Search { strategy_id, filters, market, count } => {
                 screener::cmd_screener_search(strategy_id, filters.as_slice(), market.as_str(), count, format, verbose).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,6 +18,7 @@ pub mod news;
 pub mod output;
 pub mod quant_render;
 pub mod quote;
+pub mod screener;
 pub mod run_script;
 pub mod search;
 pub mod sharelist;
@@ -974,6 +975,21 @@ pub enum Commands {
         count: u32,
     },
 
+    /// Strategy screener — browse strategies, execute stock filters, view indicator config
+    ///
+    /// Subcommands: strategies | search | indicators
+    ///
+    /// Example: longbridge screener strategies
+    /// Example: longbridge screener strategies --mine
+    /// Example: longbridge screener strategies --id 42
+    /// Example: longbridge screener search --strategy-id 42
+    /// Example: longbridge screener search --market US
+    /// Example: longbridge screener indicators
+    Screener {
+        #[command(subcommand)]
+        cmd: ScreenerCmd,
+    },
+
     /// Multi-stock valuation comparison (PE, PB, PS, market cap, close price)
     ///
     /// Compare 2–5 stocks side-by-side on valuation multiples.
@@ -1623,6 +1639,54 @@ impl IndustryRankSortType {
             Self::Multi => "1",
         }
     }
+}
+
+#[derive(Subcommand)]
+pub enum ScreenerCmd {
+    /// List stock-selection strategies (recommended by default)
+    ///
+    /// --mine: user's saved strategies.
+    /// --all: all strategies (recommended + user).
+    /// --id N: single strategy's filter conditions.
+    ///
+    /// Example: longbridge screener strategies
+    /// Example: longbridge screener strategies --mine
+    /// Example: longbridge screener strategies --id 42
+    Strategies {
+        /// Show user's saved strategies
+        #[arg(long)]
+        mine: bool,
+        /// Show all strategies (recommended + user)
+        #[arg(long)]
+        all: bool,
+        /// Show filter conditions for a single strategy
+        #[arg(long, value_name = "ID")]
+        id: Option<i64>,
+    },
+
+    /// Execute a strategy or custom filter to find matching stocks
+    ///
+    /// Example: longbridge screener search --strategy-id 42
+    /// Example: longbridge screener search --market US
+    Search {
+        /// Run a saved strategy by ID (from `screener strategies`)
+        #[arg(long)]
+        strategy_id: Option<i64>,
+        /// Market: US | HK | CN (default: US)
+        #[arg(long, default_value = "US")]
+        market: String,
+        /// Number of results (default: 20)
+        #[arg(long, alias = "limit", default_value = "20")]
+        count: u32,
+    },
+
+    /// List all available filter indicators and their value ranges
+    ///
+    /// Example: longbridge screener indicators
+    Indicators {
+        /// Optional symbol to get symbol-specific indicator values
+        symbol: Option<String>,
+    },
 }
 
 #[derive(ValueEnum, Clone, Debug)]
@@ -3348,6 +3412,17 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
         Commands::StockEvents { market, sort, count } => {
             quote::cmd_stock_events(market, sort.as_api_value(), count, format, verbose).await
         }
+        Commands::Screener { cmd } => match cmd {
+            ScreenerCmd::Strategies { mine, all, id } => {
+                screener::cmd_screener_strategies(mine, all, id, format, verbose).await
+            }
+            ScreenerCmd::Search { strategy_id, market, count } => {
+                screener::cmd_screener_search(strategy_id, market.as_str(), count, format, verbose).await
+            }
+            ScreenerCmd::Indicators { symbol } => {
+                screener::cmd_screener_indicators(symbol.clone(), format, verbose).await
+            }
+        },
         Commands::Compare { base, others, currency } => {
             fundamental::cmd_compare(base.as_str(), others.as_slice(), currency.as_str(), format, verbose).await
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -953,17 +953,21 @@ pub enum Commands {
         count: i32,
     },
 
-    /// Hot stock anomaly events with alert reason and pinned news
+    /// Top stocks with abnormal price movements and correlated news
     ///
-    /// Different from `anomaly` (technical signals only): `stock-events` includes
-    /// the reason text (e.g. "波动超 20 日均值"), pinned news, and industry tags.
+    /// When a stock's price fluctuation exceeds its standard deviation over the
+    /// past ~20 trading days, it is flagged as an abnormal change. The system
+    /// then correlates related news to provide an interpretation of the move.
     ///
-    /// Sort values: hot (default) | time | change
+    /// Different from `anomaly` (pure technical signals): `top-movers` pairs
+    /// each alert with a reason summary, pinned news article, and industry tags.
     ///
-    /// Example: longbridge stock-events
-    /// Example: longbridge stock-events --market HK
-    /// Example: longbridge stock-events --market US --sort time --count 50
-    StockEvents {
+    /// Sort: hot (default) | time | change
+    ///
+    /// Example: longbridge top-movers
+    /// Example: longbridge top-movers --market HK
+    /// Example: longbridge top-movers --market US --sort time --count 50
+    TopMovers {
         /// Market filter: HK | US | CN | SG (omit for all markets)
         #[arg(long)]
         market: Option<String>,
@@ -1137,25 +1141,41 @@ pub enum Commands {
     },
 
     // ── Short positions ─────────────────────────────────────────────────
-    /// Short selling data — open positions or daily short sale volume
+    /// Short selling open interest — undisclosed short positions held over time
     ///
-    /// Supports US and HK markets. Market is inferred from the symbol suffix.
-    /// Without --trades: short interest / open short positions.
-    /// With --trades: daily short sale volume.
+    /// Supports US and HK markets; market is inferred from the symbol suffix.
     ///
-    /// US positions: `short_interest`, `rate`, `days_to_cover`, `close`
-    /// HK positions: `open_short_shares`, `balance`, `cost`, `rate`
+    /// US: bi-weekly FINRA short interest data (`short_interest`, `rate`, `days_to_cover`, `close`).
+    /// HK: daily HKEX disclosed short positions (`open_short_shares`, `balance`, `cost`, `rate`).
+    ///
+    /// For daily short sale volume (shares sold short each day), use `short-trades`.
     ///
     /// Example: longbridge short-positions AAPL.US
     /// Example: longbridge short-positions 700.HK
-    /// Example: longbridge short-positions AAPL.US --trades
-    /// Example: longbridge short-positions 700.HK --trades
     ShortPositions {
         /// Symbol in <CODE>.<MARKET> format (US or HK, e.g. AAPL.US 700.HK)
         symbol: String,
-        /// Show short sale volume (trades) instead of open positions
-        #[arg(long)]
-        trades: bool,
+        /// Number of records to return (1–100, default: 20)
+        #[arg(long, alias = "limit", default_value = "20")]
+        count: u32,
+    },
+
+    /// Daily short sale volume — shares sold short each trading day
+    ///
+    /// Supports US and HK markets; market is inferred from the symbol suffix.
+    ///
+    /// US: FINRA/NASDAQ daily short volume (`nus_amount`, `ny_amount`, `total_amount`, `rate`, `close`).
+    ///     Data source: NASDAQ + NYSE consolidated short sale reports.
+    /// HK: HKEX daily short sale volume (`amount`, `balance`, `total_amount`, `rate`, `close`).
+    ///     Data source: HKEX daily short selling disclosure.
+    ///
+    /// For total open short interest (cumulative undisclosed positions), use `short-positions`.
+    ///
+    /// Example: longbridge short-trades AAPL.US
+    /// Example: longbridge short-trades 700.HK
+    ShortTrades {
+        /// Symbol in <CODE>.<MARKET> format (US or HK, e.g. AAPL.US 700.HK)
+        symbol: String,
         /// Number of records to return (1–100, default: 20)
         #[arg(long, alias = "limit", default_value = "20")]
         count: u32,
@@ -3409,7 +3429,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             symbol,
             count,
         } => quote::cmd_anomaly(&market, symbol, count, format, verbose).await,
-        Commands::StockEvents { market, sort, count } => {
+        Commands::TopMovers { market, sort, count } => {
             quote::cmd_stock_events(market, sort.as_api_value(), count, format, verbose).await
         }
         Commands::Screener { cmd } => match cmd {
@@ -3502,8 +3522,11 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             limit,
         } => dca::cmd_dca(cmd, status.as_deref(), symbol.as_deref(), page, limit, format).await,
 
-        Commands::ShortPositions { symbol, trades, count } => {
-            quote::cmd_short_positions(symbol, trades, count, format, verbose).await
+        Commands::ShortPositions { symbol, count } => {
+            quote::cmd_short_positions(symbol, false, count, format, verbose).await
+        }
+        Commands::ShortTrades { symbol, count } => {
+            quote::cmd_short_positions(symbol, true, count, format, verbose).await
         }
 
         Commands::Sharelist { cmd, count } => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -799,7 +799,7 @@ pub enum Commands {
         #[arg(long, default_value = "desc")]
         order: String,
         /// Max number of institutions to show (default mode)
-        #[arg(long, default_value = "20")]
+        #[arg(long, default_value = "50")]
         count: u32,
         /// Number of reporting periods to show with --top (default: 1 = Latest only)
         #[arg(long, default_value = "1")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1002,6 +1002,29 @@ pub enum Commands {
         cmd: ScreenerCmd,
     },
 
+    /// LB popularity ranking lists (热度排行榜)
+    ///
+    /// Returns stocks ranked by a composite heat score combining trading activity,
+    /// media coverage, community discussion, and price volatility.
+    ///
+    /// Use `rank categories` to discover available tab keys, then pass a key to
+    /// list the corresponding ranking.
+    ///
+    /// Example: longbridge rank categories
+    /// Example: longbridge rank --key hotness --market US
+    /// Example: longbridge rank --key trading --market HK --count 20
+    Rank {
+        /// Ranking tab key (from `rank categories`). Omit to show categories.
+        #[arg(long)]
+        key: Option<String>,
+        /// Market filter applied when listing (default: US)
+        #[arg(long, default_value = "US")]
+        market: String,
+        /// Number of results (default: 20)
+        #[arg(long, alias = "limit", default_value = "20")]
+        count: u32,
+    },
+
     /// Multi-stock valuation comparison (PE, PB, PS, market cap, close price)
     ///
     /// Compare 2–5 stocks side-by-side on valuation multiples.
@@ -3451,6 +3474,9 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             symbol,
             count,
         } => quote::cmd_anomaly(&market, symbol, count, format, verbose).await,
+        Commands::Rank { key, market, count } => {
+            quote::cmd_rank(key.clone(), market.as_str(), count, format, verbose).await
+        }
         Commands::TopMovers { market, sort, count } => {
             quote::cmd_stock_events(market, sort.as_api_value(), count, format, verbose).await
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -423,7 +423,7 @@ pub enum Commands {
     /// Industry ranking list by market and indicator
     ///
     /// Returns a ranked list of industries. The "Counter ID" column contains BK
-    /// counter_ids (e.g. BK/US/IN00258) that can be passed directly to `industry-peers`
+    /// `counter_ids` (e.g. BK/US/IN00258) that can be passed directly to `industry-peers`
     /// to explore the sub-sector hierarchy for that industry.
     ///
     /// Example: longbridge industry-rank --market US
@@ -444,7 +444,7 @@ pub enum Commands {
         count: u32,
     },
 
-    /// Industry peer group tree for a BK counter_id
+    /// Industry peer group tree for a BK `counter_id`
     ///
     /// Returns the hierarchical sub-sector tree for an industry group, with stock
     /// count, daily change, and YTD change at each level.
@@ -454,7 +454,7 @@ pub enum Commands {
     /// Example: longbridge industry-peers BK/US/IN00258
     /// Example: longbridge industry-peers BK/HK/IN20337
     IndustryPeers {
-        /// BK counter_id from `industry-rank`, e.g. BK/US/IN00258
+        /// BK `counter_id` from `industry-rank`, e.g. BK/US/IN00258
         symbol: String,
         /// Market override (default: inferred from symbol suffix)
         #[arg(long)]
@@ -771,13 +771,23 @@ pub enum Commands {
 
     /// Institutional shareholders for a symbol
     ///
-    /// Returns: shareholder name, related symbol (if listed), % shares held, share change, report date.
+    /// Without flags: institution list (change direction, sort).
+    /// --top: Top20 major shareholders across multiple periods (includes individuals and insiders).
+    /// --object-id: Holding history and trade detail for a specific shareholder (use `object_id` from --top).
+    ///
     /// Example: longbridge shareholder AAPL.US
+    /// Example: longbridge shareholder AAPL.US --top
+    /// Example: longbridge shareholder AAPL.US --object-id 1001
     /// Example: longbridge shareholder AAPL.US --range inc --sort owned
-    /// Example: longbridge shareholder AAPL.US --format json
     Shareholder {
         /// Symbol in <CODE>.<MARKET> format
         symbol: String,
+        /// Show Top20 major shareholders (multi-period, includes individuals and insiders)
+        #[arg(long)]
+        top: bool,
+        /// Show holding and trade detail for a specific shareholder ID (from --top output)
+        #[arg(long, value_name = "ID")]
+        object_id: Option<i64>,
         /// Filter by change direction: all | inc (increase) | dec (decrease)
         #[arg(long, default_value = "all")]
         range: String,
@@ -1072,14 +1082,25 @@ pub enum Commands {
     },
 
     // ── Short positions ─────────────────────────────────────────────────
-    /// US stock short selling data (short interest, short ratio, days to cover)
+    /// Short selling data — open positions or daily short sale volume
     ///
-    /// Only supports US-listed stocks and ETFs.
+    /// Supports US and HK markets. Market is inferred from the symbol suffix.
+    /// Without --trades: short interest / open short positions.
+    /// With --trades: daily short sale volume.
+    ///
+    /// US positions: `short_interest`, `rate`, `days_to_cover`, `close`
+    /// HK positions: `open_short_shares`, `balance`, `cost`, `rate`
+    ///
     /// Example: longbridge short-positions AAPL.US
-    /// Example: longbridge short-positions TSLA.US --count 50
+    /// Example: longbridge short-positions 700.HK
+    /// Example: longbridge short-positions AAPL.US --trades
+    /// Example: longbridge short-positions 700.HK --trades
     ShortPositions {
-        /// Symbol in <CODE>.<MARKET> format (US market only, e.g. AAPL.US)
+        /// Symbol in <CODE>.<MARKET> format (US or HK, e.g. AAPL.US 700.HK)
         symbol: String,
+        /// Show short sale volume (trades) instead of open positions
+        #[arg(long)]
+        trades: bool,
         /// Number of records to return (1–100, default: 20)
         #[arg(long, alias = "limit", default_value = "20")]
         count: u32,
@@ -3144,10 +3165,20 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
 
         Commands::Shareholder {
             symbol,
+            top,
+            object_id,
             range,
             sort,
             order,
-        } => fundamental::cmd_shareholders(symbol, range, sort, order, format, verbose).await,
+        } => {
+            if top {
+                fundamental::cmd_shareholders_top(symbol, format, verbose).await
+            } else if let Some(oid) = object_id {
+                fundamental::cmd_shareholder_detail(symbol, oid, format, verbose).await
+            } else {
+                fundamental::cmd_shareholders(symbol, range, sort, order, format, verbose).await
+            }
+        }
         Commands::FundHolder { symbol, count } => {
             fundamental::cmd_fund_holders(symbol, count, format, verbose).await
         }
@@ -3331,8 +3362,8 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             limit,
         } => dca::cmd_dca(cmd, status.as_deref(), symbol.as_deref(), page, limit, format).await,
 
-        Commands::ShortPositions { symbol, count } => {
-            quote::cmd_short_positions(symbol, count, format, verbose).await
+        Commands::ShortPositions { symbol, trades, count } => {
+            quote::cmd_short_positions(symbol, trades, count, format, verbose).await
         }
 
         Commands::Sharelist { cmd, count } => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -798,6 +798,12 @@ pub enum Commands {
         /// Sort order: desc | asc
         #[arg(long, default_value = "desc")]
         order: String,
+        /// Max number of institutions to show (default mode)
+        #[arg(long, default_value = "20")]
+        count: u32,
+        /// Number of reporting periods to show with --top (default: 1 = Latest only)
+        #[arg(long, default_value = "1")]
+        periods: u32,
     },
 
     // ── Pending Commands ──────────────────────────────────────────────────────
@@ -3366,13 +3372,16 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             range,
             sort,
             order,
+            count,
+            periods,
         } => {
             if top {
-                fundamental::cmd_shareholders_top(symbol, format, verbose).await
+                fundamental::cmd_shareholders_top(symbol, periods, format, verbose).await
             } else if let Some(oid) = object_id {
                 fundamental::cmd_shareholder_detail(symbol, oid, format, verbose).await
             } else {
-                fundamental::cmd_shareholders(symbol, range, sort, order, format, verbose).await
+                fundamental::cmd_shareholders(symbol, range, sort, order, count, format, verbose)
+                    .await
             }
         }
         Commands::FundHolder { symbol, count } => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3495,7 +3495,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             quote::cmd_rank(key.clone(), market.as_str(), count, format, verbose).await
         }
         Commands::TopMovers { market, sort, count } => {
-            quote::cmd_stock_events(market, sort.as_api_value(), count, format, verbose).await
+            quote::cmd_top_movers(market, sort.as_api_value(), count, format, verbose).await
         }
         Commands::Screener { cmd } => match cmd {
             ScreenerCmd::Strategies { mine, all, id } => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1720,9 +1720,20 @@ pub enum ScreenerCmd {
     /// The strategy's built-in market and filter conditions are applied automatically.
     ///
     /// Example: longbridge screener run 42
+    /// Example: longbridge screener run 42 --sort roe --order asc
+    /// Example: longbridge screener run 42 --show pettm --show pbmrq
     Run {
         /// Strategy ID from `screener strategies` output
         id: i64,
+        /// Sort results by this indicator key (default: first column, descending)
+        #[arg(long)]
+        sort: Option<String>,
+        /// Sort direction: desc (default) | asc
+        #[arg(long, default_value = "desc")]
+        order: String,
+        /// Extra columns to display without adding a filter condition
+        #[arg(long = "show", value_name = "KEY")]
+        show: Vec<String>,
         /// Number of results (default: 20)
         #[arg(long, alias = "limit", default_value = "20")]
         count: u32,
@@ -1736,6 +1747,7 @@ pub enum ScreenerCmd {
     ///
     /// Example: longbridge screener filter pettm:10:50 roe:5: --market HK
     /// Example: longbridge screener filter marketcap:100: divyld:3: --market US
+    /// Example: longbridge screener filter roe:20: --market HK --sort roe --show pettm --show pbmrq
     Filter {
         /// Filter conditions in KEY:MIN:MAX format
         #[arg(value_name = "KEY:MIN:MAX")]
@@ -1743,6 +1755,15 @@ pub enum ScreenerCmd {
         /// Market: US | HK | CN (default: US)
         #[arg(long, default_value = "US")]
         market: String,
+        /// Sort results by this indicator key (default: first condition, descending)
+        #[arg(long)]
+        sort: Option<String>,
+        /// Sort direction: desc (default) | asc
+        #[arg(long, default_value = "desc")]
+        order: String,
+        /// Extra columns to display without adding a filter condition
+        #[arg(long = "show", value_name = "KEY")]
+        show: Vec<String>,
         /// Number of results (default: 20)
         #[arg(long, alias = "limit", default_value = "20")]
         count: u32,
@@ -3494,11 +3515,11 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             ScreenerCmd::Strategies { mine, all } => {
                 screener::cmd_screener_strategies(mine, all, format, verbose).await
             }
-            ScreenerCmd::Run { id, count } => {
-                screener::cmd_screener_run(id, count, format, verbose).await
+            ScreenerCmd::Run { id, sort, order, show, count } => {
+                screener::cmd_screener_run(id, sort.as_deref(), order.as_str(), show.as_slice(), count, format, verbose).await
             }
-            ScreenerCmd::Filter { conditions, market, count } => {
-                screener::cmd_screener_filter(conditions.as_slice(), market.as_str(), count, format, verbose).await
+            ScreenerCmd::Filter { conditions, market, sort, order, show, count } => {
+                screener::cmd_screener_filter(conditions.as_slice(), market.as_str(), sort.as_deref(), order.as_str(), show.as_slice(), count, format, verbose).await
             }
             ScreenerCmd::Indicators { symbol } => {
                 screener::cmd_screener_indicators(symbol.clone(), format, verbose).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -952,6 +952,45 @@ pub enum Commands {
         count: i32,
     },
 
+    /// Hot stock anomaly events with alert reason and pinned news
+    ///
+    /// Different from `anomaly` (technical signals only): `stock-events` includes
+    /// the reason text (e.g. "波动超 20 日均值"), pinned news, and industry tags.
+    ///
+    /// Sort values: hot (default) | time | change
+    ///
+    /// Example: longbridge stock-events
+    /// Example: longbridge stock-events --market HK
+    /// Example: longbridge stock-events --market US --sort time --count 50
+    StockEvents {
+        /// Market filter: HK | US | CN | SG (omit for all markets)
+        #[arg(long)]
+        market: Option<String>,
+        /// Sort order: hot (default) | time | change
+        #[arg(long, default_value = "hot")]
+        sort: StockEventSort,
+        /// Number of results (default: 20)
+        #[arg(long, alias = "limit", default_value = "20")]
+        count: u32,
+    },
+
+    /// Multi-stock valuation comparison (PE, PB, PS, market cap, close price)
+    ///
+    /// Compare 2–5 stocks side-by-side on valuation multiples.
+    /// The first symbol is the base; remaining symbols are compared against it.
+    ///
+    /// Example: longbridge compare AAPL.US BABA.US JD.US
+    /// Example: longbridge compare 700.HK 9988.HK --currency HKD
+    Compare {
+        /// Base symbol in <CODE>.<MARKET> format
+        base: String,
+        /// Additional symbols to compare (1–4 more)
+        others: Vec<String>,
+        /// Currency: USD | HKD | CNY (default: USD)
+        #[arg(long, default_value = "USD")]
+        currency: String,
+    },
+
     /// Price alerts (list, add, delete)
     ///
     /// Without subcommand: lists all alerts.
@@ -1582,6 +1621,26 @@ impl IndustryRankSortType {
         match self {
             Self::Single => "0",
             Self::Multi => "1",
+        }
+    }
+}
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum StockEventSort {
+    #[value(name = "hot")]
+    Hot,
+    #[value(name = "time")]
+    Time,
+    #[value(name = "change")]
+    Change,
+}
+
+impl StockEventSort {
+    pub fn as_api_value(&self) -> u8 {
+        match self {
+            Self::Time   => 0,
+            Self::Change => 1,
+            Self::Hot    => 2,
         }
     }
 }
@@ -3286,6 +3345,12 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             symbol,
             count,
         } => quote::cmd_anomaly(&market, symbol, count, format, verbose).await,
+        Commands::StockEvents { market, sort, count } => {
+            quote::cmd_stock_events(market, sort.as_api_value(), count, format, verbose).await
+        }
+        Commands::Compare { base, others, currency } => {
+            fundamental::cmd_compare(base.as_str(), others.as_slice(), currency.as_str(), format, verbose).await
+        }
         Commands::Alert { symbol, cmd } => match cmd {
             Some(AlertCmd::Add {
                 symbol: s,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -981,7 +981,15 @@ pub enum Commands {
 
     /// Strategy screener — browse strategies, execute stock filters, view indicator config
     ///
-    /// Subcommands: strategies | search | indicators
+    /// Two workflows:
+    ///
+    /// Workflow A — use a saved strategy:
+    ///   1. `screener strategies` to list recommended strategies and get an ID
+    ///   2. `screener search --strategy-id <ID>` to run the strategy
+    ///
+    /// Workflow B — custom filter using indicator conditions:
+    ///   1. `screener indicators` to discover available indicator IDs and value ranges
+    ///   2. `screener search --market US` with custom conditions (see --help for details)
     ///
     /// Example: longbridge screener strategies
     /// Example: longbridge screener strategies --mine
@@ -1663,11 +1671,14 @@ impl IndustryRankSortType {
 
 #[derive(Subcommand)]
 pub enum ScreenerCmd {
-    /// List stock-selection strategies (recommended by default)
+    /// List stock-selection strategies and their filter conditions
     ///
-    /// --mine: user's saved strategies.
-    /// --all: all strategies (recommended + user).
-    /// --id N: single strategy's filter conditions.
+    /// Default: platform recommended strategies (use ID with `screener search`).
+    /// --mine:  your saved strategies.
+    /// --all:   all strategies (recommended + user).
+    /// --id N:  show the full filter conditions of a single strategy.
+    ///
+    /// The `id` field in the output is passed to `screener search --strategy-id`.
     ///
     /// Example: longbridge screener strategies
     /// Example: longbridge screener strategies --mine
@@ -1679,20 +1690,27 @@ pub enum ScreenerCmd {
         /// Show all strategies (recommended + user)
         #[arg(long)]
         all: bool,
-        /// Show filter conditions for a single strategy
+        /// Show the filter conditions of a single strategy by its ID
         #[arg(long, value_name = "ID")]
         id: Option<i64>,
     },
 
-    /// Execute a strategy or custom filter to find matching stocks
+    /// Find stocks matching a strategy or custom indicator conditions
+    ///
+    /// Mode A — strategy: pass --strategy-id from `screener strategies` output.
+    ///   The strategy's pre-configured conditions are applied automatically.
+    ///
+    /// Mode B — custom: omit --strategy-id and the server uses any indicator
+    ///   conditions you configure. Use `screener indicators` to discover
+    ///   available indicator IDs, keys, and valid value ranges.
     ///
     /// Example: longbridge screener search --strategy-id 42
-    /// Example: longbridge screener search --market US
+    /// Example: longbridge screener search --market HK
     Search {
-        /// Run a saved strategy by ID (from `screener strategies`)
+        /// Strategy ID from `screener strategies` output (Mode A)
         #[arg(long)]
         strategy_id: Option<i64>,
-        /// Market: US | HK | CN (default: US)
+        /// Market to search in: US | HK | CN (default: US)
         #[arg(long, default_value = "US")]
         market: String,
         /// Number of results (default: 20)
@@ -1700,11 +1718,15 @@ pub enum ScreenerCmd {
         count: u32,
     },
 
-    /// List all available filter indicators and their value ranges
+    /// List all available filter indicators with IDs, keys, and value ranges
+    ///
+    /// Use indicator IDs and keys to build custom conditions for `screener search`.
+    /// Each indicator shows: id, key (e.g. `filter_pettm`), name, unit,
+    /// default value range (min/max), and recommended range options.
     ///
     /// Example: longbridge screener indicators
     Indicators {
-        /// Optional symbol to get symbol-specific indicator values
+        /// Optional symbol — filter to indicators relevant for that symbol
         symbol: Option<String>,
     },
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -985,22 +985,19 @@ pub enum Commands {
         count: u32,
     },
 
-    /// Strategy screener — browse strategies, execute stock filters, view indicator config
+    /// Strategy screener — browse strategies, run filters, view indicator config
     ///
-    /// Two workflows:
+    /// Workflow A — run a saved strategy:
+    ///   1. `screener strategies` to list recommended strategies and note the ID
+    ///   2. `screener run <ID>` to execute it
     ///
-    /// Workflow A — use a saved strategy:
-    ///   1. `screener strategies` to list recommended strategies and get an ID
-    ///   2. `screener search --strategy-id <ID>` to run the strategy
-    ///
-    /// Workflow B — custom filter using indicator conditions:
-    ///   1. `screener indicators` to discover available indicator keys and value ranges
-    ///   2. `screener search --market HK --filter filter_marketcap:100:1000 --filter filter_divyld:3:`
+    /// Workflow B — custom filter:
+    ///   1. `screener indicators` to discover available keys and value ranges
+    ///   2. `screener filter KEY:MIN:MAX ... --market HK`
     ///
     /// Example: longbridge screener strategies
-    /// Example: longbridge screener strategies --mine
-    /// Example: longbridge screener search --strategy-id 42
-    /// Example: `longbridge screener search --market HK --filter filter_marketcap:100:1000 --filter filter_divyld:3:`
+    /// Example: longbridge screener run 42
+    /// Example: longbridge screener filter pettm:10:50 roe:5: --market HK
     /// Example: longbridge screener indicators
     Screener {
         #[command(subcommand)]
@@ -1718,31 +1715,32 @@ pub enum ScreenerCmd {
         all: bool,
     },
 
-    /// Find stocks matching a strategy or custom indicator conditions
+    /// Run a saved strategy by its ID (from `screener strategies` output)
     ///
-    /// Mode A — strategy: pass --strategy-id from `screener strategies` output.
-    ///   The strategy's pre-configured market and conditions are applied automatically.
-    ///   --market is ignored in Mode A — the strategy's built-in market takes precedence.
+    /// The strategy's built-in market and filter conditions are applied automatically.
     ///
-    /// Mode B — custom: use --filter key:min:max (repeatable) to specify conditions.
-    ///   Run `screener indicators` first to discover available keys, units, and ranges.
-    ///   Either bound can be empty: `filter_roe:10:` means ROE >= 10,
-    ///   `filter_pettm::50` means P/E <= 50. Units follow what `screener indicators` shows.
-    ///   --market is required in Mode B (default: US).
+    /// Example: longbridge screener run 42
+    Run {
+        /// Strategy ID from `screener strategies` output
+        id: i64,
+        /// Number of results (default: 20)
+        #[arg(long, alias = "limit", default_value = "20")]
+        count: u32,
+    },
+
+    /// Filter stocks with custom indicator conditions
     ///
-    /// Example: longbridge screener search --strategy-id 42
-    /// Example: `longbridge screener search --market HK --filter filter_marketcap:100:1000 --filter filter_divyld:3:`
-    Search {
-        /// Strategy ID from `screener strategies` output (Mode A)
-        #[arg(long)]
-        strategy_id: Option<i64>,
-        /// Filter condition: key:min:max (repeatable, Mode B).
-        /// Run `screener indicators` to get valid keys, units, and value ranges.
-        /// Omit either bound to leave it unbounded: `filter_roe:10:` (>= 10), `filter_pettm::50` (<= 50).
-        #[arg(long = "filter", value_name = "KEY:MIN:MAX")]
-        filters: Vec<String>,
-        /// Market to search in: US | HK | CN (default: US). Mode B only —
-        /// in Mode A the strategy's built-in market overrides this value.
+    /// Each condition is KEY:MIN:MAX. Omit either bound to leave it open:
+    ///   `pettm:10:` means P/E >= 10, `pettm::50` means P/E <= 50.
+    /// Run `screener indicators` to discover available keys and value ranges.
+    ///
+    /// Example: longbridge screener filter pettm:10:50 roe:5: --market HK
+    /// Example: longbridge screener filter marketcap:100: divyld:3: --market US
+    Filter {
+        /// Filter conditions in KEY:MIN:MAX format
+        #[arg(value_name = "KEY:MIN:MAX")]
+        conditions: Vec<String>,
+        /// Market: US | HK | CN (default: US)
         #[arg(long, default_value = "US")]
         market: String,
         /// Number of results (default: 20)
@@ -1750,15 +1748,15 @@ pub enum ScreenerCmd {
         count: u32,
     },
 
-    /// List all available filter indicators with IDs, keys, and value ranges
+    /// List all available filter indicators with keys and value ranges
     ///
-    /// Use indicator IDs and keys to build custom conditions for `screener search`.
-    /// Each indicator shows: id, key (e.g. `filter_pettm`), name, unit,
-    /// default value range (min/max), and recommended range options.
+    /// Use keys to build conditions for `screener filter` (without the `filter_` prefix).
     ///
     /// Example: longbridge screener indicators
+    /// Example: longbridge screener indicators --symbol AAPL.US
     Indicators {
-        /// Optional symbol — filter to indicators relevant for that symbol
+        /// Filter to indicators relevant for this symbol
+        #[arg(long)]
         symbol: Option<String>,
     },
 }
@@ -3496,8 +3494,11 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             ScreenerCmd::Strategies { mine, all } => {
                 screener::cmd_screener_strategies(mine, all, format, verbose).await
             }
-            ScreenerCmd::Search { strategy_id, filters, market, count } => {
-                screener::cmd_screener_search(strategy_id, filters.as_slice(), market.as_str(), count, format, verbose).await
+            ScreenerCmd::Run { id, count } => {
+                screener::cmd_screener_run(id, count, format, verbose).await
+            }
+            ScreenerCmd::Filter { conditions, market, count } => {
+                screener::cmd_screener_filter(conditions.as_slice(), market.as_str(), count, format, verbose).await
             }
             ScreenerCmd::Indicators { symbol } => {
                 screener::cmd_screener_indicators(symbol.clone(), format, verbose).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,8 +18,8 @@ pub mod news;
 pub mod output;
 pub mod quant_render;
 pub mod quote;
-pub mod screener;
 pub mod run_script;
+pub mod screener;
 pub mod search;
 pub mod sharelist;
 pub mod statement;
@@ -988,14 +988,13 @@ pub enum Commands {
     ///   2. `screener search --strategy-id <ID>` to run the strategy
     ///
     /// Workflow B — custom filter using indicator conditions:
-    ///   1. `screener indicators` to discover available indicator IDs and value ranges
-    ///   2. `screener search --market US` with custom conditions (see --help for details)
+    ///   1. `screener indicators` to discover available indicator keys and value ranges
+    ///   2. `screener search --market HK --filter filter_marketcap:100:1000 --filter filter_divyld:3:`
     ///
     /// Example: longbridge screener strategies
     /// Example: longbridge screener strategies --mine
-    /// Example: longbridge screener strategies --id 42
     /// Example: longbridge screener search --strategy-id 42
-    /// Example: longbridge screener search --market US
+    /// Example: `longbridge screener search --market HK --filter filter_marketcap:100:1000 --filter filter_divyld:3:`
     /// Example: longbridge screener indicators
     Screener {
         #[command(subcommand)]
@@ -1007,14 +1006,14 @@ pub enum Commands {
     /// Returns stocks ranked by a composite heat score combining trading activity,
     /// media coverage, community discussion, and price volatility.
     ///
-    /// Use `rank categories` to discover available tab keys, then pass a key to
-    /// list the corresponding ranking.
+    /// Run `rank` without --key to list all available tab keys (e.g. `ib_hot_all-us`).
+    /// Then pass a key to `--key` to get the corresponding ranking.
     ///
-    /// Example: longbridge rank categories
-    /// Example: longbridge rank --key hotness --market US
-    /// Example: longbridge rank --key trading --market HK --count 20
+    /// Example: longbridge rank
+    /// Example: longbridge rank --key ib_hot_all-us
+    /// Example: longbridge rank --key ib_trade_heat-hk --count 20
     Rank {
-        /// Ranking tab key (from `rank categories`). Omit to show categories.
+        /// Ranking tab key (from `rank` with no --key). Omit to list available keys.
         #[arg(long)]
         key: Option<String>,
         /// Market filter applied when listing (default: US)
@@ -1025,17 +1024,17 @@ pub enum Commands {
         count: u32,
     },
 
-    /// Multi-stock valuation comparison (PE, PB, PS, market cap, close price)
+    /// Multi-stock valuation comparison (price, market cap, PE/PB/PS, ROE, ROA, div yield, and more)
     ///
-    /// Compare 2–5 stocks side-by-side on valuation multiples.
-    /// The first symbol is the base; remaining symbols are compared against it.
+    /// Without extra symbols: shows the stock alongside server-selected industry peers.
+    /// With extra symbols: compares the specified stocks side by side.
     ///
-    /// Example: longbridge compare AAPL.US BABA.US JD.US
-    /// Example: longbridge compare 700.HK 9988.HK --currency HKD
+    /// Example: longbridge compare AAPL.US
+    /// Example: longbridge compare 9988.HK 700.HK 9999.HK --currency HKD
     Compare {
         /// Base symbol in <CODE>.<MARKET> format
-        base: String,
-        /// Additional symbols to compare (1–4 more)
+        symbol: String,
+        /// Additional symbols to compare (up to 4)
         others: Vec<String>,
         /// Currency: USD | HKD | CNY (default: USD)
         #[arg(long, default_value = "USD")]
@@ -1721,19 +1720,28 @@ pub enum ScreenerCmd {
     /// Find stocks matching a strategy or custom indicator conditions
     ///
     /// Mode A — strategy: pass --strategy-id from `screener strategies` output.
-    ///   The strategy's pre-configured conditions are applied automatically.
+    ///   The strategy's pre-configured market and conditions are applied automatically.
+    ///   --market is ignored in Mode A — the strategy's built-in market takes precedence.
     ///
-    /// Mode B — custom: omit --strategy-id and the server uses any indicator
-    ///   conditions you configure. Use `screener indicators` to discover
-    ///   available indicator IDs, keys, and valid value ranges.
+    /// Mode B — custom: use --filter key:min:max (repeatable) to specify conditions.
+    ///   Run `screener indicators` first to discover available keys, units, and ranges.
+    ///   Either bound can be empty: `filter_roe:10:` means ROE >= 10,
+    ///   `filter_pettm::50` means P/E <= 50. Units follow what `screener indicators` shows.
+    ///   --market is required in Mode B (default: US).
     ///
     /// Example: longbridge screener search --strategy-id 42
-    /// Example: longbridge screener search --market HK
+    /// Example: `longbridge screener search --market HK --filter filter_marketcap:100:1000 --filter filter_divyld:3:`
     Search {
         /// Strategy ID from `screener strategies` output (Mode A)
         #[arg(long)]
         strategy_id: Option<i64>,
-        /// Market to search in: US | HK | CN (default: US)
+        /// Filter condition: key:min:max (repeatable, Mode B).
+        /// Run `screener indicators` to get valid keys, units, and value ranges.
+        /// Omit either bound to leave it unbounded: `filter_roe:10:` (>= 10), `filter_pettm::50` (<= 50).
+        #[arg(long = "filter", value_name = "KEY:MIN:MAX")]
+        filters: Vec<String>,
+        /// Market to search in: US | HK | CN (default: US). Mode B only —
+        /// in Mode A the strategy's built-in market overrides this value.
         #[arg(long, default_value = "US")]
         market: String,
         /// Number of results (default: 20)
@@ -1767,9 +1775,9 @@ pub enum StockEventSort {
 impl StockEventSort {
     pub fn as_api_value(&self) -> u8 {
         match self {
-            Self::Time   => 0,
+            Self::Time => 0,
             Self::Change => 1,
-            Self::Hot    => 2,
+            Self::Hot => 2,
         }
     }
 }
@@ -3484,14 +3492,14 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             ScreenerCmd::Strategies { mine, all, id } => {
                 screener::cmd_screener_strategies(mine, all, id, format, verbose).await
             }
-            ScreenerCmd::Search { strategy_id, market, count } => {
-                screener::cmd_screener_search(strategy_id, market.as_str(), count, format, verbose).await
+            ScreenerCmd::Search { strategy_id, filters, market, count } => {
+                screener::cmd_screener_search(strategy_id, filters.as_slice(), market.as_str(), count, format, verbose).await
             }
             ScreenerCmd::Indicators { symbol } => {
                 screener::cmd_screener_indicators(symbol.clone(), format, verbose).await
             }
         },
-        Commands::Compare { base, others, currency } => {
+        Commands::Compare { symbol: base, others, currency } => {
             fundamental::cmd_compare(base.as_str(), others.as_slice(), currency.as_str(), format, verbose).await
         }
         Commands::Alert { symbol, cmd } => match cmd {

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -3001,7 +3001,7 @@ pub async fn cmd_short_positions(
     Ok(())
 }
 
-pub async fn cmd_stock_events(
+pub async fn cmd_top_movers(
     market: Option<String>,
     sort: u8,
     count: u32,
@@ -3038,7 +3038,11 @@ pub async fn cmd_stock_events(
                     let ts = val_str(&e["timestamp"]);
                     let code = val_str(&stock["code"]);
                     let mkt = val_str(&stock["market"]);
-                    let chg = val_str(&stock["change"]);
+                    let chg_raw = val_str(&stock["change"]);
+                    let chg = chg_raw
+                        .parse::<f64>()
+                        .map(|f| format!("{f:+.2}%"))
+                        .unwrap_or(chg_raw);
                     let reason = val_str(&e["alert_reason"]);
                     let tags = stock["labels"]
                         .as_array()

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2941,7 +2941,7 @@ pub async fn cmd_stock_events(
         "next_params": {},
         "date": "",
     });
-    let data = http_post("/newmarket/stock_events", body, verbose).await?;
+    let data = http_post("/v1/quote/market/stock-events", body, verbose).await?;
     match format {
         OutputFormat::Json => print_json(&data),
         OutputFormat::Pretty => {

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -3041,7 +3041,7 @@ pub async fn cmd_top_movers(
                     let chg_raw = val_str(&stock["change"]);
                     let chg = chg_raw
                         .parse::<f64>()
-                        .map(|f| format!("{f:+.2}%"))
+                        .map(|f| format!("{:+.2}%", f * 100.0))
                         .unwrap_or(chg_raw);
                     let reason = val_str(&e["alert_reason"]);
                     let tags = stock["labels"]

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2983,6 +2983,84 @@ pub async fn cmd_stock_events(
     Ok(())
 }
 
+
+pub async fn cmd_rank(
+    key: Option<String>,
+    market: &str,
+    count: u32,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    match key {
+        None => {
+            let data = http_get("/v1/quote/market/rank/categories", &[], verbose).await?;
+            match format {
+                OutputFormat::Json => print_json(&data),
+                OutputFormat::Pretty => {
+                    let tags = data.get("first_tags").and_then(|v| v.as_array());
+                    match tags {
+                        Some(a) if !a.is_empty() => {
+                            println!("Ranking Categories (use second-level key with --key)\n");
+                            let headers = ["key", "name", "sub-key", "market"];
+                            let mut rows: Vec<Vec<String>> = Vec::new();
+                            for tag in a {
+                                let k = val_str(&tag["key"]);
+                                let n = val_str(&tag["name"]);
+                                if let Some(subs) = tag["second_tags"].as_array() {
+                                    for sub in subs {
+                                        rows.push(vec![k.clone(), n.clone(),
+                                            val_str(&sub["key"]), val_str(&sub["market"])]);
+                                    }
+                                } else {
+                                    rows.push(vec![k, n, String::new(), String::new()]);
+                                }
+                            }
+                            print_table(&headers, rows, format);
+                        }
+                        _ => println!("No ranking categories found."),
+                    }
+                }
+            }
+        }
+        Some(k) => {
+            let count_str = count.to_string();
+            let data = http_get(
+                "/v1/quote/market/rank/list",
+                &[
+                    ("key", k.as_str()),
+                    ("delay_bmp", "false"),
+                    ("need_article", "true"),
+                    ("market", market),
+                    ("size", count_str.as_str()),
+                ],
+                verbose,
+            ).await?;
+            match format {
+                OutputFormat::Json => print_json(&data),
+                OutputFormat::Pretty => {
+                    let lists = match data.get("lists").and_then(|v| v.as_array()) {
+                        Some(a) if !a.is_empty() => a,
+                        _ => {
+                            println!("No ranking data found for key \'{k}\'.");
+                            return Ok(());
+                        }
+                    };
+                    println!("Ranking: {k} ({market})\n");
+                    let headers = ["rank", "symbol", "name", "price", "chg%", "pre/post", "pre/post chg%"];
+                    let rows: Vec<Vec<String>> = lists.iter().enumerate().map(|(i, s)| {
+                        let sym = crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"]));
+                        vec![(i + 1).to_string(), sym, val_str(&s["name"]),
+                             val_str(&s["last_done"]), val_str(&s["chg"]),
+                             val_str(&s["pre_post_price"]), val_str(&s["pre_post_chg"])]
+                    }).collect();
+                    print_table(&headers, rows, format);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2814,19 +2814,27 @@ pub async fn cmd_option_volume_daily(
 
 pub async fn cmd_short_positions(
     symbol: String,
+    trades: bool,
     count: u32,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
     let cid = symbol_to_counter_id(&symbol);
+    let is_hk = symbol.to_uppercase().ends_with(".HK");
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
         .to_string();
     let count_str = count.clamp(1, 100).to_string();
+    let path = match (is_hk, trades) {
+        (true, false)  => "/v1/quote/short-positions/hk",
+        (true, true)   => "/v1/quote/short-trades/hk",
+        (false, false) => "/v1/quote/short-positions/us",
+        (false, true)  => "/v1/quote/short-trades/us",
+    };
     let data = http_get(
-        "/v1/quote/short-positions/us",
+        path,
         &[
             ("counter_id", cid.as_str()),
             ("last_timestamp", now.as_str()),
@@ -2846,40 +2854,71 @@ pub async fn cmd_short_positions(
                 }
             };
             items.reverse();
-            println!("Short Selling Data — {symbol}\n");
-            let headers = [
-                "date",
-                "rate%",
-                "short_shares",
-                "avg_daily_vol",
-                "days_cover",
-                "close",
-            ];
-            let rows: Vec<Vec<String>> = items
-                .iter()
-                .map(|item| {
-                    let ts = val_str(&item["timestamp"]);
-                    let rate = val_str(&item["rate"])
-                        .parse::<f64>()
-                        .map_or_else(|_| val_str(&item["rate"]), |v| format!("{:.2}%", v * 100.0));
-                    let short_shares: i64 =
-                        val_str(&item["current_shares_short"]).parse().unwrap_or(0);
-                    let avg_vol: i64 = val_str(&item["avg_daily_share_volume"])
-                        .parse()
-                        .unwrap_or(0);
-                    let days = val_str(&item["days_to_cover"]);
-                    let close = val_str(&item["close"]);
-                    vec![
-                        fmt_ts(&ts),
-                        rate,
-                        format_with_commas(short_shares),
-                        format_with_commas(avg_vol),
-                        days,
-                        close,
-                    ]
-                })
-                .collect();
-            print_table(&headers, rows, format);
+            let label = if trades { "Short Trades" } else { "Short Positions" };
+            println!("{label} — {symbol}");
+            if let Some(ts) = data.get("update_timestamp").and_then(serde_json::Value::as_i64) {
+                println!("Updated: {}\n", fmt_ts(&ts.to_string()));
+            } else {
+                println!();
+            }
+            match (is_hk, trades) {
+                (false, false) => {
+                    // US positions: existing layout
+                    let headers = ["date", "rate%", "short_shares", "avg_daily_vol", "days_cover", "close"];
+                    let rows: Vec<Vec<String>> = items.iter().map(|item| {
+                        let ts = val_str(&item["timestamp"]);
+                        let rate = val_str(&item["rate"]).parse::<f64>()
+                            .map_or_else(|_| val_str(&item["rate"]), |v| format!("{:.2}%", v * 100.0));
+                        let short_shares: i64 = val_str(&item["current_shares_short"]).parse().unwrap_or(0);
+                        let avg_vol: i64 = val_str(&item["avg_daily_share_volume"]).parse().unwrap_or(0);
+                        vec![fmt_ts(&ts), rate, format_with_commas(short_shares),
+                             format_with_commas(avg_vol), val_str(&item["days_to_cover"]), val_str(&item["close"])]
+                    }).collect();
+                    print_table(&headers, rows, format);
+                }
+                (false, true) => {
+                    // US trades
+                    let headers = ["date", "nas_short", "ny_short", "total_vol", "rate%", "close"];
+                    let rows: Vec<Vec<String>> = items.iter().map(|item| {
+                        let ts = val_str(&item["timestamp"]);
+                        let rate = val_str(&item["rate"]).parse::<f64>()
+                            .map_or_else(|_| val_str(&item["rate"]), |v| format!("{:.2}%", v * 100.0));
+                        let nus: i64 = val_str(&item["nus_amount"]).parse().unwrap_or(0);
+                        let ny: i64  = val_str(&item["ny_amount"]).parse().unwrap_or(0);
+                        let tot: i64 = val_str(&item["total_amount"]).parse().unwrap_or(0);
+                        vec![fmt_ts(&ts), format_with_commas(nus), format_with_commas(ny),
+                             format_with_commas(tot), rate, val_str(&item["close"])]
+                    }).collect();
+                    print_table(&headers, rows, format);
+                }
+                (true, false) => {
+                    // HK positions
+                    let headers = ["date", "short_shares", "balance", "cost", "rate%"];
+                    let rows: Vec<Vec<String>> = items.iter().map(|item| {
+                        let ts = val_str(&item["timestamp"]);
+                        let rate = val_str(&item["rate"]).parse::<f64>()
+                            .map_or_else(|_| val_str(&item["rate"]), |v| format!("{:.2}%", v * 100.0));
+                        let amount: i64 = item["amount"].as_i64().unwrap_or(0);
+                        vec![fmt_ts(&ts), format_with_commas(amount),
+                             val_str(&item["balance"]), val_str(&item["cost"]), rate]
+                    }).collect();
+                    print_table(&headers, rows, format);
+                }
+                (true, true) => {
+                    // HK trades
+                    let headers = ["date", "short_shares", "balance", "total_vol", "rate%", "close"];
+                    let rows: Vec<Vec<String>> = items.iter().map(|item| {
+                        let ts = val_str(&item["timestamp"]);
+                        let rate = val_str(&item["rate"]).parse::<f64>()
+                            .map_or_else(|_| val_str(&item["rate"]), |v| format!("{:.2}%", v * 100.0));
+                        let amount: i64 = item["amount"].as_i64().unwrap_or(0);
+                        let total: i64  = item["total_amount"].as_i64().unwrap_or(0);
+                        vec![fmt_ts(&ts), format_with_commas(amount), val_str(&item["balance"]),
+                             format_with_commas(total), rate, val_str(&item["close"])]
+                    }).collect();
+                    print_table(&headers, rows, format);
+                }
+            }
         }
     }
     Ok(())

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -3054,7 +3054,15 @@ pub async fn cmd_top_movers(
                                 .join(", ")
                         })
                         .unwrap_or_default();
-                    vec![fmt_ts(&ts), symbol, chg, reason, tags]
+                    vec![
+                        ts.parse::<i64>()
+                            .map(crate::utils::datetime::format_timestamp)
+                            .unwrap_or(ts),
+                        symbol,
+                        chg,
+                        reason,
+                        tags,
+                    ]
                 })
                 .collect();
             print_table(&headers, rows, format);

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -8,7 +8,7 @@ use time::Date;
 use serde_json::Value;
 
 use super::{
-    api::{http_get, LbQuoteApi, QuoteApi},
+    api::{http_get, http_post, LbQuoteApi, QuoteApi},
     output::{
         fmt_date, fmt_datetime, fmt_dec, fmt_decimal, fmt_decimal_div100, fmt_decimal_div252,
         parse_date, print_table,
@@ -2919,6 +2919,65 @@ pub async fn cmd_short_positions(
                     print_table(&headers, rows, format);
                 }
             }
+        }
+    }
+    Ok(())
+}
+
+pub async fn cmd_stock_events(
+    market: Option<String>,
+    sort: u8,
+    count: u32,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    let markets: Vec<String> = market
+        .map(|m| vec![m.to_uppercase()])
+        .unwrap_or_default();
+    let body = serde_json::json!({
+        "limit": u64::from(count),
+        "sort": sort,
+        "markets": markets,
+        "next_params": {},
+        "date": "",
+    });
+    let data = http_post("/newmarket/stock_events", body, verbose).await?;
+    match format {
+        OutputFormat::Json => print_json(&data),
+        OutputFormat::Pretty => {
+            if let Some(ts) = data.get("updated_at").and_then(serde_json::Value::as_i64) {
+                println!("Updated: {}\n", fmt_ts(&ts.to_string()));
+            }
+            let events = match data.get("events").and_then(|v| v.as_array()) {
+                Some(a) if !a.is_empty() => a,
+                _ => {
+                    println!("No events found.");
+                    return Ok(());
+                }
+            };
+            let headers = ["time", "symbol", "market", "change%", "reason", "tags"];
+            let rows: Vec<Vec<String>> = events
+                .iter()
+                .map(|e| {
+                    let stock = &e["stock"];
+                    let ts = val_str(&e["timestamp"]);
+                    let code = val_str(&stock["code"]);
+                    let mkt  = val_str(&stock["market"]);
+                    let chg  = val_str(&stock["change"]);
+                    let reason = val_str(&e["alert_reason"]);
+                    let tags = stock["labels"]
+                        .as_array()
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|v| v.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        })
+                        .unwrap_or_default();
+                    vec![fmt_ts(&ts), code, mkt, chg, reason, tags]
+                })
+                .collect();
+            print_table(&headers, rows, format);
         }
     }
     Ok(())

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -3030,7 +3030,7 @@ pub async fn cmd_top_movers(
                     return Ok(());
                 }
             };
-            let headers = ["time", "symbol", "market", "change%", "reason", "tags"];
+            let headers = ["time", "symbol", "change%", "reason", "tags"];
             let rows: Vec<Vec<String>> = events
                 .iter()
                 .map(|e| {
@@ -3038,6 +3038,7 @@ pub async fn cmd_top_movers(
                     let ts = val_str(&e["timestamp"]);
                     let code = val_str(&stock["code"]);
                     let mkt = val_str(&stock["market"]);
+                    let symbol = format!("{code}.{mkt}");
                     let chg_raw = val_str(&stock["change"]);
                     let chg = chg_raw
                         .parse::<f64>()
@@ -3053,7 +3054,7 @@ pub async fn cmd_top_movers(
                                 .join(", ")
                         })
                         .unwrap_or_default();
-                    vec![fmt_ts(&ts), code, mkt, chg, reason, tags]
+                    vec![fmt_ts(&ts), symbol, chg, reason, tags]
                 })
                 .collect();
             print_table(&headers, rows, format);

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2828,10 +2828,10 @@ pub async fn cmd_short_positions(
         .to_string();
     let count_str = count.clamp(1, 100).to_string();
     let path = match (is_hk, trades) {
-        (true, false)  => "/v1/quote/short-positions/hk",
-        (true, true)   => "/v1/quote/short-trades/hk",
+        (true, false) => "/v1/quote/short-positions/hk",
+        (true, true) => "/v1/quote/short-trades/hk",
         (false, false) => "/v1/quote/short-positions/us",
-        (false, true)  => "/v1/quote/short-trades/us",
+        (false, true) => "/v1/quote/short-trades/us",
     };
     let data = http_get(
         path,
@@ -2854,9 +2854,16 @@ pub async fn cmd_short_positions(
                 }
             };
             items.reverse();
-            let label = if trades { "Short Trades" } else { "Short Positions" };
+            let label = if trades {
+                "Short Trades"
+            } else {
+                "Short Positions"
+            };
             println!("{label} — {symbol}");
-            if let Some(ts) = data.get("update_timestamp").and_then(serde_json::Value::as_i64) {
+            if let Some(ts) = data
+                .get("update_timestamp")
+                .and_then(serde_json::Value::as_i64)
+            {
                 println!("Updated: {}\n", fmt_ts(&ts.to_string()));
             } else {
                 println!();
@@ -2864,58 +2871,125 @@ pub async fn cmd_short_positions(
             match (is_hk, trades) {
                 (false, false) => {
                     // US positions: existing layout
-                    let headers = ["date", "rate%", "short_shares", "avg_daily_vol", "days_cover", "close"];
-                    let rows: Vec<Vec<String>> = items.iter().map(|item| {
-                        let ts = val_str(&item["timestamp"]);
-                        let rate = val_str(&item["rate"]).parse::<f64>()
-                            .map_or_else(|_| val_str(&item["rate"]), |v| format!("{:.2}%", v * 100.0));
-                        let short_shares: i64 = val_str(&item["current_shares_short"]).parse().unwrap_or(0);
-                        let avg_vol: i64 = val_str(&item["avg_daily_share_volume"]).parse().unwrap_or(0);
-                        vec![fmt_ts(&ts), rate, format_with_commas(short_shares),
-                             format_with_commas(avg_vol), val_str(&item["days_to_cover"]), val_str(&item["close"])]
-                    }).collect();
+                    let headers = [
+                        "date",
+                        "rate%",
+                        "short_shares",
+                        "avg_daily_vol",
+                        "days_cover",
+                        "close",
+                    ];
+                    let rows: Vec<Vec<String>> = items
+                        .iter()
+                        .map(|item| {
+                            let ts = val_str(&item["timestamp"]);
+                            let rate = val_str(&item["rate"]).parse::<f64>().map_or_else(
+                                |_| val_str(&item["rate"]),
+                                |v| format!("{:.2}%", v * 100.0),
+                            );
+                            let short_shares: i64 =
+                                val_str(&item["current_shares_short"]).parse().unwrap_or(0);
+                            let avg_vol: i64 = val_str(&item["avg_daily_share_volume"])
+                                .parse()
+                                .unwrap_or(0);
+                            vec![
+                                fmt_ts(&ts),
+                                rate,
+                                format_with_commas(short_shares),
+                                format_with_commas(avg_vol),
+                                val_str(&item["days_to_cover"]),
+                                val_str(&item["close"]),
+                            ]
+                        })
+                        .collect();
                     print_table(&headers, rows, format);
                 }
                 (false, true) => {
                     // US trades
-                    let headers = ["date", "nas_short", "ny_short", "total_vol", "rate%", "close"];
-                    let rows: Vec<Vec<String>> = items.iter().map(|item| {
-                        let ts = val_str(&item["timestamp"]);
-                        let rate = val_str(&item["rate"]).parse::<f64>()
-                            .map_or_else(|_| val_str(&item["rate"]), |v| format!("{:.2}%", v * 100.0));
-                        let nus: i64 = val_str(&item["nus_amount"]).parse().unwrap_or(0);
-                        let ny: i64  = val_str(&item["ny_amount"]).parse().unwrap_or(0);
-                        let tot: i64 = val_str(&item["total_amount"]).parse().unwrap_or(0);
-                        vec![fmt_ts(&ts), format_with_commas(nus), format_with_commas(ny),
-                             format_with_commas(tot), rate, val_str(&item["close"])]
-                    }).collect();
+                    let headers = [
+                        "date",
+                        "nas_short",
+                        "ny_short",
+                        "total_vol",
+                        "rate%",
+                        "close",
+                    ];
+                    let rows: Vec<Vec<String>> = items
+                        .iter()
+                        .map(|item| {
+                            let ts = val_str(&item["timestamp"]);
+                            let rate = val_str(&item["rate"]).parse::<f64>().map_or_else(
+                                |_| val_str(&item["rate"]),
+                                |v| format!("{:.2}%", v * 100.0),
+                            );
+                            let nus: i64 = val_str(&item["nus_amount"]).parse().unwrap_or(0);
+                            let ny: i64 = val_str(&item["ny_amount"]).parse().unwrap_or(0);
+                            let tot: i64 = val_str(&item["total_amount"]).parse().unwrap_or(0);
+                            vec![
+                                fmt_ts(&ts),
+                                format_with_commas(nus),
+                                format_with_commas(ny),
+                                format_with_commas(tot),
+                                rate,
+                                val_str(&item["close"]),
+                            ]
+                        })
+                        .collect();
                     print_table(&headers, rows, format);
                 }
                 (true, false) => {
                     // HK positions
                     let headers = ["date", "short_shares", "balance", "cost", "rate%"];
-                    let rows: Vec<Vec<String>> = items.iter().map(|item| {
-                        let ts = val_str(&item["timestamp"]);
-                        let rate = val_str(&item["rate"]).parse::<f64>()
-                            .map_or_else(|_| val_str(&item["rate"]), |v| format!("{:.2}%", v * 100.0));
-                        let amount: i64 = item["amount"].as_i64().unwrap_or(0);
-                        vec![fmt_ts(&ts), format_with_commas(amount),
-                             val_str(&item["balance"]), val_str(&item["cost"]), rate]
-                    }).collect();
+                    let rows: Vec<Vec<String>> = items
+                        .iter()
+                        .map(|item| {
+                            let ts = val_str(&item["timestamp"]);
+                            let rate = val_str(&item["rate"]).parse::<f64>().map_or_else(
+                                |_| val_str(&item["rate"]),
+                                |v| format!("{:.2}%", v * 100.0),
+                            );
+                            let amount: i64 = item["amount"].as_i64().unwrap_or(0);
+                            vec![
+                                fmt_ts(&ts),
+                                format_with_commas(amount),
+                                val_str(&item["balance"]),
+                                val_str(&item["cost"]),
+                                rate,
+                            ]
+                        })
+                        .collect();
                     print_table(&headers, rows, format);
                 }
                 (true, true) => {
                     // HK trades
-                    let headers = ["date", "short_shares", "balance", "total_vol", "rate%", "close"];
-                    let rows: Vec<Vec<String>> = items.iter().map(|item| {
-                        let ts = val_str(&item["timestamp"]);
-                        let rate = val_str(&item["rate"]).parse::<f64>()
-                            .map_or_else(|_| val_str(&item["rate"]), |v| format!("{:.2}%", v * 100.0));
-                        let amount: i64 = item["amount"].as_i64().unwrap_or(0);
-                        let total: i64  = item["total_amount"].as_i64().unwrap_or(0);
-                        vec![fmt_ts(&ts), format_with_commas(amount), val_str(&item["balance"]),
-                             format_with_commas(total), rate, val_str(&item["close"])]
-                    }).collect();
+                    let headers = [
+                        "date",
+                        "short_shares",
+                        "balance",
+                        "total_vol",
+                        "rate%",
+                        "close",
+                    ];
+                    let rows: Vec<Vec<String>> = items
+                        .iter()
+                        .map(|item| {
+                            let ts = val_str(&item["timestamp"]);
+                            let rate = val_str(&item["rate"]).parse::<f64>().map_or_else(
+                                |_| val_str(&item["rate"]),
+                                |v| format!("{:.2}%", v * 100.0),
+                            );
+                            let amount: i64 = item["amount"].as_i64().unwrap_or(0);
+                            let total: i64 = item["total_amount"].as_i64().unwrap_or(0);
+                            vec![
+                                fmt_ts(&ts),
+                                format_with_commas(amount),
+                                val_str(&item["balance"]),
+                                format_with_commas(total),
+                                rate,
+                                val_str(&item["close"]),
+                            ]
+                        })
+                        .collect();
                     print_table(&headers, rows, format);
                 }
             }
@@ -2931,9 +3005,7 @@ pub async fn cmd_stock_events(
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
-    let markets: Vec<String> = market
-        .map(|m| vec![m.to_uppercase()])
-        .unwrap_or_default();
+    let markets: Vec<String> = market.map(|m| vec![m.to_uppercase()]).unwrap_or_default();
     let body = serde_json::json!({
         "limit": u64::from(count),
         "sort": sort,
@@ -2962,8 +3034,8 @@ pub async fn cmd_stock_events(
                     let stock = &e["stock"];
                     let ts = val_str(&e["timestamp"]);
                     let code = val_str(&stock["code"]);
-                    let mkt  = val_str(&stock["market"]);
-                    let chg  = val_str(&stock["change"]);
+                    let mkt = val_str(&stock["market"]);
+                    let chg = val_str(&stock["change"]);
                     let reason = val_str(&e["alert_reason"]);
                     let tags = stock["labels"]
                         .as_array()
@@ -2982,7 +3054,6 @@ pub async fn cmd_stock_events(
     }
     Ok(())
 }
-
 
 pub async fn cmd_rank(
     key: Option<String>,
@@ -3008,8 +3079,12 @@ pub async fn cmd_rank(
                                 let n = val_str(&tag["name"]);
                                 if let Some(subs) = tag["second_tags"].as_array() {
                                     for sub in subs {
-                                        rows.push(vec![k.clone(), n.clone(),
-                                            val_str(&sub["key"]), val_str(&sub["market"])]);
+                                        rows.push(vec![
+                                            k.clone(),
+                                            n.clone(),
+                                            val_str(&sub["key"]),
+                                            val_str(&sub["market"]),
+                                        ]);
                                     }
                                 } else {
                                     rows.push(vec![k, n, String::new(), String::new()]);
@@ -3024,17 +3099,24 @@ pub async fn cmd_rank(
         }
         Some(k) => {
             let count_str = count.to_string();
+            // Derive market from key suffix (e.g. ib_hot_all-hk → HK); fall back to --market.
+            let key_market = k
+                .rsplit_once('-')
+                .map(|(_, m)| m.to_uppercase())
+                .filter(|m| matches!(m.as_str(), "US" | "HK" | "CN" | "SG"))
+                .unwrap_or_else(|| market.to_uppercase());
             let data = http_get(
                 "/v1/quote/market/rank/list",
                 &[
                     ("key", k.as_str()),
                     ("delay_bmp", "false"),
                     ("need_article", "true"),
-                    ("market", market),
+                    ("market", key_market.as_str()),
                     ("size", count_str.as_str()),
                 ],
                 verbose,
-            ).await?;
+            )
+            .await?;
             match format {
                 OutputFormat::Json => print_json(&data),
                 OutputFormat::Pretty => {
@@ -3045,14 +3127,34 @@ pub async fn cmd_rank(
                             return Ok(());
                         }
                     };
-                    println!("Ranking: {k} ({market})\n");
-                    let headers = ["rank", "symbol", "name", "price", "chg%", "pre/post", "pre/post chg%"];
-                    let rows: Vec<Vec<String>> = lists.iter().enumerate().map(|(i, s)| {
-                        let sym = crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"]));
-                        vec![(i + 1).to_string(), sym, val_str(&s["name"]),
-                             val_str(&s["last_done"]), val_str(&s["chg"]),
-                             val_str(&s["pre_post_price"]), val_str(&s["pre_post_chg"])]
-                    }).collect();
+                    println!("Ranking: {k} ({key_market})\n");
+                    let headers = [
+                        "rank",
+                        "symbol",
+                        "name",
+                        "price",
+                        "chg%",
+                        "pre/post",
+                        "pre/post chg%",
+                    ];
+                    let rows: Vec<Vec<String>> = lists
+                        .iter()
+                        .enumerate()
+                        .map(|(i, s)| {
+                            let sym = crate::utils::counter::counter_id_to_symbol(&val_str(
+                                &s["counter_id"],
+                            ));
+                            vec![
+                                (i + 1).to_string(),
+                                sym,
+                                val_str(&s["name"]),
+                                val_str(&s["last_done"]),
+                                val_str(&s["chg"]),
+                                val_str(&s["pre_post_price"]),
+                                val_str(&s["pre_post_chg"]),
+                            ]
+                        })
+                        .collect();
                     print_table(&headers, rows, format);
                 }
             }

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -16,6 +16,7 @@ use super::{
     OutputFormat,
 };
 use crate::utils::counter::symbol_to_counter_id;
+use crate::utils::number::format_financial_value;
 
 /// Return the locale-appropriate display name for a security.
 ///
@@ -2939,7 +2940,7 @@ pub async fn cmd_short_positions(
                 }
                 (true, false) => {
                     // HK positions
-                    let headers = ["date", "short_shares", "balance", "cost", "rate%"];
+                    let headers = ["date", "short_shares", "balance(HKD)", "cost", "rate%"];
                     let rows: Vec<Vec<String>> = items
                         .iter()
                         .map(|item| {
@@ -2948,11 +2949,12 @@ pub async fn cmd_short_positions(
                                 |_| val_str(&item["rate"]),
                                 |v| format!("{:.2}%", v * 100.0),
                             );
-                            let amount: i64 = item["amount"].as_i64().unwrap_or(0);
+                            let amount: i64 = val_str(&item["amount"]).parse().unwrap_or(0);
+                            let balance = format_financial_value(&val_str(&item["balance"]), false);
                             vec![
                                 fmt_ts(&ts),
                                 format_with_commas(amount),
-                                val_str(&item["balance"]),
+                                balance,
                                 val_str(&item["cost"]),
                                 rate,
                             ]
@@ -2965,7 +2967,7 @@ pub async fn cmd_short_positions(
                     let headers = [
                         "date",
                         "short_shares",
-                        "balance",
+                        "balance(HKD)",
                         "total_vol",
                         "rate%",
                         "close",
@@ -2978,12 +2980,13 @@ pub async fn cmd_short_positions(
                                 |_| val_str(&item["rate"]),
                                 |v| format!("{:.2}%", v * 100.0),
                             );
-                            let amount: i64 = item["amount"].as_i64().unwrap_or(0);
-                            let total: i64 = item["total_amount"].as_i64().unwrap_or(0);
+                            let amount: i64 = val_str(&item["amount"]).parse().unwrap_or(0);
+                            let total: i64 = val_str(&item["total_amount"]).parse().unwrap_or(0);
+                            let balance = format_financial_value(&val_str(&item["balance"]), false);
                             vec![
                                 fmt_ts(&ts),
                                 format_with_commas(amount),
-                                val_str(&item["balance"]),
+                                balance,
                                 format_with_commas(total),
                                 rate,
                                 val_str(&item["close"]),

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2939,7 +2939,7 @@ pub async fn cmd_short_positions(
                 }
                 (true, false) => {
                     // HK positions
-                    let headers = ["date", "short_shares", "balance(HKD)", "cost", "rate%"];
+                    let headers = ["date", "short_shares", "balance", "cost", "rate%"];
                     let rows: Vec<Vec<String>> = items
                         .iter()
                         .map(|item| {
@@ -2948,12 +2948,11 @@ pub async fn cmd_short_positions(
                                 |_| val_str(&item["rate"]),
                                 |v| format!("{:.2}%", v * 100.0),
                             );
-                            let amount: i64 = val_str(&item["amount"]).parse().unwrap_or(0);
-                            let balance: i64 = val_str(&item["balance"]).parse().unwrap_or(0);
+                            let amount: i64 = item["amount"].as_i64().unwrap_or(0);
                             vec![
                                 fmt_ts(&ts),
                                 format_with_commas(amount),
-                                format_with_commas(balance),
+                                val_str(&item["balance"]),
                                 val_str(&item["cost"]),
                                 rate,
                             ]
@@ -2966,7 +2965,7 @@ pub async fn cmd_short_positions(
                     let headers = [
                         "date",
                         "short_shares",
-                        "balance(HKD)",
+                        "balance",
                         "total_vol",
                         "rate%",
                         "close",
@@ -2979,16 +2978,12 @@ pub async fn cmd_short_positions(
                                 |_| val_str(&item["rate"]),
                                 |v| format!("{:.2}%", v * 100.0),
                             );
-                            let amount: i64 = val_str(&item["amount"]).parse().unwrap_or(0);
-                            let balance: i64 = val_str(&item["balance"])
-                                .parse::<f64>()
-                                .map(|f| f as i64)
-                                .unwrap_or(0);
-                            let total: i64 = val_str(&item["total_amount"]).parse().unwrap_or(0);
+                            let amount: i64 = item["amount"].as_i64().unwrap_or(0);
+                            let total: i64 = item["total_amount"].as_i64().unwrap_or(0);
                             vec![
                                 fmt_ts(&ts),
                                 format_with_commas(amount),
-                                format_with_commas(balance),
+                                val_str(&item["balance"]),
                                 format_with_commas(total),
                                 rate,
                                 val_str(&item["close"]),

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2939,7 +2939,7 @@ pub async fn cmd_short_positions(
                 }
                 (true, false) => {
                     // HK positions
-                    let headers = ["date", "short_shares", "balance", "cost", "rate%"];
+                    let headers = ["date", "short_shares", "balance(HKD)", "cost", "rate%"];
                     let rows: Vec<Vec<String>> = items
                         .iter()
                         .map(|item| {
@@ -2948,11 +2948,12 @@ pub async fn cmd_short_positions(
                                 |_| val_str(&item["rate"]),
                                 |v| format!("{:.2}%", v * 100.0),
                             );
-                            let amount: i64 = item["amount"].as_i64().unwrap_or(0);
+                            let amount: i64 = val_str(&item["amount"]).parse().unwrap_or(0);
+                            let balance: i64 = val_str(&item["balance"]).parse().unwrap_or(0);
                             vec![
                                 fmt_ts(&ts),
                                 format_with_commas(amount),
-                                val_str(&item["balance"]),
+                                format_with_commas(balance),
                                 val_str(&item["cost"]),
                                 rate,
                             ]
@@ -2965,7 +2966,7 @@ pub async fn cmd_short_positions(
                     let headers = [
                         "date",
                         "short_shares",
-                        "balance",
+                        "balance(HKD)",
                         "total_vol",
                         "rate%",
                         "close",
@@ -2978,12 +2979,16 @@ pub async fn cmd_short_positions(
                                 |_| val_str(&item["rate"]),
                                 |v| format!("{:.2}%", v * 100.0),
                             );
-                            let amount: i64 = item["amount"].as_i64().unwrap_or(0);
-                            let total: i64 = item["total_amount"].as_i64().unwrap_or(0);
+                            let amount: i64 = val_str(&item["amount"]).parse().unwrap_or(0);
+                            let balance: i64 = val_str(&item["balance"])
+                                .parse::<f64>()
+                                .map(|f| f as i64)
+                                .unwrap_or(0);
+                            let total: i64 = val_str(&item["total_amount"]).parse().unwrap_or(0);
                             vec![
                                 fmt_ts(&ts),
                                 format_with_commas(amount),
-                                val_str(&item["balance"]),
+                                format_with_commas(balance),
                                 format_with_commas(total),
                                 rate,
                                 val_str(&item["close"]),

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -1,0 +1,188 @@
+use anyhow::Result;
+use serde_json::Value;
+
+use super::{api::http_get, api::http_post, output::print_table, OutputFormat};
+use crate::utils::counter::symbol_to_counter_id;
+
+fn val_str(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Null => "-".to_string(),
+        other => other.to_string(),
+    }
+}
+
+pub async fn cmd_screener_strategies(
+    mine: bool,
+    all: bool,
+    id: Option<i64>,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    if let Some(sid) = id {
+        let sid_str = sid.to_string();
+        let data = http_get(
+            "/calc/filter/strategy",
+            &[("id", sid_str.as_str())],
+            verbose,
+        )
+        .await?;
+        match format {
+            OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&data).unwrap_or_default()),
+            OutputFormat::Pretty => {
+                let name = val_str(&data["name"]);
+                println!("Strategy #{sid} — {name}\n");
+                if let Some(groups) = data["groups"].as_array() {
+                    for group in groups {
+                        let gname = val_str(&group["group_name"]);
+                        println!("  {gname}");
+                        if let Some(indicators) = group["indicators"].as_array() {
+                            let headers = ["id", "key", "name", "unit", "description"];
+                            let rows: Vec<Vec<String>> = indicators.iter().map(|ind| {
+                                vec![
+                                    val_str(&ind["id"]),
+                                    val_str(&ind["key"]),
+                                    val_str(&ind["name"]),
+                                    val_str(&ind["unit"]),
+                                    val_str(&ind["description"]),
+                                ]
+                            }).collect();
+                            print_table(&headers, rows, format);
+                        }
+                        println!();
+                    }
+                }
+            }
+        }
+        return Ok(());
+    }
+
+    let path = if mine {
+        "/calc/filter/user/strategy"
+    } else if all {
+        "/calc/filter/all/strategy"
+    } else {
+        "/calc/filter/recommend/strategy"
+    };
+
+    let data = http_get(path, &[], verbose).await?;
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&data).unwrap_or_default()),
+        OutputFormat::Pretty => {
+            let screeners = match data.get("screeners").and_then(|v| v.as_array()) {
+                Some(a) if !a.is_empty() => a,
+                _ => {
+                    println!("No strategies found.");
+                    return Ok(());
+                }
+            };
+            let label = if mine { "My Strategies" } else if all { "All Strategies" } else { "Recommended Strategies" };
+            println!("{label}\n");
+            let headers = ["ID", "Name", "Avg Day Chg", "Type"];
+            let rows: Vec<Vec<String>> = screeners.iter().map(|s| {
+                let type_str = match s["type"].as_i64() {
+                    Some(1) => "User",
+                    _ => "Platform",
+                };
+                vec![
+                    val_str(&s["id"]),
+                    val_str(&s["name"]),
+                    val_str(&s["average_day_chg"]),
+                    type_str.to_string(),
+                ]
+            }).collect();
+            print_table(&headers, rows, format);
+        }
+    }
+    Ok(())
+}
+
+pub async fn cmd_screener_search(
+    strategy_id: Option<i64>,
+    market: &str,
+    count: u32,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    let mut body = serde_json::json!({
+        "market": market.to_uppercase(),
+        "page": 1,
+        "size": count,
+    });
+    if let Some(sid) = strategy_id {
+        body["id"] = serde_json::json!(sid.to_string());
+    }
+    let data = http_post("/calc/filter/search", body, verbose).await?;
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&data).unwrap_or_default()),
+        OutputFormat::Pretty => {
+            let total = data["total"].as_i64().unwrap_or(0);
+            let strategy_label = strategy_id
+                .map_or_else(|| format!("Custom filter ({market})"), |id| format!("Strategy #{id}"));
+            println!("{strategy_label} — {total} stocks found\n");
+            let stocks = match data.get("stocks").and_then(|v| v.as_array()) {
+                Some(a) if !a.is_empty() => a,
+                _ => {
+                    println!("No stocks found matching the criteria.");
+                    return Ok(());
+                }
+            };
+            let headers = ["Symbol", "Name"];
+            let rows: Vec<Vec<String>> = stocks.iter().map(|s| {
+                let cid = val_str(&s["counter_id"]);
+                let sym = crate::utils::counter::counter_id_to_symbol(&cid);
+                vec![sym, val_str(&s["name"])]
+            }).collect();
+            print_table(&headers, rows, format);
+        }
+    }
+    Ok(())
+}
+
+pub async fn cmd_screener_indicators(
+    symbol: Option<String>,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    let mut params: Vec<(&str, &str)> = vec![];
+    let cid;
+    if let Some(ref sym) = symbol {
+        cid = symbol_to_counter_id(sym);
+        params.push(("counter_id", cid.as_str()));
+    }
+    let data = http_get("/calc/filter/indicator/config", &params, verbose).await?;
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&data).unwrap_or_default()),
+        OutputFormat::Pretty => {
+            let groups = match data.get("groups").and_then(|v| v.as_array()) {
+                Some(a) if !a.is_empty() => a,
+                _ => {
+                    println!("No indicator config found.");
+                    return Ok(());
+                }
+            };
+            for group in groups {
+                let gname = val_str(&group["group_name"]);
+                println!("── {gname} ──");
+                if let Some(indicators) = group["indicators"].as_array() {
+                    let headers = ["ID", "Key", "Name", "Unit", "Min", "Max"];
+                    let rows: Vec<Vec<String>> = indicators.iter().map(|ind| {
+                        let min = val_str(&ind["default_range"]["min"]);
+                        let max = val_str(&ind["default_range"]["max"]);
+                        vec![
+                            val_str(&ind["id"]),
+                            val_str(&ind["key"]),
+                            val_str(&ind["name"]),
+                            val_str(&ind["unit"]),
+                            min,
+                            max,
+                        ]
+                    }).collect();
+                    print_table(&headers, rows, format);
+                }
+                println!();
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -15,54 +15,9 @@ fn val_str(v: &Value) -> String {
 pub async fn cmd_screener_strategies(
     mine: bool,
     all: bool,
-    id: Option<i64>,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
-    if let Some(sid) = id {
-        let sid_str = sid.to_string();
-        let data = http_get(
-            "/v1/quote/screener/strategy",
-            &[("id", sid_str.as_str())],
-            verbose,
-        )
-        .await?;
-        match format {
-            OutputFormat::Json => println!(
-                "{}",
-                serde_json::to_string_pretty(&data).unwrap_or_default()
-            ),
-            OutputFormat::Pretty => {
-                let name = val_str(&data["name"]);
-                println!("Strategy #{sid} — {name}\n");
-                if let Some(groups) = data["groups"].as_array() {
-                    for group in groups {
-                        let gname = val_str(&group["group_name"]);
-                        println!("  {gname}");
-                        if let Some(indicators) = group["indicators"].as_array() {
-                            let headers = ["id", "key", "name", "unit", "description"];
-                            let rows: Vec<Vec<String>> = indicators
-                                .iter()
-                                .map(|ind| {
-                                    vec![
-                                        val_str(&ind["id"]),
-                                        val_str(&ind["key"]),
-                                        val_str(&ind["name"]),
-                                        val_str(&ind["unit"]),
-                                        val_str(&ind["description"]),
-                                    ]
-                                })
-                                .collect();
-                            print_table(&headers, rows, format);
-                        }
-                        println!();
-                    }
-                }
-            }
-        }
-        return Ok(());
-    }
-
     let path = if mine {
         "/v1/quote/screener/strategies/mine"
     } else if all {

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -22,7 +22,7 @@ pub async fn cmd_screener_strategies(
     if let Some(sid) = id {
         let sid_str = sid.to_string();
         let data = http_get(
-            "/calc/filter/strategy",
+            "/v1/quote/screener/strategy",
             &[("id", sid_str.as_str())],
             verbose,
         )
@@ -58,11 +58,11 @@ pub async fn cmd_screener_strategies(
     }
 
     let path = if mine {
-        "/calc/filter/user/strategy"
+        "/v1/quote/screener/strategies/mine"
     } else if all {
-        "/calc/filter/all/strategy"
+        "/v1/quote/screener/strategies"
     } else {
-        "/calc/filter/recommend/strategy"
+        "/v1/quote/screener/strategies/recommend"
     };
 
     let data = http_get(path, &[], verbose).await?;
@@ -112,7 +112,7 @@ pub async fn cmd_screener_search(
     if let Some(sid) = strategy_id {
         body["id"] = serde_json::json!(sid.to_string());
     }
-    let data = http_post("/calc/filter/search", body, verbose).await?;
+    let data = http_post("/v1/quote/screener/search", body, verbose).await?;
     match format {
         OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&data).unwrap_or_default()),
         OutputFormat::Pretty => {
@@ -150,7 +150,7 @@ pub async fn cmd_screener_indicators(
         cid = symbol_to_counter_id(sym);
         params.push(("counter_id", cid.as_str()));
     }
-    let data = http_get("/calc/filter/indicator/config", &params, verbose).await?;
+    let data = http_get("/v1/quote/screener/indicators", &params, verbose).await?;
     match format {
         OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&data).unwrap_or_default()),
         OutputFormat::Pretty => {

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -211,9 +211,15 @@ async fn print_screener_results(
     verbose: bool,
 ) -> Result<()> {
     let sort_key = sort.map(normalize_key);
+    let mut effective_returns = returns.to_vec();
+    if let Some(ref k) = sort_key {
+        if !effective_returns.contains(k) {
+            effective_returns.push(k.clone());
+        }
+    }
     let sort_by = sort_key
         .as_deref()
-        .and_then(|k| returns.iter().position(|r| r == k))
+        .and_then(|k| effective_returns.iter().position(|r| r == k))
         .unwrap_or(0);
     let sort_order: u8 = u8::from(order != "asc");
     let body = serde_json::json!({
@@ -221,7 +227,7 @@ async fn print_screener_results(
         "page": 1,
         "size": count,
         "filters": filters,
-        "returns": returns,
+        "returns": effective_returns,
         "sort_by": sort_by,
         "sort_order": sort_order,
         "industries": [],
@@ -256,7 +262,7 @@ async fn print_screener_results(
             };
             let mut headers = vec!["Symbol".to_string(), "Name".to_string()];
             headers.extend(
-                returns
+                effective_returns
                     .iter()
                     .map(|k| k.replace("filter_", "").to_uppercase()),
             );
@@ -270,6 +276,9 @@ async fn print_screener_results(
                     if let Some(indicators) = s["indicators"].as_array() {
                         row.extend(indicators.iter().map(|ind| {
                             let v = val_str(&ind["value"]);
+                            if v.is_empty() || v == "-" {
+                                return "-".to_string();
+                            }
                             let unit = val_str(&ind["unit"]);
                             let (display_v, display_unit) = match unit.as_str() {
                                 "亿" => (

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -220,7 +220,12 @@ async fn print_screener_results(
                 }
             };
             let mut headers = vec!["Symbol".to_string(), "Name".to_string()];
-            headers.extend(returns.iter().take(5).map(|k| k.replace("filter_", "")));
+            headers.extend(
+                returns
+                    .iter()
+                    .take(5)
+                    .map(|k| k.replace("filter_", "").to_uppercase()),
+            );
             let header_refs: Vec<&str> = headers.iter().map(String::as_str).collect();
             let rows: Vec<Vec<String>> = stocks
                 .iter()

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -253,12 +253,16 @@ pub async fn cmd_screener_search(
                         row.extend(indicators.iter().take(5).map(|ind| {
                             let v = val_str(&ind["value"]);
                             let unit = val_str(&ind["unit"]);
-                            let display_v = if unit == "亿" {
-                                v.parse::<f64>()
+                            let display_v = match unit.as_str() {
+                                "亿" => v
+                                    .parse::<f64>()
                                     .map(|f| format!("{:.2}", f / 1e8))
-                                    .unwrap_or(v)
-                            } else {
-                                v
+                                    .unwrap_or(v),
+                                "万" => v
+                                    .parse::<f64>()
+                                    .map(|f| format!("{:.2}", f / 1e4))
+                                    .unwrap_or(v),
+                                _ => v,
                             };
                             if unit.is_empty() || unit == "-" {
                                 display_v

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -70,95 +70,119 @@ pub async fn cmd_screener_strategies(
     Ok(())
 }
 
-pub async fn cmd_screener_search(
-    strategy_id: Option<i64>,
-    filter_args: &[String],
-    market: &str,
+pub async fn cmd_screener_run(
+    id: i64,
     count: u32,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
-    // When a strategy ID is given, fetch recommend list to get its groups (no extra request needed).
-    let (mkt, filters, returns) = if let Some(sid) = strategy_id {
-        let strategies = http_get("/v1/quote/screener/strategies/recommend", &[], verbose).await?;
-        // Also try user strategies if not found in recommend
-        let strategy_obj = strategies["screeners"]
-            .as_array()
-            .and_then(|arr| arr.iter().find(|s| s["id"].as_i64() == Some(sid)))
-            .cloned()
-            .unwrap_or(serde_json::Value::Null);
-        // Fall back to fetching by ID if not in list
-        let strategy = if strategy_obj.is_null() {
-            let sid_str = sid.to_string();
-            http_get(
-                "/v1/quote/screener/strategy",
-                &[("id", sid_str.as_str())],
-                verbose,
-            )
-            .await?
-        } else {
-            strategy_obj
-        };
-        let mut mkt = market.to_uppercase();
-        let mut filters: Vec<serde_json::Value> = Vec::new();
-        let mut returns: Vec<String> = Vec::new();
-        if let Some(groups) = strategy["groups"].as_array() {
-            for group in groups {
-                if let Some(indicators) = group["indicators"].as_array() {
-                    for ind in indicators {
-                        let key = val_str(&ind["key"]);
-                        let id = ind["id"].as_i64().unwrap_or(0);
-                        if id == -1 && key == "filter_market" {
-                            // Market indicator — extract market value
-                            let v = val_str(&ind["value"]);
-                            if !v.is_empty() && v != "-" {
-                                mkt = v;
-                            }
-                        } else {
-                            let min = val_str(&ind["min"]);
-                            let max = val_str(&ind["max"]);
-                            let has_range =
-                                (!min.is_empty() && min != "-") || (!max.is_empty() && max != "-");
-                            if has_range || id > 0 {
-                                filters.push(serde_json::json!({
-                                    "key": key,
-                                    "min": min,
-                                    "max": max,
-                                    "tech_values": {}
-                                }));
-                                returns.push(key);
-                            }
+    let strategies = http_get("/v1/quote/screener/strategies/recommend", &[], verbose).await?;
+    let strategy_obj = strategies["screeners"]
+        .as_array()
+        .and_then(|arr| arr.iter().find(|s| s["id"].as_i64() == Some(id)))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let strategy = if strategy_obj.is_null() {
+        let id_str = id.to_string();
+        http_get(
+            "/v1/quote/screener/strategy",
+            &[("id", id_str.as_str())],
+            verbose,
+        )
+        .await?
+    } else {
+        strategy_obj
+    };
+
+    let mut mkt = "US".to_string();
+    let mut filters: Vec<serde_json::Value> = Vec::new();
+    let mut returns: Vec<String> = Vec::new();
+    if let Some(groups) = strategy["groups"].as_array() {
+        for group in groups {
+            if let Some(indicators) = group["indicators"].as_array() {
+                for ind in indicators {
+                    let key = val_str(&ind["key"]);
+                    let ind_id = ind["id"].as_i64().unwrap_or(0);
+                    if ind_id == -1 && key == "filter_market" {
+                        let v = val_str(&ind["value"]);
+                        if !v.is_empty() && v != "-" {
+                            mkt = v;
+                        }
+                    } else {
+                        let min = val_str(&ind["min"]);
+                        let max = val_str(&ind["max"]);
+                        let has_range =
+                            (!min.is_empty() && min != "-") || (!max.is_empty() && max != "-");
+                        if has_range || ind_id > 0 {
+                            filters.push(serde_json::json!({
+                                "key": key,
+                                "min": min,
+                                "max": max,
+                                "tech_values": {}
+                            }));
+                            returns.push(key);
                         }
                     }
                 }
             }
         }
-        (mkt, filters, returns)
-    } else {
-        // Mode B: parse --filter key:min:max args
-        let mut filters: Vec<serde_json::Value> = Vec::new();
-        let mut returns: Vec<String> = Vec::new();
-        for arg in filter_args {
-            let parts: Vec<&str> = arg.splitn(3, ':').collect();
-            let key = parts.first().copied().unwrap_or("").to_string();
-            let min = parts.get(1).copied().unwrap_or("").to_string();
-            let max = parts.get(2).copied().unwrap_or("").to_string();
-            if key.is_empty() {
-                continue;
-            }
-            filters.push(serde_json::json!({
-                "key": key,
-                "min": min,
-                "max": max,
-                "tech_values": {}
-            }));
-            returns.push(key);
-        }
-        (market.to_uppercase(), filters, returns)
-    };
+    }
+    print_screener_results(id, &mkt, &filters, &returns, count, format, verbose).await
+}
 
+pub async fn cmd_screener_filter(
+    conditions: &[String],
+    market: &str,
+    count: u32,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
+    let mut filters: Vec<serde_json::Value> = Vec::new();
+    let mut returns: Vec<String> = Vec::new();
+    for cond in conditions {
+        let parts: Vec<&str> = cond.splitn(3, ':').collect();
+        let raw_key = parts.first().copied().unwrap_or("");
+        if raw_key.is_empty() {
+            continue;
+        }
+        let key = if raw_key.starts_with("filter_") {
+            raw_key.to_string()
+        } else {
+            format!("filter_{raw_key}")
+        };
+        let min = parts.get(1).copied().unwrap_or("").to_string();
+        let max = parts.get(2).copied().unwrap_or("").to_string();
+        filters.push(serde_json::json!({
+            "key": key,
+            "min": min,
+            "max": max,
+            "tech_values": {}
+        }));
+        returns.push(key);
+    }
+    print_screener_results(
+        0,
+        &market.to_uppercase(),
+        &filters,
+        &returns,
+        count,
+        format,
+        verbose,
+    )
+    .await
+}
+
+async fn print_screener_results(
+    strategy_id: i64,
+    market: &str,
+    filters: &[serde_json::Value],
+    returns: &[String],
+    count: u32,
+    format: &OutputFormat,
+    verbose: bool,
+) -> Result<()> {
     let body = serde_json::json!({
-        "market": mkt,
+        "market": market,
         "page": 1,
         "size": count,
         "filters": filters,
@@ -182,10 +206,11 @@ pub async fn cmd_screener_search(
                         .as_array()
                         .map_or(0, |a| i64::try_from(a.len()).unwrap_or(0))
                 });
-            let label = strategy_id.map_or_else(
-                || format!("Custom filter ({mkt})"),
-                |id| format!("Strategy #{id} ({mkt})"),
-            );
+            let label = if strategy_id > 0 {
+                format!("Strategy #{strategy_id} ({market})")
+            } else {
+                format!("Custom filter ({market})")
+            };
             println!("{label} — {total} stocks found\n");
             let stocks = match data.get("items").and_then(|v| v.as_array()) {
                 Some(a) if !a.is_empty() => a,
@@ -194,7 +219,6 @@ pub async fn cmd_screener_search(
                     return Ok(());
                 }
             };
-            // Build column headers from returns keys
             let mut headers = vec!["Symbol".to_string(), "Name".to_string()];
             headers.extend(returns.iter().take(5).map(|k| k.replace("filter_", "")));
             let header_refs: Vec<&str> = headers.iter().map(String::as_str).collect();

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -253,21 +253,29 @@ pub async fn cmd_screener_search(
                         row.extend(indicators.iter().take(5).map(|ind| {
                             let v = val_str(&ind["value"]);
                             let unit = val_str(&ind["unit"]);
-                            let display_v = match unit.as_str() {
-                                "亿" => v
-                                    .parse::<f64>()
-                                    .map(|f| format!("{:.2}", f / 1e8))
-                                    .unwrap_or(v),
+                            let (display_v, display_unit) = match unit.as_str() {
+                                "亿" => (
+                                    v.parse::<f64>()
+                                        .map(|f| format!("{:.2}", f / 1e8))
+                                        .unwrap_or(v),
+                                    "亿".to_string(),
+                                ),
                                 "万" => v
                                     .parse::<f64>()
-                                    .map(|f| format!("{:.2}", f / 1e4))
-                                    .unwrap_or(v),
-                                _ => v,
+                                    .map(|f| {
+                                        if f >= 1e8 {
+                                            (format!("{:.2}", f / 1e8), "亿".to_string())
+                                        } else {
+                                            (format!("{:.2}", f / 1e4), "万".to_string())
+                                        }
+                                    })
+                                    .unwrap_or((v, unit)),
+                                _ => (v, unit),
                             };
-                            if unit.is_empty() || unit == "-" {
+                            if display_unit.is_empty() || display_unit == "-" {
                                 display_v
                             } else {
-                                format!("{display_v} {unit}")
+                                format!("{display_v} {display_unit}")
                             }
                         }));
                     }

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -253,10 +253,17 @@ pub async fn cmd_screener_search(
                         row.extend(indicators.iter().take(5).map(|ind| {
                             let v = val_str(&ind["value"]);
                             let unit = val_str(&ind["unit"]);
-                            if unit.is_empty() || unit == "-" {
-                                v
+                            let display_v = if unit == "亿" {
+                                v.parse::<f64>()
+                                    .map(|f| format!("{:.2}", f / 1e8))
+                                    .unwrap_or(v)
                             } else {
-                                format!("{v} {unit}")
+                                v
+                            };
+                            if unit.is_empty() || unit == "-" {
+                                display_v
+                            } else {
+                                format!("{display_v} {unit}")
                             }
                         }));
                     }

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -28,7 +28,10 @@ pub async fn cmd_screener_strategies(
         )
         .await?;
         match format {
-            OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&data).unwrap_or_default()),
+            OutputFormat::Json => println!(
+                "{}",
+                serde_json::to_string_pretty(&data).unwrap_or_default()
+            ),
             OutputFormat::Pretty => {
                 let name = val_str(&data["name"]);
                 println!("Strategy #{sid} — {name}\n");
@@ -38,15 +41,18 @@ pub async fn cmd_screener_strategies(
                         println!("  {gname}");
                         if let Some(indicators) = group["indicators"].as_array() {
                             let headers = ["id", "key", "name", "unit", "description"];
-                            let rows: Vec<Vec<String>> = indicators.iter().map(|ind| {
-                                vec![
-                                    val_str(&ind["id"]),
-                                    val_str(&ind["key"]),
-                                    val_str(&ind["name"]),
-                                    val_str(&ind["unit"]),
-                                    val_str(&ind["description"]),
-                                ]
-                            }).collect();
+                            let rows: Vec<Vec<String>> = indicators
+                                .iter()
+                                .map(|ind| {
+                                    vec![
+                                        val_str(&ind["id"]),
+                                        val_str(&ind["key"]),
+                                        val_str(&ind["name"]),
+                                        val_str(&ind["unit"]),
+                                        val_str(&ind["description"]),
+                                    ]
+                                })
+                                .collect();
                             print_table(&headers, rows, format);
                         }
                         println!();
@@ -67,7 +73,10 @@ pub async fn cmd_screener_strategies(
 
     let data = http_get(path, &[], verbose).await?;
     match format {
-        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&data).unwrap_or_default()),
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&data).unwrap_or_default()
+        ),
         OutputFormat::Pretty => {
             let screeners = match data.get("screeners").and_then(|v| v.as_array()) {
                 Some(a) if !a.is_empty() => a,
@@ -76,21 +85,30 @@ pub async fn cmd_screener_strategies(
                     return Ok(());
                 }
             };
-            let label = if mine { "My Strategies" } else if all { "All Strategies" } else { "Recommended Strategies" };
+            let label = if mine {
+                "My Strategies"
+            } else if all {
+                "All Strategies"
+            } else {
+                "Recommended Strategies"
+            };
             println!("{label}\n");
             let headers = ["ID", "Name", "Avg Day Chg", "Type"];
-            let rows: Vec<Vec<String>> = screeners.iter().map(|s| {
-                let type_str = match s["type"].as_i64() {
-                    Some(1) => "User",
-                    _ => "Platform",
-                };
-                vec![
-                    val_str(&s["id"]),
-                    val_str(&s["name"]),
-                    val_str(&s["average_day_chg"]),
-                    type_str.to_string(),
-                ]
-            }).collect();
+            let rows: Vec<Vec<String>> = screeners
+                .iter()
+                .map(|s| {
+                    let type_str = match s["type"].as_i64() {
+                        Some(1) => "User",
+                        _ => "Platform",
+                    };
+                    vec![
+                        val_str(&s["id"]),
+                        val_str(&s["name"]),
+                        val_str(&s["average_day_chg"]),
+                        type_str.to_string(),
+                    ]
+                })
+                .collect();
             print_table(&headers, rows, format);
         }
     }
@@ -99,6 +117,7 @@ pub async fn cmd_screener_strategies(
 
 pub async fn cmd_screener_search(
     strategy_id: Option<i64>,
+    filter_args: &[String],
     market: &str,
     count: u32,
     format: &OutputFormat,
@@ -108,14 +127,20 @@ pub async fn cmd_screener_search(
     let (mkt, filters, returns) = if let Some(sid) = strategy_id {
         let strategies = http_get("/v1/quote/screener/strategies/recommend", &[], verbose).await?;
         // Also try user strategies if not found in recommend
-        let strategy_obj = strategies["screeners"].as_array()
+        let strategy_obj = strategies["screeners"]
+            .as_array()
             .and_then(|arr| arr.iter().find(|s| s["id"].as_i64() == Some(sid)))
             .cloned()
             .unwrap_or(serde_json::Value::Null);
         // Fall back to fetching by ID if not in list
         let strategy = if strategy_obj.is_null() {
             let sid_str = sid.to_string();
-            http_get("/v1/quote/screener/strategy", &[("id", sid_str.as_str())], verbose).await?
+            http_get(
+                "/v1/quote/screener/strategy",
+                &[("id", sid_str.as_str())],
+                verbose,
+            )
+            .await?
         } else {
             strategy_obj
         };
@@ -131,11 +156,14 @@ pub async fn cmd_screener_search(
                         if id == -1 && key == "filter_market" {
                             // Market indicator — extract market value
                             let v = val_str(&ind["value"]);
-                            if !v.is_empty() && v != "-" { mkt = v; }
+                            if !v.is_empty() && v != "-" {
+                                mkt = v;
+                            }
                         } else {
                             let min = val_str(&ind["min"]);
                             let max = val_str(&ind["max"]);
-                            let has_range = (!min.is_empty() && min != "-") || (!max.is_empty() && max != "-");
+                            let has_range =
+                                (!min.is_empty() && min != "-") || (!max.is_empty() && max != "-");
                             if has_range || id > 0 {
                                 filters.push(serde_json::json!({
                                     "key": key,
@@ -152,7 +180,26 @@ pub async fn cmd_screener_search(
         }
         (mkt, filters, returns)
     } else {
-        (market.to_uppercase(), Vec::new(), Vec::new())
+        // Mode B: parse --filter key:min:max args
+        let mut filters: Vec<serde_json::Value> = Vec::new();
+        let mut returns: Vec<String> = Vec::new();
+        for arg in filter_args {
+            let parts: Vec<&str> = arg.splitn(3, ':').collect();
+            let key = parts.first().copied().unwrap_or("").to_string();
+            let min = parts.get(1).copied().unwrap_or("").to_string();
+            let max = parts.get(2).copied().unwrap_or("").to_string();
+            if key.is_empty() {
+                continue;
+            }
+            filters.push(serde_json::json!({
+                "key": key,
+                "min": min,
+                "max": max,
+                "tech_values": {}
+            }));
+            returns.push(key);
+        }
+        (market.to_uppercase(), filters, returns)
     };
 
     let body = serde_json::json!({
@@ -167,11 +214,23 @@ pub async fn cmd_screener_search(
     });
     let data = http_post("/v1/quote/screener/search", body, verbose).await?;
     match format {
-        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&data).unwrap_or_default()),
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&data).unwrap_or_default()
+        ),
         OutputFormat::Pretty => {
-            let total = data.get("total").and_then(|v| v.as_i64()).unwrap_or_else(|| data["items"].as_array().map(|a| a.len() as i64).unwrap_or(0));
-            let label = strategy_id
-                .map_or_else(|| format!("Custom filter ({mkt})"), |id| format!("Strategy #{id} ({mkt})"));
+            let total = data
+                .get("total")
+                .and_then(serde_json::Value::as_i64)
+                .unwrap_or_else(|| {
+                    data["items"]
+                        .as_array()
+                        .map_or(0, |a| i64::try_from(a.len()).unwrap_or(0))
+                });
+            let label = strategy_id.map_or_else(
+                || format!("Custom filter ({mkt})"),
+                |id| format!("Strategy #{id} ({mkt})"),
+            );
             println!("{label} — {total} stocks found\n");
             let stocks = match data.get("items").and_then(|v| v.as_array()) {
                 Some(a) if !a.is_empty() => a,
@@ -184,18 +243,26 @@ pub async fn cmd_screener_search(
             let mut headers = vec!["Symbol".to_string(), "Name".to_string()];
             headers.extend(returns.iter().take(5).map(|k| k.replace("filter_", "")));
             let header_refs: Vec<&str> = headers.iter().map(String::as_str).collect();
-            let rows: Vec<Vec<String>> = stocks.iter().map(|s| {
-                let sym = crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"]));
-                let mut row = vec![sym, val_str(&s["name"])];
-                if let Some(indicators) = s["indicators"].as_array() {
-                    row.extend(indicators.iter().take(5).map(|ind| {
-                        let v = val_str(&ind["value"]);
-                        let unit = val_str(&ind["unit"]);
-                        if unit.is_empty() || unit == "-" { v } else { format!("{v} {unit}") }
-                    }));
-                }
-                row
-            }).collect();
+            let rows: Vec<Vec<String>> = stocks
+                .iter()
+                .map(|s| {
+                    let sym =
+                        crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"]));
+                    let mut row = vec![sym, val_str(&s["name"])];
+                    if let Some(indicators) = s["indicators"].as_array() {
+                        row.extend(indicators.iter().take(5).map(|ind| {
+                            let v = val_str(&ind["value"]);
+                            let unit = val_str(&ind["unit"]);
+                            if unit.is_empty() || unit == "-" {
+                                v
+                            } else {
+                                format!("{v} {unit}")
+                            }
+                        }));
+                    }
+                    row
+                })
+                .collect();
             print_table(&header_refs, rows, format);
         }
     }
@@ -215,7 +282,10 @@ pub async fn cmd_screener_indicators(
     }
     let data = http_get("/v1/quote/screener/indicators", &params, verbose).await?;
     match format {
-        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&data).unwrap_or_default()),
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&data).unwrap_or_default()
+        ),
         OutputFormat::Pretty => {
             let groups = match data.get("groups").and_then(|v| v.as_array()) {
                 Some(a) if !a.is_empty() => a,
@@ -229,18 +299,21 @@ pub async fn cmd_screener_indicators(
                 println!("── {gname} ──");
                 if let Some(indicators) = group["indicators"].as_array() {
                     let headers = ["ID", "Key", "Name", "Unit", "Min", "Max"];
-                    let rows: Vec<Vec<String>> = indicators.iter().map(|ind| {
-                        let min = val_str(&ind["default_range"]["min"]);
-                        let max = val_str(&ind["default_range"]["max"]);
-                        vec![
-                            val_str(&ind["id"]),
-                            val_str(&ind["key"]),
-                            val_str(&ind["name"]),
-                            val_str(&ind["unit"]),
-                            min,
-                            max,
-                        ]
-                    }).collect();
+                    let rows: Vec<Vec<String>> = indicators
+                        .iter()
+                        .map(|ind| {
+                            let min = val_str(&ind["default_range"]["min"]);
+                            let max = val_str(&ind["default_range"]["max"]);
+                            vec![
+                                val_str(&ind["id"]),
+                                val_str(&ind["key"]),
+                                val_str(&ind["name"]),
+                                val_str(&ind["unit"]),
+                                min,
+                                max,
+                            ]
+                        })
+                        .collect();
                     print_table(&headers, rows, format);
                 }
                 println!();

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -249,12 +249,19 @@ async fn print_screener_results(
                                         }
                                     })
                                     .unwrap_or((v, unit)),
-                                _ => (v, unit),
+                                "%" => (
+                                    v.parse::<f64>().map(|f| format!("{f:.2}")).unwrap_or(v),
+                                    "%".to_string(),
+                                ),
+                                _ => (
+                                    v.parse::<f64>().map(|f| format!("{f:.2}")).unwrap_or(v),
+                                    unit,
+                                ),
                             };
                             if display_unit.is_empty() || display_unit == "-" {
                                 display_v
                             } else {
-                                format!("{display_v} {display_unit}")
+                                format!("{display_v}{display_unit}")
                             }
                         }));
                     }

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -4,6 +4,14 @@ use serde_json::Value;
 use super::{api::http_get, api::http_post, output::print_table, OutputFormat};
 use crate::utils::counter::symbol_to_counter_id;
 
+fn normalize_key(key: &str) -> String {
+    if key.starts_with("filter_") {
+        key.to_string()
+    } else {
+        format!("filter_{key}")
+    }
+}
+
 fn val_str(v: &Value) -> String {
     match v {
         Value::String(s) => s.clone(),
@@ -72,6 +80,9 @@ pub async fn cmd_screener_strategies(
 
 pub async fn cmd_screener_run(
     id: i64,
+    sort: Option<&str>,
+    order: &str,
+    show: &[String],
     count: u32,
     format: &OutputFormat,
     verbose: bool,
@@ -127,12 +138,24 @@ pub async fn cmd_screener_run(
             }
         }
     }
-    print_screener_results(id, &mkt, &filters, &returns, count, format, verbose).await
+    for key in show {
+        let full_key = normalize_key(key);
+        if !returns.contains(&full_key) {
+            returns.push(full_key);
+        }
+    }
+    print_screener_results(
+        id, &mkt, &filters, &returns, sort, order, count, format, verbose,
+    )
+    .await
 }
 
 pub async fn cmd_screener_filter(
     conditions: &[String],
     market: &str,
+    sort: Option<&str>,
+    order: &str,
+    show: &[String],
     count: u32,
     format: &OutputFormat,
     verbose: bool,
@@ -145,11 +168,7 @@ pub async fn cmd_screener_filter(
         if raw_key.is_empty() {
             continue;
         }
-        let key = if raw_key.starts_with("filter_") {
-            raw_key.to_string()
-        } else {
-            format!("filter_{raw_key}")
-        };
+        let key = normalize_key(raw_key);
         let min = parts.get(1).copied().unwrap_or("").to_string();
         let max = parts.get(2).copied().unwrap_or("").to_string();
         filters.push(serde_json::json!({
@@ -160,11 +179,19 @@ pub async fn cmd_screener_filter(
         }));
         returns.push(key);
     }
+    for key in show {
+        let full_key = normalize_key(key);
+        if !returns.contains(&full_key) {
+            returns.push(full_key);
+        }
+    }
     print_screener_results(
         0,
         &market.to_uppercase(),
         &filters,
         &returns,
+        sort,
+        order,
         count,
         format,
         verbose,
@@ -177,18 +204,26 @@ async fn print_screener_results(
     market: &str,
     filters: &[serde_json::Value],
     returns: &[String],
+    sort: Option<&str>,
+    order: &str,
     count: u32,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
+    let sort_key = sort.map(normalize_key);
+    let sort_by = sort_key
+        .as_deref()
+        .and_then(|k| returns.iter().position(|r| r == k))
+        .unwrap_or(0);
+    let sort_order: u8 = u8::from(order != "asc");
     let body = serde_json::json!({
         "market": market,
         "page": 1,
         "size": count,
         "filters": filters,
         "returns": returns,
-        "sort_by": 0,
-        "sort_order": 1,
+        "sort_by": sort_by,
+        "sort_order": sort_order,
         "industries": [],
     });
     let data = http_post("/v1/quote/screener/search", body, verbose).await?;
@@ -223,7 +258,6 @@ async fn print_screener_results(
             headers.extend(
                 returns
                     .iter()
-                    .take(5)
                     .map(|k| k.replace("filter_", "").to_uppercase()),
             );
             let header_refs: Vec<&str> = headers.iter().map(String::as_str).collect();
@@ -234,7 +268,7 @@ async fn print_screener_results(
                         crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"]));
                     let mut row = vec![sym, val_str(&s["name"])];
                     if let Some(indicators) = s["indicators"].as_array() {
-                        row.extend(indicators.iter().take(5).map(|ind| {
+                        row.extend(indicators.iter().map(|ind| {
                             let v = val_str(&ind["value"]);
                             let unit = val_str(&ind["unit"]);
                             let (display_v, display_unit) = match unit.as_str() {

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -104,36 +104,99 @@ pub async fn cmd_screener_search(
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
-    let mut body = serde_json::json!({
-        "market": market.to_uppercase(),
+    // When a strategy ID is given, fetch recommend list to get its groups (no extra request needed).
+    let (mkt, filters, returns) = if let Some(sid) = strategy_id {
+        let strategies = http_get("/v1/quote/screener/strategies/recommend", &[], verbose).await?;
+        // Also try user strategies if not found in recommend
+        let strategy_obj = strategies["screeners"].as_array()
+            .and_then(|arr| arr.iter().find(|s| s["id"].as_i64() == Some(sid)))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        // Fall back to fetching by ID if not in list
+        let strategy = if strategy_obj.is_null() {
+            let sid_str = sid.to_string();
+            http_get("/v1/quote/screener/strategy", &[("id", sid_str.as_str())], verbose).await?
+        } else {
+            strategy_obj
+        };
+        let mut mkt = market.to_uppercase();
+        let mut filters: Vec<serde_json::Value> = Vec::new();
+        let mut returns: Vec<String> = Vec::new();
+        if let Some(groups) = strategy["groups"].as_array() {
+            for group in groups {
+                if let Some(indicators) = group["indicators"].as_array() {
+                    for ind in indicators {
+                        let key = val_str(&ind["key"]);
+                        let id = ind["id"].as_i64().unwrap_or(0);
+                        if id == -1 && key == "filter_market" {
+                            // Market indicator — extract market value
+                            let v = val_str(&ind["value"]);
+                            if !v.is_empty() && v != "-" { mkt = v; }
+                        } else {
+                            let min = val_str(&ind["min"]);
+                            let max = val_str(&ind["max"]);
+                            let has_range = (!min.is_empty() && min != "-") || (!max.is_empty() && max != "-");
+                            if has_range || id > 0 {
+                                filters.push(serde_json::json!({
+                                    "key": key,
+                                    "min": min,
+                                    "max": max,
+                                    "tech_values": {}
+                                }));
+                                returns.push(key);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        (mkt, filters, returns)
+    } else {
+        (market.to_uppercase(), Vec::new(), Vec::new())
+    };
+
+    let body = serde_json::json!({
+        "market": mkt,
         "page": 1,
         "size": count,
+        "filters": filters,
+        "returns": returns,
+        "sort_by": 0,
+        "sort_order": 1,
+        "industries": [],
     });
-    if let Some(sid) = strategy_id {
-        body["id"] = serde_json::json!(sid.to_string());
-    }
     let data = http_post("/v1/quote/screener/search", body, verbose).await?;
     match format {
         OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&data).unwrap_or_default()),
         OutputFormat::Pretty => {
-            let total = data["total"].as_i64().unwrap_or(0);
-            let strategy_label = strategy_id
-                .map_or_else(|| format!("Custom filter ({market})"), |id| format!("Strategy #{id}"));
-            println!("{strategy_label} — {total} stocks found\n");
-            let stocks = match data.get("stocks").and_then(|v| v.as_array()) {
+            let total = data.get("total").and_then(|v| v.as_i64()).unwrap_or_else(|| data["items"].as_array().map(|a| a.len() as i64).unwrap_or(0));
+            let label = strategy_id
+                .map_or_else(|| format!("Custom filter ({mkt})"), |id| format!("Strategy #{id} ({mkt})"));
+            println!("{label} — {total} stocks found\n");
+            let stocks = match data.get("items").and_then(|v| v.as_array()) {
                 Some(a) if !a.is_empty() => a,
                 _ => {
                     println!("No stocks found matching the criteria.");
                     return Ok(());
                 }
             };
-            let headers = ["Symbol", "Name"];
+            // Build column headers from returns keys
+            let mut headers = vec!["Symbol".to_string(), "Name".to_string()];
+            headers.extend(returns.iter().take(5).map(|k| k.replace("filter_", "")));
+            let header_refs: Vec<&str> = headers.iter().map(String::as_str).collect();
             let rows: Vec<Vec<String>> = stocks.iter().map(|s| {
-                let cid = val_str(&s["counter_id"]);
-                let sym = crate::utils::counter::counter_id_to_symbol(&cid);
-                vec![sym, val_str(&s["name"])]
+                let sym = crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"]));
+                let mut row = vec![sym, val_str(&s["name"])];
+                if let Some(indicators) = s["indicators"].as_array() {
+                    row.extend(indicators.iter().take(5).map(|ind| {
+                        let v = val_str(&ind["value"]);
+                        let unit = val_str(&ind["unit"]);
+                        if unit.is_empty() || unit == "-" { v } else { format!("{v} {unit}") }
+                    }));
+                }
+                row
             }).collect();
-            print_table(&headers, rows, format);
+            print_table(&header_refs, rows, format);
         }
     }
     Ok(())

--- a/src/utils/counter.rs
+++ b/src/utils/counter.rs
@@ -1,4 +1,8 @@
-include!(concat!(env!("OUT_DIR"), "/special_counter_ids.rs"));
+#[allow(clippy::unreadable_literal)]
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/special_counter_ids.rs"));
+}
+use generated::SPECIAL_COUNTER_IDS;
 
 /// Convert a `counter_id` (e.g. `ST/US/TSLA`, `ETF/US/SPY`, `IX/US/.DJI`, `ST/HK/700`) back to
 /// a display symbol (e.g. `TSLA.US`, `SPY.US`, `.DJI.US`, `700.HK`).


### PR DESCRIPTION
## Summary

Based on `docs/stock-tools-gap.md`. Adds 9 new commands/flags across 5 business domains:

### 🏢 Shareholders
- **`shareholder SYMBOL`** — Institution list with `--range inc/dec/all`, `--sort`, `--count N` (default 50). Uses `position=detail` to return all records; `range` filter works correctly
- **`shareholder SYMBOL --top`** — Top20 major shareholders for Latest period; `--periods N` for multiple quarters (deduplicates holders by `object_id`, skips aggregate snapshot when N>1)
- **`shareholder SYMBOL --object-id <id>`** — Holding history + trade detail. `object_id` from `--top` output
- Format `shares_held`/`shares_changed` via `format_financial_value` (K/M/B); zero changes show as `-`
- Hide `title` column when no holder in the period has a title

### 🩸 Short Selling
- **`short-positions SYMBOL`** extended to support HK — auto-routes by symbol suffix; fixes `short_shares` parsing (was always 0) and formats `balance` as `21.20B`
- **`short-trades SYMBOL`** — Daily short sale volume. Supports both US and HK

### 🔍 Strategy Screener
New `screener` command group (`src/cli/screener.rs`):
- **`screener strategies`** — Recommended strategies (default), `--mine`, `--all`
- **`screener run <ID>`** — Run a saved strategy by ID; supports `--sort KEY`, `--order asc/desc`, `--show KEY`, `--count N`
- **`screener filter KEY:MIN:MAX ...`** — Custom filter with positional conditions; `filter_` prefix auto-added; supports `--market`, `--sort`, `--order`, `--show`, `--count`
  - Omit either bound for open ranges: `pettm:10:` means PE ≥ 10, `pettm::50` means PE ≤ 50
  - `--show KEY` adds display-only columns without adding filter conditions
  - `--sort KEY` auto-adds the key to returned columns if not already present
  - Values formatted: `亿`/`万` scaled, `%` unit shown as `12.34%`, empty values shown as `-`
- **`screener indicators`** — Available filter keys and value ranges; `--symbol` to scope to one stock

### 📊 Stock Comparison
- **`compare SYMBOL SYMBOL...`** — Multi-stock valuation comparison (PE/PB/PS/market-cap/close); large numbers formatted as K/M/B; ratios formatted as `%`

### 🔥 Top Movers
- **`top-movers`** — Stocks with abnormal price movements paired with alert reason and industry tags. `symbol` shown as `CODE.MARKET`; `change%` formatted as `+12.62%`; `time` in RFC 3339

## Test plan

- [x] `longbridge screener strategies` — lists strategies with IDs
- [x] `longbridge screener run 1 --sort divyld --show pettm` — runs strategy with custom sort and extra column
- [x] `longbridge screener run 1 --sort divyld --order asc` — ascending sort
- [x] `longbridge screener filter pettm:10:50 roe:5: --market HK` — multi-condition HK filter
- [x] `longbridge screener filter marketcap:1000: roe:15: --market US --sort marketcap` — large-cap US filter (marketcap unit: 亿)
- [x] `longbridge screener filter pettm:0:20 pbmrq:0:2 roe:10: --market CN --show divyld` — A-share value investing
- [x] `longbridge screener filter roe:15: --market HK --sort roe --show pettm --show pbmrq` — sort key auto-added to returns
- [x] `longbridge screener indicators`
- [x] `longbridge shareholder AAPL.US` — shows top 50
- [x] `longbridge shareholder AAPL.US --range inc`
- [x] `longbridge short-positions 700.HK` — correct short_shares and formatted balance
- [x] `longbridge short-trades AAPL.US`
- [x] `longbridge compare AAPL.US BABA.US JD.US`
- [x] `longbridge top-movers` — symbol as `01810.HK`, change as `-2.48%`, time as RFC 3339
- [x] `cargo clippy` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)