### PR TITLE
feat: add snapcraft.yaml for Snap Store publishing

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,33 @@
+name: longbridge-terminal
+base: core22
+version: '0.22.1'
+summary: AI-native CLI for Longbridge Securities
+description: |
+  longbridge-terminal is an AI-native command-line interface for Longbridge
+  Securities. It provides real-time market data, portfolio management, and
+  trading operations directly from your terminal.
+
+  Features:
+  - Real-time quotes for HK / US / A-share / Singapore markets
+  - Portfolio and account analytics
+  - Candlestick / OHLCV data and charting
+  - Watchlist management
+  - Order placement and trade history
+  - AI-assisted market research
+
+grade: stable
+confinement: classic
+architectures:
+  - build-on: amd64
+
+apps:
+  longbridge:
+    command: bin/longbridge
+
+parts:
+  longbridge:
+    plugin: dump
+    source: https://github.com/longbridge/longbridge-terminal/releases/download/v0.22.1/longbridge-terminal-linux-amd64.tar.gz
+    source-checksum: sha256/8e62bad91fe002da52b476290d1abb653beb8da1bb4d87a82b272e9f4e8d1dd8
+    organize:
+      longbridge: bin/longbridge


### PR DESCRIPTION
## Summary

- Adds `snap/snapcraft.yaml` to enable publishing `longbridge-terminal` to the [Snap Store](https://snapcraft.io/)
- Uses `classic` confinement (required for a CLI tool that needs full filesystem/network access)
- Uses the `dump` plugin to install the pre-built `linux-amd64` binary from GitHub Releases
- Targets the `core22` base (Ubuntu 22.04 LTS)

## Package details

| Field | Value |
|---|---|
| Version | 0.22.1 |
| Architecture | amd64 |
| Confinement | classic |
| Base | core22 |
| Source | GitHub Releases tarball |

## Test plan

- [ ] Run `snapcraft` in the repo root (requires snapcraft installed, e.g. `snap install snapcraft --classic`)
- [ ] Install the resulting `.snap` with `snap install --dangerous --classic longbridge-terminal_0.22.1_amd64.snap`
- [ ] Verify `longbridge --help` works after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)