### PR TITLE
cli: Document short selling behavior for `order sell`

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2315,11 +2315,13 @@ pub enum OrderCmd {
     ///
     /// Short selling: submitting a sell order for a symbol with no existing position
     /// opens a short. US stocks support short selling without additional account setup.
-    /// HK stocks require signing the Securities Borrowing and Lending (SBL) agreement
-    /// first — open the Longbridge mobile app, place your first HK short sell order
-    /// there, and complete the in-app SBL agreement signing flow. After that, the API,
-    /// CLI, and MCP can short HK stocks directly. Without the agreement, the API
-    /// returns error 602301.
+    /// HK stocks require two steps: (1) contact Longbridge customer support to apply
+    /// for HK short selling permission and wait for approval (error 602101 until
+    /// approved); (2) once approved, open the Longbridge mobile app, place your first
+    /// HK short sell order there, and complete the in-app SBL (Securities Borrowing
+    /// and Lending) agreement signing flow. After both steps, the API, CLI, and MCP
+    /// can short HK stocks directly. Without the agreement, the API returns error
+    /// 602301.
     ///
     /// Example: longbridge order sell TSLA.US 100 --price 260.00
     /// Example: longbridge order sell NVDA.US 10 --order-type MIT --trigger-price 177.89 --tif Day

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2312,6 +2312,15 @@ pub enum OrderCmd {
     ///   (case-insensitive)
     /// Trailing orders (TSLPAMT/TSLPPCT) require --trailing-amount/--trailing-percent
     ///   and --limit-offset.
+    ///
+    /// Short selling: submitting a sell order for a symbol with no existing position
+    /// opens a short. US stocks support short selling without additional account setup.
+    /// HK stocks require signing the Securities Borrowing and Lending (SBL) agreement
+    /// first — open the Longbridge mobile app, place your first HK short sell order
+    /// there, and complete the in-app SBL agreement signing flow. After that, the API,
+    /// CLI, and MCP can short HK stocks directly. Without the agreement, the API
+    /// returns error 602301.
+    ///
     /// Example: longbridge order sell TSLA.US 100 --price 260.00
     /// Example: longbridge order sell NVDA.US 10 --order-type MIT --trigger-price 177.89 --tif Day
     /// Example: longbridge order sell TSLA.US 130 --order-type TSLPPCT --trailing-percent 3 --limit-offset 1 --tif gtc

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2314,14 +2314,14 @@ pub enum OrderCmd {
     ///   and --limit-offset.
     ///
     /// Short selling: submitting a sell order for a symbol with no existing position
-    /// opens a short. US stocks support short selling without additional account setup.
-    /// HK stocks require two steps: (1) contact Longbridge customer support to apply
-    /// for HK short selling permission and wait for approval (error 602101 until
-    /// approved); (2) once approved, open the Longbridge mobile app, place your first
-    /// HK short sell order there, and complete the in-app SBL (Securities Borrowing
-    /// and Lending) agreement signing flow. After both steps, the API, CLI, and MCP
-    /// can short HK stocks directly. Without the agreement, the API returns error
-    /// 602301.
+    /// opens a short. US and HK markets must each be activated separately before
+    /// short selling is available via the API, CLI, or MCP:
+    /// (1) open the Longbridge mobile app and place your first short sell order for
+    ///     that market — the app will trigger an SBL (Securities Borrowing and
+    ///     Lending) agreement signing flow;
+    /// (2) complete the signing, then wait for the review to be approved.
+    /// Once approved, short selling for that market is available. The API returns
+    /// error 602301 before the agreement is signed.
     ///
     /// Example: longbridge order sell TSLA.US 100 --price 260.00
     /// Example: longbridge order sell NVDA.US 10 --order-type MIT --trigger-price 177.89 --tif Day


### PR DESCRIPTION
## Summary

- Adds short selling documentation to the `order sell` command help text
- Explains that selling a symbol with no position opens a short
- Documents US vs HK market differences: US works directly; HK requires signing the Securities Borrowing and Lending (SBL) agreement in the Longbridge mobile app first
- Includes error code `602301` reference for HK without SBL agreement

## Test plan

- [ ] `longbridge order sell --help` shows updated short selling notes