### PR TITLE
cli: Support HK, CN, SG markets in `security-list` command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -324,13 +324,14 @@ pub enum Commands {
         cmd: TradingCmd,
     },
 
-    /// List of US overnight-eligible securities
+    /// List of overnight-eligible securities by market
     ///
-    /// Returns securities that can be traded in the US overnight session.
-    /// Only the US market is supported (Longbridge API limitation).
+    /// Returns securities that can be traded in the overnight session for the given market.
+    /// Supported markets: US, HK, CN, SG
     /// Example: longbridge security-list US
+    /// Example: longbridge security-list HK
     SecurityList {
-        /// Market: only US is supported (overnight category)
+        /// Market: US, HK, CN, SG
         #[arg(default_value = "US")]
         market: String,
         /// NOTE: currently unused — the SDK only exposes the Overnight category.
@@ -3723,6 +3724,12 @@ mod tests {
         let cli = parse(&["longbridge", "security-list", "US"]).unwrap();
         if let Some(Commands::SecurityList { market, .. }) = cli.command {
             assert_eq!(market, "US");
+        } else {
+            panic!("expected SecurityList command");
+        }
+        let cli = parse(&["longbridge", "security-list", "HK"]).unwrap();
+        if let Some(Commands::SecurityList { market, .. }) = cli.command {
+            assert_eq!(market, "HK");
         } else {
             panic!("expected SecurityList command");
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -329,11 +329,17 @@ pub enum Commands {
     /// Returns securities that can be traded in the overnight session for the given market.
     /// Supported markets: US, HK, CN, SG
     /// Example: longbridge security-list US
-    /// Example: longbridge security-list HK
+    /// Example: longbridge security-list HK --page 2 --count 50
     SecurityList {
         /// Market: US, HK, CN, SG
         #[arg(default_value = "US")]
         market: String,
+        /// Page number (1-based)
+        #[arg(long, default_value = "1")]
+        page: usize,
+        /// Records per page
+        #[arg(long, alias = "limit", default_value = "50")]
+        count: usize,
         /// NOTE: currently unused — the SDK only exposes the Overnight category.
         #[arg(long, default_value = "main", hide = true)]
         category: String,
@@ -2775,9 +2781,12 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                 quote::cmd_trading_days(&market, start, end, format).await
             }
         },
-        Commands::SecurityList { market, category } => {
-            quote::cmd_security_list(&market, &category, format).await
-        }
+        Commands::SecurityList {
+            market,
+            page,
+            count,
+            category,
+        } => quote::cmd_security_list(&market, &category, page, count, format).await,
         Commands::Participants => quote::cmd_participants(format).await,
         Commands::Subscriptions => quote::cmd_subscriptions(format).await,
         Commands::Option { cmd } => match cmd {

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -1025,24 +1025,61 @@ pub async fn cmd_trading_days(
     Ok(())
 }
 
-pub async fn cmd_security_list(market: &str, category: &str, format: &OutputFormat) -> Result<()> {
+pub async fn cmd_security_list(
+    market: &str,
+    category: &str,
+    page: usize,
+    count: usize,
+    format: &OutputFormat,
+) -> Result<()> {
+    if page == 0 {
+        bail!("Page number must be >= 1");
+    }
     let ctx = crate::openapi::quote();
     let m = parse_market(market)?;
     let cat = parse_security_list_category(category);
     let securities = ctx.security_list(m, cat).await?;
+    let total = securities.len();
 
-    let headers = &["Symbol", "Name"];
-    let rows = securities
-        .iter()
-        .map(|s| {
-            vec![
-                s.symbol.clone(),
-                locale_name(&s.name_en, &s.name_cn).to_owned(),
-            ]
-        })
-        .collect();
+    let start = (page - 1) * count;
+    if start >= total && total > 0 {
+        bail!(
+            "Page {page} out of range — total {total} records, {} per page",
+            count
+        );
+    }
 
-    print_table(headers, rows, format);
+    let page_items: Vec<_> = securities.iter().skip(start).take(count).collect();
+
+    match format {
+        OutputFormat::Json => {
+            let records: Vec<serde_json::Value> = page_items
+                .iter()
+                .map(|s| {
+                    serde_json::json!({
+                        "symbol": s.symbol,
+                        "name_en": s.name_en,
+                        "name_cn": s.name_cn,
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&records)?);
+        }
+        _ => {
+            let headers = &["Symbol", "Name"];
+            let rows = page_items
+                .iter()
+                .map(|s| {
+                    vec![
+                        s.symbol.clone(),
+                        locale_name(&s.name_en, &s.name_cn).to_owned(),
+                    ]
+                })
+                .collect();
+            print_table(headers, rows, format);
+            eprintln!("Page {page} of {} ({total} total)", total.div_ceil(count),);
+        }
+    }
     Ok(())
 }
 

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -1026,9 +1026,6 @@ pub async fn cmd_trading_days(
 }
 
 pub async fn cmd_security_list(market: &str, category: &str, format: &OutputFormat) -> Result<()> {
-    if !matches!(market.to_uppercase().as_str(), "US") {
-        bail!("Only US market is supported for security-list (Longbridge API only exposes the Overnight category)");
-    }
     let ctx = crate::openapi::quote();
     let m = parse_market(market)?;
     let cat = parse_security_list_category(category);


### PR DESCRIPTION
## Summary

- Remove the US-only guard in `cmd_security_list` — staging environment now returns overnight security lists for HK, CN, and SG markets
- Update command help text and arg description to reflect all four supported markets (US, HK, CN, SG)
- Add HK market parse assertion to existing unit test

## Test plan

- [ ] `longbridge security-list US` — returns US overnight securities
- [ ] `longbridge security-list HK` — returns HK securities
- [ ] `longbridge security-list CN` — returns CN securities
- [ ] `longbridge security-list SG` — returns SG securities
- [ ] `longbridge security-list --help` — shows "Supported markets: US, HK, CN, SG"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)