### PR TITLE
cli: Use format_financial_value for screener indicator display

### DIFF
--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -1044,10 +1044,7 @@ pub async fn cmd_security_list(
 
     let start = (page - 1) * count;
     if start >= total && total > 0 {
-        bail!(
-            "Page {page} out of range — total {total} records, {} per page",
-            count
-        );
+        bail!("Page {page} out of range — total {total} records, {count} per page");
     }
 
     let page_items: Vec<_> = securities.iter().skip(start).take(count).collect();
@@ -1066,7 +1063,7 @@ pub async fn cmd_security_list(
                 .collect();
             println!("{}", serde_json::to_string_pretty(&records)?);
         }
-        _ => {
+        OutputFormat::Pretty => {
             let headers = &["Symbol", "Name"];
             let rows = page_items
                 .iter()
@@ -1078,7 +1075,7 @@ pub async fn cmd_security_list(
                 })
                 .collect();
             print_table(headers, rows, format);
-            eprintln!("Page {page} of {} ({total} total)", total.div_ceil(count),);
+            eprintln!("Page {page} of {} ({total} total)", total.div_ceil(count));
         }
     }
     Ok(())

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 
 use super::{api::http_get, api::http_post, output::print_table, OutputFormat};
 use crate::utils::counter::symbol_to_counter_id;
+use crate::utils::number::format_financial_value;
 
 fn normalize_key(key: &str) -> String {
     if key.starts_with("filter_") {
@@ -280,37 +281,7 @@ async fn print_screener_results(
                                 return "-".to_string();
                             }
                             let unit = val_str(&ind["unit"]);
-                            let (display_v, display_unit) = match unit.as_str() {
-                                "亿" => (
-                                    v.parse::<f64>()
-                                        .map(|f| format!("{:.2}", f / 1e8))
-                                        .unwrap_or(v),
-                                    "亿".to_string(),
-                                ),
-                                "万" => v
-                                    .parse::<f64>()
-                                    .map(|f| {
-                                        if f >= 1e8 {
-                                            (format!("{:.2}", f / 1e8), "亿".to_string())
-                                        } else {
-                                            (format!("{:.2}", f / 1e4), "万".to_string())
-                                        }
-                                    })
-                                    .unwrap_or((v, unit)),
-                                "%" => (
-                                    v.parse::<f64>().map(|f| format!("{f:.2}")).unwrap_or(v),
-                                    "%".to_string(),
-                                ),
-                                _ => (
-                                    v.parse::<f64>().map(|f| format!("{f:.2}")).unwrap_or(v),
-                                    unit,
-                                ),
-                            };
-                            if display_unit.is_empty() || display_unit == "-" {
-                                display_v
-                            } else {
-                                format!("{display_v}{display_unit}")
-                            }
+                            format_financial_value(&v, unit == "%")
                         }));
                     }
                     row


### PR DESCRIPTION
## Summary

- Replace inline 亿/万 Chinese unit scaling in screener pretty output with the existing `format_financial_value` util (B/M/K English units, handles `%` correctly)
- Fix two clippy pedantic warnings in `quote.rs`: format string variable interpolation and explicit `OutputFormat::Pretty` match arm

## Test plan

- [ ] `cargo run -- screener filter marketcap:100: --market HK --count 5` — market cap shows as `2.53T` / `2.45T` etc.
- [ ] `cargo run -- screener filter balance:10: --market HK --count 5` — turnover shows as `7.48B` etc.
- [ ] `cargo run -- screener run 1` — strategy results display correctly
- [ ] `cargo clippy` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)