### PR TITLE
cli: Show account type banner before positions/assets output

### DIFF
--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -2,6 +2,31 @@ use tabled::{builder::Builder, settings::Style};
 
 use super::OutputFormat;
 
+// ANSI colors for the account-type banner.
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const RESET: &str = "\x1b[0m";
+
+/// Print a one-line account-type banner (paper vs. live) ahead of
+/// position/asset output so the reader can immediately tell whether the data
+/// belongs to a paper-trading or a live account.
+///
+/// Only rendered for `Pretty`; JSON output is intentionally left untouched so
+/// existing consumers keep parsing the top-level array/object unchanged.
+pub fn print_account_banner(format: &OutputFormat) {
+    if !matches!(format, OutputFormat::Pretty) {
+        return;
+    }
+    let is_paper = crate::auth::account_channel().as_deref() == Some("lb_papertrading");
+    let (color, label) = if is_paper {
+        (YELLOW, "Account: Demo A/C (simulated account)")
+    } else {
+        (GREEN, "Account: Live A/C (real account)")
+    };
+    println!("{color}{label}{RESET}");
+    println!();
+}
+
 fn print_markdown_table(headers: &[&str], rows: &[Vec<String>]) {
     let mut builder = Builder::default();
     builder.push_record(headers.iter().copied());

--- a/src/cli/trade.rs
+++ b/src/cli/trade.rs
@@ -10,7 +10,9 @@ use std::str::FromStr;
 
 use super::{
     api::TradeApi,
-    output::{fmt_decimal, parse_datetime_end, parse_datetime_start, print_table},
+    output::{
+        fmt_decimal, parse_datetime_end, parse_datetime_start, print_account_banner, print_table,
+    },
     OutputFormat,
 };
 use crate::utils::datetime::fmt_rfc3339;
@@ -576,6 +578,7 @@ fn print_assets(balances: &[longbridge::trade::AccountBalance], format: &OutputF
 pub async fn cmd_assets(currency: Option<String>, format: &OutputFormat) -> Result<()> {
     let ctx = crate::openapi::trade();
     let balances = ctx.account_balance(currency.as_deref()).await?;
+    print_account_banner(format);
     print_assets(&balances, format);
     Ok(())
 }
@@ -634,6 +637,7 @@ pub async fn cmd_positions(format: &OutputFormat) -> Result<()> {
     let ctx = crate::openapi::trade();
     let resp = ctx.stock_positions(None).await?;
 
+    print_account_banner(format);
     let headers = &[
         "Symbol",
         "Name",
@@ -666,6 +670,7 @@ pub async fn cmd_fund_positions(format: &OutputFormat) -> Result<()> {
     let ctx = crate::openapi::trade();
     let resp = ctx.fund_positions(None).await?;
 
+    print_account_banner(format);
     let headers = &[
         "Symbol",
         "Name",
@@ -764,6 +769,7 @@ pub async fn cmd_max_qty(
 pub async fn cmd_portfolio(format: &OutputFormat) -> Result<()> {
     let portfolio = crate::openapi::account::fetch_portfolio().await?;
 
+    print_account_banner(format);
     match format {
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(&portfolio)?);


### PR DESCRIPTION
## Summary

When querying positions/assets via the CLI, prepend a one-line banner that states whether the account is **Live A/C (real account)** or **Demo A/C (simulated account)** — so a reader (especially an AI consuming the output) can immediately tell which kind of account the data belongs to without separately running `auth status`.

Applies to the four core holdings/asset commands:

- `positions`
- `fund-positions`
- `assets`
- `portfolio`

## Behavior

- **Pretty** output gets the banner line before the table:
  - Live account → `Account: Live A/C (real account)` (green)
  - Paper account → `Account: Demo A/C (simulated account)` (yellow)
- **`--format json`** output is intentionally left unchanged, so existing consumers keep parsing the top-level array/object as before.

Account type is detected the same way as `auth status`: `account_channel() == "lb_papertrading"` ⇒ Demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)