### PR TITLE
cli: Clarify US/HK short selling setup and note HK IRD fee

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2314,14 +2314,13 @@ pub enum OrderCmd {
     ///   and --limit-offset.
     ///
     /// Short selling: submitting a sell order for a symbol with no existing position
-    /// opens a short. US and HK markets must each be activated separately before
-    /// short selling is available via the API, CLI, or MCP:
-    /// (1) open the Longbridge mobile app and place your first short sell order for
-    ///     that market — the app will trigger an SBL (Securities Borrowing and
-    ///     Lending) agreement signing flow;
-    /// (2) complete the signing, then wait for the review to be approved.
-    /// Once approved, short selling for that market is available. The API returns
-    /// error 602301 before the agreement is signed.
+    /// opens a short. US stocks can be shorted directly with no additional setup.
+    /// HK short selling requires activation: open the Longbridge mobile app, place
+    /// your first HK short sell order — the app will trigger an SBL (Securities
+    /// Borrowing and Lending) agreement signing flow. Complete the signing and wait
+    /// for approval. Note: HK short selling is subject to a fee levied by the Hong
+    /// Kong Inland Revenue Department; details are described in the in-app agreement.
+    /// The API returns error 602301 before the HK SBL agreement is signed.
     ///
     /// Example: longbridge order sell TSLA.US 100 --price 260.00
     /// Example: longbridge order sell NVDA.US 10 --order-type MIT --trigger-price 177.89 --tif Day


### PR DESCRIPTION
## Summary

- Clarifies that US stocks can be shorted directly with no additional setup
- Clarifies that HK short selling requires activation via the mobile app: place first HK short sell order → triggers SBL agreement signing → wait for approval
- Notes that HK short selling is subject to a fee levied by the Hong Kong Inland Revenue Department, with details in the in-app agreement
- Documents API error `602301` returned before the HK SBL agreement is signed

## Test plan

- [ ] `longbridge order sell --help` shows updated short selling notes