### PR TITLE
cli: Migrate screener to AI endpoints with full JSON/AI-agent support

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -995,7 +995,7 @@ pub enum Commands {
     /// Strategy screener — browse strategies, run filters, view indicator config
     ///
     /// Workflow A — run a saved strategy:
-    ///   1. `screener strategies` to list recommended strategies and note the ID
+    ///   1. `screener strategies` to list preset strategies and note the ID
     ///   2. `screener run <ID>` to execute it
     ///
     /// Workflow B — custom filter:
@@ -1705,11 +1705,10 @@ impl IndustryRankSortType {
 pub enum ScreenerCmd {
     /// List stock-selection strategies and their filter conditions
     ///
-    /// Default: platform recommended strategies (use ID with `screener search`).
+    /// Default: platform preset strategies (use ID with `screener run`).
     /// --mine:  your saved strategies.
-    /// --all:   all strategies (recommended + user).
     ///
-    /// The `id` field in the output is passed to `screener search --strategy-id`.
+    /// The `id` field in the output is passed to `screener run <ID>`.
     ///
     /// Example: longbridge screener strategies
     /// Example: longbridge screener strategies --mine
@@ -1717,9 +1716,6 @@ pub enum ScreenerCmd {
         /// Show user's saved strategies
         #[arg(long)]
         mine: bool,
-        /// Show all strategies (recommended + user)
-        #[arg(long)]
-        all: bool,
     },
 
     /// Run a saved strategy by its ID (from `screener strategies` output)
@@ -3532,8 +3528,8 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             quote::cmd_top_movers(market, sort.as_api_value(), count, format, verbose).await
         }
         Commands::Screener { cmd } => match cmd {
-            ScreenerCmd::Strategies { mine, all } => {
-                screener::cmd_screener_strategies(mine, all, format, verbose).await
+            ScreenerCmd::Strategies { mine } => {
+                screener::cmd_screener_strategies(mine, format, verbose).await
             }
             ScreenerCmd::Run { id, sort, order, show, count } => {
                 screener::cmd_screener_run(id, sort.as_deref(), order.as_str(), show.as_slice(), count, format, verbose).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1730,6 +1730,7 @@ pub enum ScreenerCmd {
     ///
     /// Example: longbridge screener run 42
     /// Example: longbridge screener run 42 --sort pettm --order desc
+    /// Example: longbridge screener run 42 --page 2 --count 50
     /// Example: longbridge screener run 42 --show roe --show divyld
     Run {
         /// Strategy ID from `screener strategies` output
@@ -1743,7 +1744,10 @@ pub enum ScreenerCmd {
         /// Extra columns to display without adding a filter condition
         #[arg(long = "show", value_name = "KEY")]
         show: Vec<String>,
-        /// Number of results (default: 20)
+        /// Page number (default: 1)
+        #[arg(long, default_value = "1")]
+        page: u32,
+        /// Records per page (default: 20)
         #[arg(long, alias = "limit", default_value = "20")]
         count: u32,
     },
@@ -1758,6 +1762,7 @@ pub enum ScreenerCmd {
     /// Example: longbridge screener filter pettm:10:50 roe:5: --market HK
     /// Example: longbridge screener filter marketcap:100: divyld:3: --market US
     /// Example: longbridge screener filter roe:20: --market HK --sort roe --show divyld
+    /// Example: longbridge screener filter `pettm::20` --market HK --page 2 --count 50
     Filter {
         /// Filter conditions in KEY:MIN:MAX format
         #[arg(value_name = "KEY:MIN:MAX")]
@@ -1774,7 +1779,10 @@ pub enum ScreenerCmd {
         /// Extra columns to display without adding a filter condition
         #[arg(long = "show", value_name = "KEY")]
         show: Vec<String>,
-        /// Number of results (default: 20)
+        /// Page number (default: 1)
+        #[arg(long, default_value = "1")]
+        page: u32,
+        /// Records per page (default: 20)
         #[arg(long, alias = "limit", default_value = "20")]
         count: u32,
     },
@@ -3538,11 +3546,11 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             ScreenerCmd::Strategies { mine, market } => {
                 screener::cmd_screener_strategies(mine, market.as_str(), format, verbose).await
             }
-            ScreenerCmd::Run { id, sort, order, show, count } => {
-                screener::cmd_screener_run(id, sort.as_deref(), order.as_str(), show.as_slice(), count, format, verbose).await
+            ScreenerCmd::Run { id, sort, order, show, page, count } => {
+                screener::cmd_screener_run(id, sort.as_deref(), order.as_str(), show.as_slice(), page, count, format, verbose).await
             }
-            ScreenerCmd::Filter { conditions, market, sort, order, show, count } => {
-                screener::cmd_screener_filter(conditions.as_slice(), market.as_str(), sort.as_deref(), order.as_str(), show.as_slice(), count, format, verbose).await
+            ScreenerCmd::Filter { conditions, market, sort, order, show, page, count } => {
+                screener::cmd_screener_filter(conditions.as_slice(), market.as_str(), sort.as_deref(), order.as_str(), show.as_slice(), page, count, format, verbose).await
             }
             ScreenerCmd::Indicators { symbol } => {
                 screener::cmd_screener_indicators(symbol.clone(), format, verbose).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1735,7 +1735,7 @@ pub enum ScreenerCmd {
     Run {
         /// Strategy ID from `screener strategies` output
         id: i64,
-        /// Sort results by this indicator key (default: prevclose, descending)
+        /// Sort by indicator key (default: prevchg desc). Default column indices: 0=prevclose 1=prevchg 2=marketcap 3=salesgrowthyoy 4=pettm 5=pbmrq 6=industry
         #[arg(long)]
         sort: Option<String>,
         /// Sort direction: desc (default) | asc
@@ -1770,7 +1770,7 @@ pub enum ScreenerCmd {
         /// Market: US | HK | CN (default: US)
         #[arg(long, default_value = "US")]
         market: String,
-        /// Sort results by this indicator key (default: prevclose, descending)
+        /// Sort by indicator key (default: prevchg desc). Default column indices: 0=prevclose 1=prevchg 2=marketcap 3=salesgrowthyoy 4=pettm 5=pbmrq 6=industry
         #[arg(long)]
         sort: Option<String>,
         /// Sort direction: desc (default) | asc

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1754,14 +1754,16 @@ pub enum ScreenerCmd {
 
     /// Filter stocks with custom indicator conditions
     ///
-    /// Each condition is KEY:MIN:MAX. Omit either bound to leave it open:
-    ///   `pettm:10:` means P/E >= 10, `pettm::50` means P/E <= 50.
+    /// Condition format: KEY:MIN:MAX or KEY:MIN:MAX:k=v,k=v for technical indicators.
+    /// Omit either bound to leave it open: `pettm:10:` means P/E >= 10, `pettm::50` means P/E <= 50.
+    /// Technical indicators use `tech_values` instead of min/max; run `screener indicators --format json`
+    /// to see valid `tech_values` options per key (field: `tech_values`).
     /// Output columns: prevclose, prevchg, marketcap, salesgrowthyoy, pettm, pbmrq, industry.
-    /// Use --show to add extra columns; run `screener indicators` to discover valid keys.
+    /// Use --show to add extra columns.
     ///
     /// Example: longbridge screener filter pettm:10:50 roe:5: --market HK
     /// Example: longbridge screener filter marketcap:100: divyld:3: --market US
-    /// Example: longbridge screener filter roe:20: --market HK --sort roe --show divyld
+    /// Example: longbridge screener filter `macd_day:::category=goldenfork,period=day` --market HK
     /// Example: longbridge screener filter `pettm::20` --market HK --page 1 --count 50
     Filter {
         /// Filter conditions in KEY:MIN:MAX format

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1725,14 +1725,16 @@ pub enum ScreenerCmd {
     /// Run a saved strategy by its ID (from `screener strategies` output)
     ///
     /// The strategy's built-in market and filter conditions are applied automatically.
+    /// Output columns: prevclose, prevchg, marketcap, salesgrowthyoy, pettm, pbmrq, industry.
+    /// Use --show to add extra columns; run `screener indicators` to discover valid keys.
     ///
     /// Example: longbridge screener run 42
-    /// Example: longbridge screener run 42 --sort roe --order asc
-    /// Example: longbridge screener run 42 --show pettm --show pbmrq
+    /// Example: longbridge screener run 42 --sort pettm --order desc
+    /// Example: longbridge screener run 42 --show roe --show divyld
     Run {
         /// Strategy ID from `screener strategies` output
         id: i64,
-        /// Sort results by this indicator key (default: first column, descending)
+        /// Sort results by this indicator key (default: prevclose, descending)
         #[arg(long)]
         sort: Option<String>,
         /// Sort direction: desc (default) | asc
@@ -1750,11 +1752,12 @@ pub enum ScreenerCmd {
     ///
     /// Each condition is KEY:MIN:MAX. Omit either bound to leave it open:
     ///   `pettm:10:` means P/E >= 10, `pettm::50` means P/E <= 50.
-    /// Run `screener indicators` to discover available keys and value ranges.
+    /// Output columns: prevclose, prevchg, marketcap, salesgrowthyoy, pettm, pbmrq, industry.
+    /// Use --show to add extra columns; run `screener indicators` to discover valid keys.
     ///
     /// Example: longbridge screener filter pettm:10:50 roe:5: --market HK
     /// Example: longbridge screener filter marketcap:100: divyld:3: --market US
-    /// Example: longbridge screener filter roe:20: --market HK --sort roe --show pettm --show pbmrq
+    /// Example: longbridge screener filter roe:20: --market HK --sort roe --show divyld
     Filter {
         /// Filter conditions in KEY:MIN:MAX format
         #[arg(value_name = "KEY:MIN:MAX")]
@@ -1762,7 +1765,7 @@ pub enum ScreenerCmd {
         /// Market: US | HK | CN (default: US)
         #[arg(long, default_value = "US")]
         market: String,
-        /// Sort results by this indicator key (default: first condition, descending)
+        /// Sort results by this indicator key (default: prevclose, descending)
         #[arg(long)]
         sort: Option<String>,
         /// Sort direction: desc (default) | asc

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1779,8 +1779,8 @@ pub enum ScreenerCmd {
         /// Extra columns to display without adding a filter condition
         #[arg(long = "show", value_name = "KEY")]
         show: Vec<String>,
-        /// Page number (default: 1)
-        #[arg(long, default_value = "1")]
+        /// Page number (default: 0)
+        #[arg(long, default_value = "0")]
         page: u32,
         /// Records per page (default: 20)
         #[arg(long, alias = "limit", default_value = "20")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1711,11 +1711,15 @@ pub enum ScreenerCmd {
     /// The `id` field in the output is passed to `screener run <ID>`.
     ///
     /// Example: longbridge screener strategies
+    /// Example: longbridge screener strategies --market HK
     /// Example: longbridge screener strategies --mine
     Strategies {
         /// Show user's saved strategies
         #[arg(long)]
         mine: bool,
+        /// Market: US | HK | CN | SG (default: US)
+        #[arg(long, default_value = "US")]
+        market: String,
     },
 
     /// Run a saved strategy by its ID (from `screener strategies` output)
@@ -3528,8 +3532,8 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             quote::cmd_top_movers(market, sort.as_api_value(), count, format, verbose).await
         }
         Commands::Screener { cmd } => match cmd {
-            ScreenerCmd::Strategies { mine } => {
-                screener::cmd_screener_strategies(mine, format, verbose).await
+            ScreenerCmd::Strategies { mine, market } => {
+                screener::cmd_screener_strategies(mine, market.as_str(), format, verbose).await
             }
             ScreenerCmd::Run { id, sort, order, show, count } => {
                 screener::cmd_screener_run(id, sort.as_deref(), order.as_str(), show.as_slice(), count, format, verbose).await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1730,7 +1730,7 @@ pub enum ScreenerCmd {
     ///
     /// Example: longbridge screener run 42
     /// Example: longbridge screener run 42 --sort pettm --order desc
-    /// Example: longbridge screener run 42 --page 2 --count 50
+    /// Example: longbridge screener run 42 --page 1 --count 50
     /// Example: longbridge screener run 42 --show roe --show divyld
     Run {
         /// Strategy ID from `screener strategies` output
@@ -1744,8 +1744,8 @@ pub enum ScreenerCmd {
         /// Extra columns to display without adding a filter condition
         #[arg(long = "show", value_name = "KEY")]
         show: Vec<String>,
-        /// Page number (default: 1)
-        #[arg(long, default_value = "1")]
+        /// Page number (default: 0)
+        #[arg(long, default_value = "0")]
         page: u32,
         /// Records per page (default: 20)
         #[arg(long, alias = "limit", default_value = "20")]
@@ -1762,7 +1762,7 @@ pub enum ScreenerCmd {
     /// Example: longbridge screener filter pettm:10:50 roe:5: --market HK
     /// Example: longbridge screener filter marketcap:100: divyld:3: --market US
     /// Example: longbridge screener filter roe:20: --market HK --sort roe --show divyld
-    /// Example: longbridge screener filter `pettm::20` --market HK --page 2 --count 50
+    /// Example: longbridge screener filter `pettm::20` --market HK --page 1 --count 50
     Filter {
         /// Filter conditions in KEY:MIN:MAX format
         #[arg(value_name = "KEY:MIN:MAX")]

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -3144,7 +3144,12 @@ pub async fn cmd_rank(
                 }
             }
         }
-        Some(k) => {
+        Some(raw_k) => {
+            let k = if raw_k.starts_with("ib_") {
+                raw_k
+            } else {
+                format!("ib_{raw_k}")
+            };
             let count_str = count.to_string();
             // Derive market from key suffix (e.g. ib_hot_all-hk → HK); fall back to --market.
             let key_market = k

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -3122,14 +3122,17 @@ pub async fn cmd_rank(
                             let headers = ["key", "name", "sub-key", "market"];
                             let mut rows: Vec<Vec<String>> = Vec::new();
                             for tag in a {
-                                let k = val_str(&tag["key"]);
+                                let k = val_str(&tag["key"]).trim_start_matches("ib_").to_string();
                                 let n = val_str(&tag["name"]);
                                 if let Some(subs) = tag["second_tags"].as_array() {
                                     for sub in subs {
+                                        let sk = val_str(&sub["key"])
+                                            .trim_start_matches("ib_")
+                                            .to_string();
                                         rows.push(vec![
                                             k.clone(),
                                             n.clone(),
-                                            val_str(&sub["key"]),
+                                            sk,
                                             val_str(&sub["market"]),
                                         ]);
                                     }

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -44,48 +44,45 @@ pub async fn cmd_screener_strategies(
     };
     let mkt = market.to_uppercase();
     let data = http_get(path, &[("market", mkt.as_str())], verbose).await?;
-    match format {
-        OutputFormat::Json => println!(
-            "{}",
-            serde_json::to_string_pretty(&data).unwrap_or_default()
-        ),
-        OutputFormat::Pretty => {
-            let screeners = match data
-                .get("strategys")
-                .or_else(|| data.get("screeners"))
-                .and_then(|v| v.as_array())
-            {
-                Some(a) if !a.is_empty() => a,
-                _ => {
-                    println!("No strategies found.");
-                    return Ok(());
-                }
-            };
-            let label = if mine {
-                "My Strategies"
-            } else {
-                "Preset Strategies"
-            };
-            println!("{label}\n");
-            let headers = ["ID", "Name", "Avg Day Chg", "Type"];
-            let rows: Vec<Vec<String>> = screeners
-                .iter()
-                .map(|s| {
-                    let type_str = match s["type"].as_i64() {
-                        Some(1) => "User",
-                        _ => "Platform",
-                    };
-                    vec![
-                        val_str(&s["id"]),
-                        val_str(&s["name"]),
-                        val_str(&s["average_day_chg"]),
-                        type_str.to_string(),
-                    ]
-                })
-                .collect();
-            print_table(&headers, rows, format);
+    let screeners = match data
+        .get("strategys")
+        .or_else(|| data.get("screeners"))
+        .and_then(|v| v.as_array())
+    {
+        Some(a) if !a.is_empty() => a,
+        _ => {
+            match format {
+                OutputFormat::Json => println!("[]"),
+                OutputFormat::Pretty => println!("No strategies found."),
+            }
+            return Ok(());
         }
+    };
+    if matches!(format, OutputFormat::Pretty) {
+        let label = if mine {
+            "My Strategies"
+        } else {
+            "Preset Strategies"
+        };
+        println!("{label}\n");
     }
+    let headers = ["ID", "Name", "Avg Day Chg", "Type"];
+    let rows: Vec<Vec<String>> = screeners
+        .iter()
+        .map(|s| {
+            let type_str = match s["type"].as_i64() {
+                Some(1) => "User",
+                _ => "Platform",
+            };
+            vec![
+                val_str(&s["id"]),
+                val_str(&s["name"]),
+                val_str(&s["average_day_chg"]),
+                type_str.to_string(),
+            ]
+        })
+        .collect();
+    print_table(&headers, rows, format);
     Ok(())
 }
 
@@ -219,62 +216,58 @@ async fn print_screener_results(
         "industries": [],
     });
     let data = http_post("/v1/quote/ai/screener/search", body, verbose).await?;
-    match format {
-        OutputFormat::Json => println!(
-            "{}",
-            serde_json::to_string_pretty(&data).unwrap_or_default()
-        ),
-        OutputFormat::Pretty => {
-            let total = data
-                .get("total")
-                .and_then(serde_json::Value::as_i64)
-                .unwrap_or_else(|| {
-                    data["items"]
-                        .as_array()
-                        .map_or(0, |a| i64::try_from(a.len()).unwrap_or(0))
-                });
-            let label = if strategy_id > 0 {
-                format!("Strategy #{strategy_id} ({market})")
-            } else {
-                format!("Custom filter ({market})")
-            };
-            println!("{label} — {total} stocks found\n");
-            let stocks = match data.get("items").and_then(|v| v.as_array()) {
-                Some(a) if !a.is_empty() => a,
-                _ => {
-                    println!("No stocks found matching the criteria.");
-                    return Ok(());
-                }
-            };
-            let mut headers = vec!["Symbol".to_string(), "Name".to_string()];
-            headers.extend(
-                effective_returns
-                    .iter()
-                    .map(|k| k.replace("filter_", "").to_uppercase()),
-            );
-            let header_refs: Vec<&str> = headers.iter().map(String::as_str).collect();
-            let rows: Vec<Vec<String>> = stocks
-                .iter()
-                .map(|s| {
-                    let sym =
-                        crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"]));
-                    let mut row = vec![sym, val_str(&s["name"])];
-                    if let Some(indicators) = s["indicators"].as_array() {
-                        row.extend(indicators.iter().map(|ind| {
-                            let v = val_str(&ind["value"]);
-                            if v.is_empty() || v == "-" {
-                                return "-".to_string();
-                            }
-                            let unit = val_str(&ind["unit"]);
-                            format_financial_value(&v, unit == "%")
-                        }));
-                    }
-                    row
-                })
-                .collect();
-            print_table(&header_refs, rows, format);
+    let total = data
+        .get("total")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or_else(|| {
+            data["items"]
+                .as_array()
+                .map_or(0, |a| i64::try_from(a.len()).unwrap_or(0))
+        });
+    let stocks = match data.get("items").and_then(|v| v.as_array()) {
+        Some(a) if !a.is_empty() => a,
+        _ => {
+            match format {
+                OutputFormat::Json => println!("[]"),
+                OutputFormat::Pretty => println!("No stocks found matching the criteria."),
+            }
+            return Ok(());
         }
+    };
+    let mut headers = vec!["Symbol".to_string(), "Name".to_string()];
+    headers.extend(
+        effective_returns
+            .iter()
+            .map(|k| k.replace("filter_", "").to_uppercase()),
+    );
+    let header_refs: Vec<&str> = headers.iter().map(String::as_str).collect();
+    let rows: Vec<Vec<String>> = stocks
+        .iter()
+        .map(|s| {
+            let sym = crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"]));
+            let mut row = vec![sym, val_str(&s["name"])];
+            if let Some(indicators) = s["indicators"].as_array() {
+                row.extend(indicators.iter().map(|ind| {
+                    let v = val_str(&ind["value"]);
+                    if v.is_empty() || v == "-" {
+                        return "-".to_string();
+                    }
+                    let unit = val_str(&ind["unit"]);
+                    format_financial_value(&v, unit == "%")
+                }));
+            }
+            row
+        })
+        .collect();
+    if matches!(format, OutputFormat::Pretty) {
+        let label = if strategy_id > 0 {
+            format!("Strategy #{strategy_id} ({market})")
+        } else {
+            format!("Custom filter ({market})")
+        };
+        println!("{label} — {total} stocks found\n");
     }
+    print_table(&header_refs, rows, format);
     Ok(())
 }
 
@@ -290,24 +283,47 @@ pub async fn cmd_screener_indicators(
         params.push(("counter_id", cid.as_str()));
     }
     let data = http_get("/v1/quote/ai/screener/indicators", &params, verbose).await?;
+    let groups = match data.get("groups").and_then(|v| v.as_array()) {
+        Some(a) if !a.is_empty() => a,
+        _ => {
+            match format {
+                OutputFormat::Json => println!("[]"),
+                OutputFormat::Pretty => println!("No indicator config found."),
+            }
+            return Ok(());
+        }
+    };
+    let headers = ["ID", "Key", "Name", "Unit", "Min", "Max"];
     match format {
-        OutputFormat::Json => println!(
-            "{}",
-            serde_json::to_string_pretty(&data).unwrap_or_default()
-        ),
+        OutputFormat::Json => {
+            let rows: Vec<Vec<String>> = groups
+                .iter()
+                .flat_map(|group| {
+                    group["indicators"]
+                        .as_array()
+                        .into_iter()
+                        .flatten()
+                        .map(|ind| {
+                            let min = val_str(&ind["default_range"]["min"]);
+                            let max = val_str(&ind["default_range"]["max"]);
+                            vec![
+                                val_str(&ind["id"]),
+                                val_str(&ind["key"]),
+                                val_str(&ind["name"]),
+                                val_str(&ind["unit"]),
+                                min,
+                                max,
+                            ]
+                        })
+                })
+                .collect();
+            print_table(&headers, rows, format);
+        }
         OutputFormat::Pretty => {
-            let groups = match data.get("groups").and_then(|v| v.as_array()) {
-                Some(a) if !a.is_empty() => a,
-                _ => {
-                    println!("No indicator config found.");
-                    return Ok(());
-                }
-            };
             for group in groups {
                 let gname = val_str(&group["group_name"]);
                 println!("── {gname} ──");
                 if let Some(indicators) = group["indicators"].as_array() {
-                    let headers = ["ID", "Key", "Name", "Unit", "Min", "Max"];
                     let rows: Vec<Vec<String>> = indicators
                         .iter()
                         .map(|ind| {

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -232,7 +232,13 @@ async fn print_screener_results(
         Some(a) if !a.is_empty() => a,
         _ => {
             match format {
-                OutputFormat::Json => println!("[]"),
+                OutputFormat::Json => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "total": total, "page": page, "items": []
+                    }))
+                    .unwrap_or_default()
+                ),
                 OutputFormat::Pretty => println!("No stocks found matching the criteria."),
             }
             return Ok(());
@@ -263,15 +269,43 @@ async fn print_screener_results(
             row
         })
         .collect();
-    if matches!(format, OutputFormat::Pretty) {
-        let label = if strategy_id > 0 {
-            format!("Strategy #{strategy_id} ({market})")
-        } else {
-            format!("Custom filter ({market})")
-        };
-        println!("{label} — {total} stocks found\n");
+    match format {
+        OutputFormat::Pretty => {
+            let label = if strategy_id > 0 {
+                format!("Strategy #{strategy_id} ({market})")
+            } else {
+                format!("Custom filter ({market})")
+            };
+            println!("{label} — {total} stocks found\n");
+            print_table(&header_refs, rows, format);
+        }
+        OutputFormat::Json => {
+            let items: Vec<serde_json::Value> = rows
+                .into_iter()
+                .map(|row| {
+                    let mut map = serde_json::Map::new();
+                    for (i, val) in row.into_iter().enumerate() {
+                        if let Some(key) = header_refs.get(i) {
+                            map.insert(
+                                key.to_lowercase().replace(' ', "_"),
+                                serde_json::Value::String(val),
+                            );
+                        }
+                    }
+                    serde_json::Value::Object(map)
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "total": total,
+                    "page": page,
+                    "items": items,
+                }))
+                .unwrap_or_default()
+            );
+        }
     }
-    print_table(&header_refs, rows, format);
     Ok(())
 }
 

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -210,7 +210,7 @@ async fn print_screener_results(
         "sort_order": sort_order,
         "industries": [],
     });
-    let data = http_post("/v1/quote/screener/search", body, verbose).await?;
+    let data = http_post("/v1/quote/ai/screener/search", body, verbose).await?;
     match format {
         OutputFormat::Json => println!(
             "{}",
@@ -281,7 +281,7 @@ pub async fn cmd_screener_indicators(
         cid = symbol_to_counter_id(sym);
         params.push(("counter_id", cid.as_str()));
     }
-    let data = http_get("/v1/quote/screener/indicators", &params, verbose).await?;
+    let data = http_get("/v1/quote/ai/screener/indicators", &params, verbose).await?;
     match format {
         OutputFormat::Json => println!(
             "{}",

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -23,6 +23,7 @@ fn val_str(v: &Value) -> String {
 
 pub async fn cmd_screener_strategies(
     mine: bool,
+    market: &str,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
@@ -31,8 +32,8 @@ pub async fn cmd_screener_strategies(
     } else {
         "/v1/quote/ai/screener/strategies/recommend"
     };
-
-    let data = http_get(path, &[], verbose).await?;
+    let mkt = market.to_uppercase();
+    let data = http_get(path, &[("market", mkt.as_str())], verbose).await?;
     match format {
         OutputFormat::Json => println!(
             "{}",

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -90,7 +90,6 @@ pub async fn cmd_screener_run(
 ) -> Result<()> {
     let path = format!("/v1/quote/ai/screener/strategy/{id}");
     let strategy = http_get(&path, &[], verbose).await?;
-
     let mkt = val_str(&strategy["market"]);
     let mkt = if mkt.is_empty() || mkt == "-" {
         "US".to_string()

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -91,6 +91,7 @@ pub async fn cmd_screener_run(
     sort: Option<&str>,
     order: &str,
     show: &[String],
+    page: u32,
     count: u32,
     format: &OutputFormat,
     verbose: bool,
@@ -129,7 +130,7 @@ pub async fn cmd_screener_run(
         }
     }
     print_screener_results(
-        id, &mkt, &filters, &returns, sort, order, count, format, verbose,
+        id, &mkt, &filters, &returns, sort, order, page, count, format, verbose,
     )
     .await
 }
@@ -140,6 +141,7 @@ pub async fn cmd_screener_filter(
     sort: Option<&str>,
     order: &str,
     show: &[String],
+    page: u32,
     count: u32,
     format: &OutputFormat,
     verbose: bool,
@@ -175,6 +177,7 @@ pub async fn cmd_screener_filter(
         &returns,
         sort,
         order,
+        page,
         count,
         format,
         verbose,
@@ -189,6 +192,7 @@ async fn print_screener_results(
     returns: &[String],
     sort: Option<&str>,
     order: &str,
+    page: u32,
     count: u32,
     format: &OutputFormat,
     verbose: bool,
@@ -207,7 +211,7 @@ async fn print_screener_results(
     let sort_order: u8 = u8::from(order != "asc");
     let body = serde_json::json!({
         "market": market,
-        "page": 1,
+        "page": page,
         "size": count,
         "filters": filters,
         "returns": effective_returns,

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -114,11 +114,17 @@ pub async fn cmd_screener_run(
             }
             let min = val_str(&ind["min"]);
             let max = val_str(&ind["max"]);
+            let tech_values = ind["tech_values"].clone();
+            let tech_values = if tech_values.is_object() {
+                tech_values
+            } else {
+                serde_json::json!({})
+            };
             filters.push(serde_json::json!({
                 "key": key,
                 "min": min,
                 "max": max,
-                "tech_values": {}
+                "tech_values": tech_values,
             }));
         }
     }
@@ -148,7 +154,7 @@ pub async fn cmd_screener_filter(
 ) -> Result<()> {
     let mut filters: Vec<serde_json::Value> = Vec::new();
     for cond in conditions {
-        let parts: Vec<&str> = cond.splitn(3, ':').collect();
+        let parts: Vec<&str> = cond.splitn(4, ':').collect();
         let raw_key = parts.first().copied().unwrap_or("");
         if raw_key.is_empty() {
             continue;
@@ -156,11 +162,27 @@ pub async fn cmd_screener_filter(
         let key = normalize_key(raw_key);
         let min = parts.get(1).copied().unwrap_or("").to_string();
         let max = parts.get(2).copied().unwrap_or("").to_string();
+        let tech_values: serde_json::Map<String, serde_json::Value> = parts
+            .get(3)
+            .map(|s| {
+                s.split(',')
+                    .filter_map(|kv| {
+                        let mut it = kv.splitn(2, '=');
+                        let k = it.next()?.trim();
+                        let v = it.next()?.trim();
+                        if k.is_empty() || v.is_empty() {
+                            return None;
+                        }
+                        Some((k.to_string(), serde_json::Value::String(v.to_string())))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
         filters.push(serde_json::json!({
             "key": key,
             "min": min,
             "max": max,
-            "tech_values": {}
+            "tech_values": tech_values,
         }));
     }
     let mut returns: Vec<String> = DEFAULT_RETURNS.iter().map(ToString::to_string).collect();
@@ -345,7 +367,7 @@ pub async fn cmd_screener_indicators(
     let headers = ["ID", "Key", "Name", "Unit", "Min", "Max"];
     match format {
         OutputFormat::Json => {
-            let rows: Vec<Vec<String>> = groups
+            let items: Vec<serde_json::Value> = groups
                 .iter()
                 .flat_map(|group| {
                     group["indicators"]
@@ -355,18 +377,43 @@ pub async fn cmd_screener_indicators(
                         .map(|ind| {
                             let min = val_str(&ind["default_range"]["min"]);
                             let max = val_str(&ind["default_range"]["max"]);
-                            vec![
-                                val_str(&ind["id"]),
-                                val_str(&ind["key"]).replace("filter_", ""),
-                                val_str(&ind["name"]),
-                                val_str(&ind["unit"]),
-                                min,
-                                max,
-                            ]
+                            let mut obj = serde_json::json!({
+                                "id": val_str(&ind["id"]),
+                                "key": val_str(&ind["key"]).replace("filter_", ""),
+                                "name": val_str(&ind["name"]),
+                                "unit": val_str(&ind["unit"]),
+                                "min": if min == "-" { serde_json::Value::Null } else { serde_json::Value::String(min) },
+                                "max": if max == "-" { serde_json::Value::Null } else { serde_json::Value::String(max) },
+                            });
+                            if let Some(tech_inds) = ind["tech_indicators"].as_array() {
+                                let tv: serde_json::Map<String, serde_json::Value> = tech_inds
+                                    .iter()
+                                    .map(|ti| {
+                                        let key = val_str(&ti["tech_key"]);
+                                        let opts: Vec<serde_json::Value> = ti["tech_items"]
+                                            .as_array()
+                                            .unwrap_or(&vec![])
+                                            .iter()
+                                            .map(|item| serde_json::json!({
+                                                "value": val_str(&item["item_value"]),
+                                                "label": val_str(&item["item_name"]),
+                                            }))
+                                            .collect();
+                                        (key, serde_json::Value::Array(opts))
+                                    })
+                                    .collect();
+                                if !tv.is_empty() {
+                                    obj["tech_values"] = serde_json::Value::Object(tv);
+                                }
+                            }
+                            obj
                         })
                 })
                 .collect();
-            print_table(&headers, rows, format);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&items).unwrap_or_default()
+            );
         }
         OutputFormat::Pretty => {
             for group in groups {

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -244,33 +244,34 @@ async fn print_screener_results(
             return Ok(());
         }
     };
-    let mut headers = vec!["Symbol".to_string(), "Name".to_string()];
-    headers.extend(
-        effective_returns
-            .iter()
-            .map(|k| k.replace("filter_", "").to_uppercase()),
-    );
-    let header_refs: Vec<&str> = headers.iter().map(String::as_str).collect();
-    let rows: Vec<Vec<String>> = stocks
-        .iter()
-        .map(|s| {
-            let sym = crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"]));
-            let mut row = vec![sym, val_str(&s["name"])];
-            if let Some(indicators) = s["indicators"].as_array() {
-                row.extend(indicators.iter().map(|ind| {
-                    let v = val_str(&ind["value"]);
-                    if v.is_empty() || v == "-" {
-                        return "-".to_string();
-                    }
-                    let unit = val_str(&ind["unit"]);
-                    format_financial_value(&v, unit == "%")
-                }));
-            }
-            row
-        })
-        .collect();
     match format {
         OutputFormat::Pretty => {
+            let mut headers = vec!["Symbol".to_string(), "Name".to_string()];
+            headers.extend(
+                effective_returns
+                    .iter()
+                    .map(|k| k.replace("filter_", "").to_uppercase()),
+            );
+            let header_refs: Vec<&str> = headers.iter().map(String::as_str).collect();
+            let rows: Vec<Vec<String>> = stocks
+                .iter()
+                .map(|s| {
+                    let sym =
+                        crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"]));
+                    let mut row = vec![sym, val_str(&s["name"])];
+                    if let Some(indicators) = s["indicators"].as_array() {
+                        row.extend(indicators.iter().map(|ind| {
+                            let v = val_str(&ind["value"]);
+                            if v.is_empty() || v == "-" {
+                                return "-".to_string();
+                            }
+                            let unit = val_str(&ind["unit"]);
+                            format_financial_value(&v, unit == "%")
+                        }));
+                    }
+                    row
+                })
+                .collect();
             let label = if strategy_id > 0 {
                 format!("Strategy #{strategy_id} ({market})")
             } else {
@@ -280,16 +281,26 @@ async fn print_screener_results(
             print_table(&header_refs, rows, format);
         }
         OutputFormat::Json => {
-            let items: Vec<serde_json::Value> = rows
-                .into_iter()
-                .map(|row| {
+            let items: Vec<serde_json::Value> = stocks
+                .iter()
+                .map(|s| {
+                    let sym =
+                        crate::utils::counter::counter_id_to_symbol(&val_str(&s["counter_id"]));
                     let mut map = serde_json::Map::new();
-                    for (i, val) in row.into_iter().enumerate() {
-                        if let Some(key) = header_refs.get(i) {
-                            map.insert(
-                                key.to_lowercase().replace(' ', "_"),
-                                serde_json::Value::String(val),
-                            );
+                    map.insert("symbol".to_string(), serde_json::Value::String(sym));
+                    map.insert(
+                        "name".to_string(),
+                        serde_json::Value::String(val_str(&s["name"])),
+                    );
+                    if let Some(indicators) = s["indicators"].as_array() {
+                        for ind in indicators {
+                            let key = val_str(&ind["key"]).replace("filter_", "");
+                            let raw = val_str(&ind["value"]);
+                            let json_val = raw
+                                .parse::<f64>()
+                                .map(|n| serde_json::json!(n))
+                                .unwrap_or(serde_json::Value::String(raw));
+                            map.insert(key, json_val);
                         }
                     }
                     serde_json::Value::Object(map)
@@ -346,7 +357,7 @@ pub async fn cmd_screener_indicators(
                             let max = val_str(&ind["default_range"]["max"]);
                             vec![
                                 val_str(&ind["id"]),
-                                val_str(&ind["key"]),
+                                val_str(&ind["key"]).replace("filter_", ""),
                                 val_str(&ind["name"]),
                                 val_str(&ind["unit"]),
                                 min,

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -40,7 +40,11 @@ pub async fn cmd_screener_strategies(
             serde_json::to_string_pretty(&data).unwrap_or_default()
         ),
         OutputFormat::Pretty => {
-            let screeners = match data.get("screeners").and_then(|v| v.as_array()) {
+            let screeners = match data
+                .get("strategys")
+                .or_else(|| data.get("screeners"))
+                .and_then(|v| v.as_array())
+            {
                 Some(a) if !a.is_empty() => a,
                 _ => {
                     println!("No strategies found.");

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -23,16 +23,13 @@ fn val_str(v: &Value) -> String {
 
 pub async fn cmd_screener_strategies(
     mine: bool,
-    all: bool,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
     let path = if mine {
-        "/v1/quote/screener/strategies/mine"
-    } else if all {
-        "/v1/quote/screener/strategies"
+        "/v1/quote/ai/screener/strategies/mine"
     } else {
-        "/v1/quote/screener/strategies/recommend"
+        "/v1/quote/ai/screener/strategies/recommend"
     };
 
     let data = http_get(path, &[], verbose).await?;
@@ -51,10 +48,8 @@ pub async fn cmd_screener_strategies(
             };
             let label = if mine {
                 "My Strategies"
-            } else if all {
-                "All Strategies"
             } else {
-                "Recommended Strategies"
+                "Preset Strategies"
             };
             println!("{label}\n");
             let headers = ["ID", "Name", "Avg Day Chg", "Type"];
@@ -88,7 +83,7 @@ pub async fn cmd_screener_run(
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
-    let strategies = http_get("/v1/quote/screener/strategies/recommend", &[], verbose).await?;
+    let strategies = http_get("/v1/quote/ai/screener/strategies/recommend", &[], verbose).await?;
     let strategy_obj = strategies["screeners"]
         .as_array()
         .and_then(|arr| arr.iter().find(|s| s["id"].as_i64() == Some(id)))
@@ -97,7 +92,7 @@ pub async fn cmd_screener_run(
     let strategy = if strategy_obj.is_null() {
         let id_str = id.to_string();
         http_get(
-            "/v1/quote/screener/strategy",
+            "/v1/quote/ai/screener/strategy",
             &[("id", id_str.as_str())],
             verbose,
         )

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -5,6 +5,16 @@ use super::{api::http_get, api::http_post, output::print_table, OutputFormat};
 use crate::utils::counter::symbol_to_counter_id;
 use crate::utils::number::format_financial_value;
 
+const DEFAULT_RETURNS: &[&str] = &[
+    "filter_prevclose",
+    "filter_prevchg",
+    "filter_marketcap",
+    "filter_salesgrowthyoy",
+    "filter_pettm",
+    "filter_pbmrq",
+    "filter_industry",
+];
+
 fn normalize_key(key: &str) -> String {
     if key.starts_with("filter_") {
         key.to_string()
@@ -98,7 +108,6 @@ pub async fn cmd_screener_run(
     };
 
     let mut filters: Vec<serde_json::Value> = Vec::new();
-    let mut returns: Vec<String> = Vec::new();
     if let Some(f) = strategy["filter"]["filters"].as_array() {
         for ind in f {
             let key = val_str(&ind["key"]);
@@ -113,9 +122,9 @@ pub async fn cmd_screener_run(
                 "max": max,
                 "tech_values": {}
             }));
-            returns.push(key);
         }
     }
+    let mut returns: Vec<String> = DEFAULT_RETURNS.iter().map(ToString::to_string).collect();
     for key in show {
         let full_key = normalize_key(key);
         if !returns.contains(&full_key) {
@@ -139,7 +148,6 @@ pub async fn cmd_screener_filter(
     verbose: bool,
 ) -> Result<()> {
     let mut filters: Vec<serde_json::Value> = Vec::new();
-    let mut returns: Vec<String> = Vec::new();
     for cond in conditions {
         let parts: Vec<&str> = cond.splitn(3, ':').collect();
         let raw_key = parts.first().copied().unwrap_or("");
@@ -155,8 +163,8 @@ pub async fn cmd_screener_filter(
             "max": max,
             "tech_values": {}
         }));
-        returns.push(key);
     }
+    let mut returns: Vec<String> = DEFAULT_RETURNS.iter().map(ToString::to_string).collect();
     for key in show {
         let full_key = normalize_key(key);
         if !returns.contains(&full_key) {

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -91,37 +91,30 @@ pub async fn cmd_screener_run(
     let path = format!("/v1/quote/ai/screener/strategy/{id}");
     let strategy = http_get(&path, &[], verbose).await?;
 
-    let mut mkt = "US".to_string();
+    let mkt = val_str(&strategy["market"]);
+    let mkt = if mkt.is_empty() || mkt == "-" {
+        "US".to_string()
+    } else {
+        mkt.to_uppercase()
+    };
+
     let mut filters: Vec<serde_json::Value> = Vec::new();
     let mut returns: Vec<String> = Vec::new();
-    if let Some(groups) = strategy["groups"].as_array() {
-        for group in groups {
-            if let Some(indicators) = group["indicators"].as_array() {
-                for ind in indicators {
-                    let key = val_str(&ind["key"]);
-                    let ind_id = ind["id"].as_i64().unwrap_or(0);
-                    if ind_id == -1 && key == "filter_market" {
-                        let v = val_str(&ind["value"]);
-                        if !v.is_empty() && v != "-" {
-                            mkt = v;
-                        }
-                    } else {
-                        let min = val_str(&ind["min"]);
-                        let max = val_str(&ind["max"]);
-                        let has_range =
-                            (!min.is_empty() && min != "-") || (!max.is_empty() && max != "-");
-                        if has_range || ind_id > 0 {
-                            filters.push(serde_json::json!({
-                                "key": key,
-                                "min": min,
-                                "max": max,
-                                "tech_values": {}
-                            }));
-                            returns.push(key);
-                        }
-                    }
-                }
+    if let Some(f) = strategy["filter"]["filters"].as_array() {
+        for ind in f {
+            let key = val_str(&ind["key"]);
+            if key.is_empty() || key == "-" {
+                continue;
             }
+            let min = val_str(&ind["min"]);
+            let max = val_str(&ind["max"]);
+            filters.push(serde_json::json!({
+                "key": key,
+                "min": min,
+                "max": max,
+                "tech_values": {}
+            }));
+            returns.push(key);
         }
     }
     for key in show {

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -207,7 +207,7 @@ async fn print_screener_results(
     let sort_by = sort_key
         .as_deref()
         .and_then(|k| effective_returns.iter().position(|r| r == k))
-        .unwrap_or(0);
+        .unwrap_or(1);
     let sort_order: u8 = u8::from(order != "asc");
     let body = serde_json::json!({
         "market": market,

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -88,13 +88,8 @@ pub async fn cmd_screener_run(
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
-    let id_str = id.to_string();
-    let strategy = http_get(
-        "/v1/quote/ai/screener/strategy",
-        &[("id", id_str.as_str())],
-        verbose,
-    )
-    .await?;
+    let path = format!("/v1/quote/ai/screener/strategy/{id}");
+    let strategy = http_get(&path, &[], verbose).await?;
 
     let mut mkt = "US".to_string();
     let mut filters: Vec<serde_json::Value> = Vec::new();

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -84,23 +84,13 @@ pub async fn cmd_screener_run(
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
-    let strategies = http_get("/v1/quote/ai/screener/strategies/recommend", &[], verbose).await?;
-    let strategy_obj = strategies["screeners"]
-        .as_array()
-        .and_then(|arr| arr.iter().find(|s| s["id"].as_i64() == Some(id)))
-        .cloned()
-        .unwrap_or(serde_json::Value::Null);
-    let strategy = if strategy_obj.is_null() {
-        let id_str = id.to_string();
-        http_get(
-            "/v1/quote/ai/screener/strategy",
-            &[("id", id_str.as_str())],
-            verbose,
-        )
-        .await?
-    } else {
-        strategy_obj
-    };
+    let id_str = id.to_string();
+    let strategy = http_get(
+        "/v1/quote/ai/screener/strategy",
+        &[("id", id_str.as_str())],
+        verbose,
+    )
+    .await?;
 
     let mut mkt = "US".to_string();
     let mut filters: Vec<serde_json::Value> = Vec::new();


### PR DESCRIPTION
## Summary

- Switch screener search and indicators to `/v1/quote/ai/screener/*` endpoints
- Add `screener filter` command — ad-hoc filtering without a saved strategy
- Add pagination (`--page`, `--count`) to `screener run` and `screener filter`
- Default sort to `prevchg` descending; document column indices in `--sort` help
- Support `tech_values` for technical indicator filters via `KEY:::k=v,k=v` format
- Fix `screener run` to pass through `tech_values` from strategy response
- Normalize JSON output for AI agent use:
  - `run`/`filter`: `{market, total, page, items: [{symbol, name, <indicators as floats>}]}`
  - `strategies`: `[{id: int, name, type: "user"|"platform"}]`
  - `indicators`: `[{id, key, name, unit, min, max, tech_values?}]`
  - Numeric indicator values as JSON numbers (not strings); `filter_` prefix stripped

## Test plan

- [ ] `LONGBRIDGE_ENV=staging cargo run -- screener strategies --format json` — ids are integers, no avg_day_chg
- [ ] `LONGBRIDGE_ENV=staging cargo run -- screener strategies --mine` — returns user strategies
- [ ] `LONGBRIDGE_ENV=staging cargo run -- screener run <ID> --format json` — includes market field
- [ ] `LONGBRIDGE_ENV=staging cargo run -- screener filter "pettm:10:20" --format json` — flat items, numeric values
- [ ] `LONGBRIDGE_ENV=staging cargo run -- screener filter "macd_day:::category=deadcross,period=day"` — tech_values
- [ ] `LONGBRIDGE_ENV=staging cargo run -- screener indicators --format json` — tech indicators include tech_values options
- [ ] `cargo clippy` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)