### PR TITLE
cli: Output `topics` JSON timestamps as RFC 3339

### DIFF
--- a/src/cli/topic.rs
+++ b/src/cli/topic.rs
@@ -48,8 +48,8 @@ fn owned_topic_to_json(item: &OwnedTopic) -> serde_json::Value {
         "views_count": item.views_count,
         "shares_count": item.shares_count,
         "url": format!("https://longbridge.com/topics/{}", item.id),
-        "created_at": item.created_at.unix_timestamp(),
-        "updated_at": item.updated_at.unix_timestamp(),
+        "created_at": fmt_rfc3339(item.created_at),
+        "updated_at": fmt_rfc3339(item.updated_at),
     })
 }
 
@@ -127,7 +127,7 @@ fn topic_reply_to_json(item: &TopicReply) -> serde_json::Value {
         },
         "likes_count": item.likes_count,
         "comments_count": item.comments_count,
-        "created_at": item.created_at.unix_timestamp(),
+        "created_at": fmt_rfc3339(item.created_at),
     })
 }
 


### PR DESCRIPTION
## What

`topics` command JSON output now emits `created_at` / `updated_at` as RFC 3339 strings (`2024-01-15T07:50:00Z`) instead of bare Unix integers.

## Why

The table (Pretty) output already used `fmt_rfc3339`, but the JSON path serialized timestamps via `unix_timestamp()`, leaving the two output formats inconsistent. The RFC 3339 migration in #223 only covered quote/asset/output and missed `topic.rs`.

## Change

Three sites in `src/cli/topic.rs` (`owned_topic_to_json`, `topic_reply_to_json`):

- `item.created_at.unix_timestamp()` → `fmt_rfc3339(item.created_at)`
- `item.updated_at.unix_timestamp()` → `fmt_rfc3339(item.updated_at)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)