### PR TITLE
cli: Default `market-temp --history` to last 30 days

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -304,7 +304,7 @@ pub enum Commands {
         /// Return historical records instead of current value
         #[arg(long)]
         history: bool,
-        /// Start date for history (YYYY-MM-DD). Defaults to today if omitted.
+        /// Start date for history (YYYY-MM-DD). Defaults to 30 days before end if omitted.
         #[arg(long)]
         start: Option<String>,
         /// End date for history (YYYY-MM-DD). Defaults to today if omitted.

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -891,8 +891,16 @@ pub async fn cmd_market_temp(
 
     if history {
         let now = time::OffsetDateTime::now_utc().date();
-        let start_date = start.as_deref().map(parse_date).transpose()?.unwrap_or(now);
         let end_date = end.as_deref().map(parse_date).transpose()?.unwrap_or(now);
+        let start_date = start
+            .as_deref()
+            .map(parse_date)
+            .transpose()?
+            .unwrap_or_else(|| {
+                end_date
+                    .checked_sub(time::Duration::days(30))
+                    .unwrap_or(end_date)
+            });
         let resp = ctx
             .history_market_temperature(m, start_date, end_date)
             .await?;


### PR DESCRIPTION
## What

`longbridge market-temp --history` (without `--start`/`--end`) returned an empty table.

## Why

Both `start` and `end` defaulted to today, so the query window was a single day — and no temperature data point exists for the current day yet, yielding zero records.

## Change

- `end` still defaults to today
- `start` now defaults to 30 days before `end` (mirrors `trading-days` behaviour)

Explicit `--start`/`--end` ranges are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)