### PR TITLE
feat(quote): enable US overnight market so quote returns overnight_quote

### DIFF
--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -112,6 +112,11 @@ pub async fn init_contexts() -> Result<(
     let mut config_builder = config_builder;
     let mut http_client_config = http_client_config;
 
+    // Enable the US overnight market so `quote` returns `overnight_quote`.
+    // Pre/post-market quotes are returned without this flag, but the overnight
+    // session is gated behind it (matches the longbridge-mcp server).
+    config_builder = config_builder.enable_overnight();
+
     // If LONGBRIDGE_ENV=staging, override all endpoints to test environment.
     // This takes highest priority over region detection.
     let effective_http_url;


### PR DESCRIPTION
## What

`quote` now returns the US **overnight** session (`overnight_quote`) in addition to pre/post-market.

## Why

`quote <SYMBOL> --format json` already returned `pre_market_quote` and `post_market_quote`, but `overnight_quote` was always `null`. Pre/post-market data comes back without any flag, but the US overnight session is gated behind `Config::enable_overnight()`, which the CLI never called. Quote is the most-used command for AI workflows, and missing overnight data skews after-close judgement.

## How

Call `config_builder.enable_overnight()` at the point where the API-key and OAuth config builders converge, so both auth paths get overnight quotes. This matches what the `longbridge-mcp` server already does.

## Verification

`cargo check` passes. Live check on `MRVL.US`:

```
overnight_quote:   { last 332.800, ts 2026-06-03T07:36:08Z, vol 3,555,870 }  ← now populated
post_market_quote: { last 318.765, ts 2026-06-02T23:59:59Z }
pre_market_quote:  { last 254.670, ts 2026-06-02T13:30:01Z }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)