### PR TITLE
cli: Fix counter_id leaks and normalize JSON output in rank/screener

### DIFF
--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2154,7 +2154,7 @@ fn replace_counter_ids(v: &mut Value) {
             if let Some(cid) = map.remove("counter_id") {
                 let sym = cid
                     .as_str()
-                    .map(|s| crate::utils::counter::counter_id_to_symbol(s))
+                    .map(crate::utils::counter::counter_id_to_symbol)
                     .unwrap_or_default();
                 map.insert("symbol".to_string(), Value::String(sym));
             }
@@ -3144,7 +3144,41 @@ pub async fn cmd_rank(
         None => {
             let data = http_get("/v1/quote/market/rank/categories", &[], verbose).await?;
             match format {
-                OutputFormat::Json => print_json(&data),
+                OutputFormat::Json => {
+                    let tags = data.get("first_tags").and_then(|v| v.as_array());
+                    let items: Vec<serde_json::Value> = tags
+                        .into_iter()
+                        .flatten()
+                        .flat_map(|tag| {
+                            let name = val_str(&tag["name"]);
+                            let k = val_str(&tag["key"]).trim_start_matches("ib_").to_string();
+                            if let Some(subs) = tag["second_tags"].as_array() {
+                                subs.iter()
+                                    .map(|sub| {
+                                        let sk = val_str(&sub["key"])
+                                            .trim_start_matches("ib_")
+                                            .to_string();
+                                        serde_json::json!({
+                                            "key": sk,
+                                            "name": name,
+                                            "market": val_str(&sub["market"]),
+                                        })
+                                    })
+                                    .collect::<Vec<_>>()
+                            } else {
+                                vec![serde_json::json!({
+                                    "key": k,
+                                    "name": name,
+                                    "market": "",
+                                })]
+                            }
+                        })
+                        .collect();
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&items).unwrap_or_default()
+                    );
+                }
                 OutputFormat::Pretty => {
                     let tags = data.get("first_tags").and_then(|v| v.as_array());
                     match tags {

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2146,6 +2146,37 @@ fn print_json(data: &Value) {
     println!("{}", serde_json::to_string_pretty(data).unwrap_or_default());
 }
 
+/// Recursively replace every `"counter_id"` key in a JSON value with
+/// `"symbol"`, converting the value via `counter_id_to_symbol`.
+fn replace_counter_ids(v: &mut Value) {
+    match v {
+        Value::Object(map) => {
+            if let Some(cid) = map.remove("counter_id") {
+                let sym = cid
+                    .as_str()
+                    .map(|s| crate::utils::counter::counter_id_to_symbol(s))
+                    .unwrap_or_default();
+                map.insert("symbol".to_string(), Value::String(sym));
+            }
+            for val in map.values_mut() {
+                replace_counter_ids(val);
+            }
+        }
+        Value::Array(arr) => {
+            for val in arr.iter_mut() {
+                replace_counter_ids(val);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn print_json_with_symbols(data: &Value) {
+    let mut v = data.clone();
+    replace_counter_ids(&mut v);
+    println!("{}", serde_json::to_string_pretty(&v).unwrap_or_default());
+}
+
 /// Convert index symbol to IX/ prefix `counter_id` (e.g. `HSI.HK` → `IX/HK/HSI`,
 /// `.DJI.US` → `IX/US/.DJI`).
 fn index_symbol_to_counter_id(symbol: &str) -> String {
@@ -2876,7 +2907,7 @@ pub async fn cmd_short_positions(
     )
     .await?;
     match format {
-        OutputFormat::Json => print_json(&data),
+        OutputFormat::Json => print_json_with_symbols(&data),
         OutputFormat::Pretty => {
             let mut items = match data.get("data").and_then(|v| v.as_array()) {
                 Some(a) if !a.is_empty() => a.clone(),
@@ -3049,7 +3080,7 @@ pub async fn cmd_top_movers(
     });
     let data = http_post("/v1/quote/market/stock-events", body, verbose).await?;
     match format {
-        OutputFormat::Json => print_json(&data),
+        OutputFormat::Json => print_json_with_symbols(&data),
         OutputFormat::Pretty => {
             if let Some(ts) = data.get("updated_at").and_then(serde_json::Value::as_i64) {
                 println!("Updated: {}\n", fmt_ts(&ts.to_string()));
@@ -3173,7 +3204,7 @@ pub async fn cmd_rank(
             )
             .await?;
             match format {
-                OutputFormat::Json => print_json(&data),
+                OutputFormat::Json => print_json_with_symbols(&data),
                 OutputFormat::Pretty => {
                     let lists = match data.get("lists").and_then(|v| v.as_array()) {
                         Some(a) if !a.is_empty() => a,

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -58,14 +58,36 @@ pub async fn cmd_screener_strategies(
             return Ok(());
         }
     };
-    if matches!(format, OutputFormat::Pretty) {
-        let label = if mine {
-            "My Strategies"
-        } else {
-            "Preset Strategies"
-        };
-        println!("{label}\n");
+    if matches!(format, OutputFormat::Json) {
+        let items: Vec<serde_json::Value> = screeners
+            .iter()
+            .map(|s| {
+                let type_str = match s["type"].as_i64() {
+                    Some(1) => "user",
+                    _ => "platform",
+                };
+                let id = s["id"]
+                    .as_i64()
+                    .unwrap_or_else(|| val_str(&s["id"]).parse::<i64>().unwrap_or(0));
+                serde_json::json!({
+                    "id": id,
+                    "name": val_str(&s["name"]),
+                    "type": type_str,
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&items).unwrap_or_default()
+        );
+        return Ok(());
     }
+    let label = if mine {
+        "My Strategies"
+    } else {
+        "Preset Strategies"
+    };
+    println!("{label}\n");
     let headers = ["ID", "Name", "Avg Day Chg", "Type"];
     let rows: Vec<Vec<String>> = screeners
         .iter()
@@ -257,7 +279,7 @@ async fn print_screener_results(
                 OutputFormat::Json => println!(
                     "{}",
                     serde_json::to_string_pretty(&serde_json::json!({
-                        "total": total, "page": page, "items": []
+                        "market": market, "total": total, "page": page, "items": []
                     }))
                     .unwrap_or_default()
                 ),
@@ -331,6 +353,7 @@ async fn print_screener_results(
             println!(
                 "{}",
                 serde_json::to_string_pretty(&serde_json::json!({
+                    "market": market,
                     "total": total,
                     "page": page,
                     "items": items,


### PR DESCRIPTION
## Summary

- `short-trades` / `top-movers` / `rank --key`: convert `counter_id` → `symbol` in JSON output via recursive `replace_counter_ids()`
- `screener strategies --format json`: output `id` as integer, `type` as lowercase, drop `avg_day_chg` (always empty); add `market` field to top-level wrapper of `run` / `filter` JSON
- `rank --format json` (no `--key`): normalize to flat array `[{key, name, market}]` with `ib_` prefix stripped — consistent with Pretty output and directly usable with `--key`

## Test plan

- [x] `longbridge short-trades 700.HK --format json` — top-level `symbol`, no `counter_id`
- [ ] `longbridge top-movers --format json` — no `counter_id` in output
- [ ] `longbridge rank --key hot_all-us --format json` — `symbol` fields present
- [ ] `longbridge rank --format json` — flat array, keys without `ib_` prefix
- [ ] `LONGBRIDGE_ENV=staging cargo run -- screener strategies --format json` — `id` integer, no `avg_day_chg`
- [ ] `LONGBRIDGE_ENV=staging cargo run -- screener filter "pettm:10:20" --format json` — `market` field present
- [ ] `cargo clippy` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)