### PR TITLE
cli: show ETF asset allocation in constituent command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,7 +1325,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1424,7 +1424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2599,8 +2599,8 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "longbridge"
-version = "4.1.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#86c3fe56197de1a6a1993a58374f9d8763faea45"
+version = "4.2.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2634,8 +2634,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-candlesticks"
-version = "4.1.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#86c3fe56197de1a6a1993a58374f9d8763faea45"
+version = "4.2.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2646,16 +2646,16 @@ dependencies = [
 
 [[package]]
 name = "longbridge-geo"
-version = "4.1.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#86c3fe56197de1a6a1993a58374f9d8763faea45"
+version = "4.2.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
 dependencies = [
  "reqwest 0.12.28",
 ]
 
 [[package]]
 name = "longbridge-httpcli"
-version = "4.1.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#86c3fe56197de1a6a1993a58374f9d8763faea45"
+version = "4.2.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -2676,8 +2676,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-oauth"
-version = "4.1.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#86c3fe56197de1a6a1993a58374f9d8763faea45"
+version = "4.2.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2693,8 +2693,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-proto"
-version = "4.1.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#86c3fe56197de1a6a1993a58374f9d8763faea45"
+version = "4.2.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2770,8 +2770,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-wscli"
-version = "4.1.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#86c3fe56197de1a6a1993a58374f9d8763faea45"
+version = "4.2.2"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3068,7 +3068,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3664,7 +3664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3779,7 +3779,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4322,7 +4322,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4986,7 +4986,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6025,7 +6025,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,7 +1325,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1424,7 +1424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2600,7 +2600,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#4f055f23d5bd75dfa7d20699289411591dea9ce8"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2635,7 +2635,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#4f055f23d5bd75dfa7d20699289411591dea9ce8"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2647,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#4f055f23d5bd75dfa7d20699289411591dea9ce8"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2655,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#4f055f23d5bd75dfa7d20699289411591dea9ce8"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#4f055f23d5bd75dfa7d20699289411591dea9ce8"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2694,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#4f055f23d5bd75dfa7d20699289411591dea9ce8"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2771,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#4f055f23d5bd75dfa7d20699289411591dea9ce8"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3068,7 +3068,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3664,7 +3664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3779,7 +3779,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4322,7 +4322,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4986,7 +4986,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6025,7 +6025,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,7 +1325,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1424,7 +1424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2600,7 +2600,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2635,7 +2635,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2647,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2655,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2694,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2771,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#7df184e93603309db0fd8fbb752779cf4c7a3b57"
+source = "git+https://github.com/longbridge/openapi.git?branch=etf-allocation#f4499018556e98d622ad2bb86e4bb15ecdf589ca"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3068,7 +3068,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3664,7 +3664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3779,7 +3779,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4322,7 +4322,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4986,7 +4986,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6025,7 +6025,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 dashmap = "6.1"
 dirs = "5.0"
 csv = "1"
-longbridge = { git = "https://github.com/longbridge/openapi.git", branch = "etf-allocation" } # TODO: revert to main after openapi PR #535 merges
+longbridge = { git = "https://github.com/longbridge/openapi.git", branch = "main" }
 futures = "0.3.28"
 open = "5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "brotli"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 dashmap = "6.1"
 dirs = "5.0"
 csv = "1"
-longbridge = { git = "https://github.com/longbridge/openapi.git", branch = "main" }
+longbridge = { git = "https://github.com/longbridge/openapi.git", branch = "etf-allocation" } # TODO: revert to main after openapi PR #535 merges
 futures = "0.3.28"
 open = "5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "brotli"] }

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ longbridge capital TSLA.US                          # Capital distribution snaps
 longbridge capital TSLA.US --flow                   # Intraday capital flow time series (large/medium/small money in vs out)
 longbridge market-temp [HK|US|CN|SG]                # Market sentiment temperature index (0–100, higher = more bullish)
 longbridge constituent .SPX.US [--sort market-cap]  # Index constituent stocks (US indexes need a leading dot, e.g. .DJI.US, .SPX.US)
-longbridge etf-asset-allocation QQQ.US              # ETF asset allocation breakdown (holdings, regional, asset class, industry)
+longbridge constituent QQQ.US                       # For an ETF, shows asset allocation breakdown (holdings, regional, asset class, industry)
 longbridge trading session                          # Trading session schedule (open/close times) for all markets
 longbridge trading days HK                          # Trading days and half-trading days for a market
 longbridge security-list HK                         # Full list of securities available in a market

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ longbridge capital TSLA.US                          # Capital distribution snaps
 longbridge capital TSLA.US --flow                   # Intraday capital flow time series (large/medium/small money in vs out)
 longbridge market-temp [HK|US|CN|SG]                # Market sentiment temperature index (0–100, higher = more bullish)
 longbridge constituent .SPX.US [--sort market-cap]  # Index constituent stocks (US indexes need a leading dot, e.g. .DJI.US, .SPX.US)
+longbridge etf-asset-allocation QQQ.US              # ETF asset allocation breakdown (holdings, regional, asset class, industry)
 longbridge trading session                          # Trading session schedule (open/close times) for all markets
 longbridge trading days HK                          # Trading days and half-trading days for a market
 longbridge security-list HK                         # Full list of securities available in a market

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -901,6 +901,19 @@ pub enum Commands {
         order: ConstituentOrder,
     },
 
+    /// ETF asset allocation breakdown (holdings, regional, asset class, industry)
+    ///
+    /// Returns the fund's composition grouped by element type. Holdings include
+    /// the underlying security symbol and industry; the other groups show name
+    /// and weight only.
+    ///
+    /// Example: longbridge etf-asset-allocation QQQ.US
+    /// Example: longbridge etf-asset-allocation 2800.HK --format json
+    EtfAssetAllocation {
+        /// ETF symbol in <CODE>.<MARKET> format (e.g. QQQ.US, 2800.HK)
+        symbol: String,
+    },
+
     /// Market open/close status for each exchange
     ///
     /// Example: longbridge market-status
@@ -3495,6 +3508,9 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             sort,
             order,
         } => quote::cmd_constituent(symbol, limit, &sort, &order, format, verbose).await,
+        Commands::EtfAssetAllocation { symbol } => {
+            quote::cmd_etf_asset_allocation(symbol, format).await
+        }
         Commands::MarketStatus => quote::cmd_market_status(format, verbose).await,
         Commands::BrokerHolding {
             symbol,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -881,14 +881,18 @@ pub enum Commands {
 
     /// Index or ETF constituent stocks
     ///
-    /// US index symbols require a leading dot (e.g. .DJI.US, .SPX.US, .IXIC.US).
-    /// HK indexes use the plain code (e.g. HSI.HK).
+    /// For an index, lists its member stocks. US index symbols require a leading
+    /// dot (e.g. .DJI.US, .SPX.US, .IXIC.US); HK indexes use the plain code (e.g.
+    /// HSI.HK). For an ETF, shows its asset allocation breakdown (holdings,
+    /// regional, asset class, industry) instead; --sort/--order are ignored for
+    /// ETFs since the data is already weight-ranked.
     ///
     /// Example: longbridge constituent HSI.HK
     /// Example: longbridge constituent .SPX.US --sort market-cap --order asc
     /// Example: longbridge constituent HSI.HK --limit 20 --sort change
+    /// Example: longbridge constituent QQQ.US
     Constituent {
-        /// Index symbol in <CODE>.<MARKET> format (e.g. HSI.HK, .DJI.US, .SPX.US)
+        /// Index or ETF symbol in <CODE>.<MARKET> format (e.g. HSI.HK, .SPX.US, QQQ.US)
         symbol: String,
         /// Number of results to return
         #[arg(long, default_value = "50")]
@@ -899,19 +903,6 @@ pub enum Commands {
         /// Sort order
         #[arg(long, value_enum, default_value_t = ConstituentOrder::Desc)]
         order: ConstituentOrder,
-    },
-
-    /// ETF asset allocation breakdown (holdings, regional, asset class, industry)
-    ///
-    /// Returns the fund's composition grouped by element type. Holdings include
-    /// the underlying security symbol and industry; the other groups show name
-    /// and weight only.
-    ///
-    /// Example: longbridge etf-asset-allocation QQQ.US
-    /// Example: longbridge etf-asset-allocation 2800.HK --format json
-    EtfAssetAllocation {
-        /// ETF symbol in <CODE>.<MARKET> format (e.g. QQQ.US, 2800.HK)
-        symbol: String,
     },
 
     /// Market open/close status for each exchange
@@ -3508,9 +3499,6 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             sort,
             order,
         } => quote::cmd_constituent(symbol, limit, &sort, &order, format, verbose).await,
-        Commands::EtfAssetAllocation { symbol } => {
-            quote::cmd_etf_asset_allocation(symbol, format).await
-        }
         Commands::MarketStatus => quote::cmd_market_status(format, verbose).await,
         Commands::BrokerHolding {
             symbol,

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -3319,6 +3319,108 @@ pub async fn cmd_rank(
     Ok(())
 }
 
+/// Human-readable label for an ETF asset-allocation group type.
+fn asset_allocation_type_label(t: longbridge::quote::ElementType) -> &'static str {
+    use longbridge::quote::ElementType;
+    match t {
+        ElementType::Holdings => "Holdings",
+        ElementType::Regional => "Regional",
+        ElementType::AssetClass => "Asset Class",
+        ElementType::Industry => "Industry",
+        ElementType::Unknown => "Unknown",
+    }
+}
+
+/// Format an ETF position-ratio string (e.g. `0.0861114`) as a percentage.
+fn fmt_position_ratio(raw: &str) -> String {
+    raw.parse::<f64>()
+        .map_or_else(|_| raw.to_string(), |v| format!("{:.2}%", v * 100.0))
+}
+
+/// Pick the locale-appropriate display name for an asset-allocation item,
+/// falling back to the default `name` when no localized variant exists.
+fn allocation_item_name(item: &longbridge::quote::AssetAllocationItem) -> String {
+    let locale = crate::locale::get();
+    let keys: &[&str] = match locale {
+        "zh-CN" => &["zh-CN", "zh-HK"],
+        "zh-HK" => &["zh-HK", "zh-CN"],
+        _ => &["en"],
+    };
+    for key in keys {
+        if let Some(name) = item.name_locales.get(*key) {
+            if !name.is_empty() {
+                return name.clone();
+            }
+        }
+    }
+    item.name.clone()
+}
+
+pub async fn cmd_etf_asset_allocation(symbol: String, format: &OutputFormat) -> Result<()> {
+    let ctx = crate::openapi::quote();
+    let resp = ctx.etf_asset_allocation(symbol.clone()).await?;
+
+    match format {
+        OutputFormat::Json => {
+            let value = serde_json::to_value(&resp)?;
+            print_json(&value);
+        }
+        OutputFormat::Pretty => {
+            if resp.info.is_empty() {
+                println!("No ETF asset allocation data found for {symbol}.");
+                return Ok(());
+            }
+            println!("ETF Asset Allocation — {symbol}\n");
+            for group in &resp.info {
+                let label = asset_allocation_type_label(group.asset_type);
+                println!("{label}  (report date: {})", group.report_date);
+                if group.lists.is_empty() {
+                    println!("  (no elements)\n");
+                    continue;
+                }
+                let is_holdings =
+                    matches!(group.asset_type, longbridge::quote::ElementType::Holdings);
+                if is_holdings {
+                    let headers = ["name", "symbol", "weight", "industry"];
+                    let rows: Vec<Vec<String>> = group
+                        .lists
+                        .iter()
+                        .map(|item| {
+                            let industry = item
+                                .holding_detail
+                                .as_ref()
+                                .map(|d| d.industry_name.clone())
+                                .unwrap_or_default();
+                            vec![
+                                allocation_item_name(item),
+                                item.symbol.clone(),
+                                fmt_position_ratio(&item.position_ratio),
+                                industry,
+                            ]
+                        })
+                        .collect();
+                    print_table(&headers, rows, format);
+                } else {
+                    let headers = ["name", "weight"];
+                    let rows: Vec<Vec<String>> = group
+                        .lists
+                        .iter()
+                        .map(|item| {
+                            vec![
+                                allocation_item_name(item),
+                                fmt_position_ratio(&item.position_ratio),
+                            ]
+                        })
+                        .collect();
+                    print_table(&headers, rows, format);
+                }
+                println!();
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -2292,6 +2292,20 @@ pub async fn cmd_constituent(
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
+    // ETF symbols expose their composition via the fundamental asset-allocation
+    // endpoint rather than the index-constituents endpoint. Non-ETF symbols
+    // (indexes) keep the original index-constituents behaviour unchanged.
+    if crate::utils::counter::is_etf(&symbol) {
+        let resp = crate::openapi::fundamental()
+            .etf_asset_allocation(symbol.clone())
+            .await?;
+        if !resp.info.is_empty() {
+            render_etf_asset_allocation(&resp, &symbol, limit, format);
+            return Ok(());
+        }
+        // No allocation data available — fall through to index-constituents.
+    }
+
     let cid = index_symbol_to_counter_id(&symbol);
     let limit_str = limit.to_string();
     let data = http_get(
@@ -3320,8 +3334,8 @@ pub async fn cmd_rank(
 }
 
 /// Human-readable label for an ETF asset-allocation group type.
-fn asset_allocation_type_label(t: longbridge::quote::ElementType) -> &'static str {
-    use longbridge::quote::ElementType;
+fn asset_allocation_type_label(t: longbridge::fundamental::ElementType) -> &'static str {
+    use longbridge::fundamental::ElementType;
     match t {
         ElementType::Holdings => "Holdings",
         ElementType::Regional => "Regional",
@@ -3339,7 +3353,7 @@ fn fmt_position_ratio(raw: &str) -> String {
 
 /// Pick the locale-appropriate display name for an asset-allocation item,
 /// falling back to the default `name` when no localized variant exists.
-fn allocation_item_name(item: &longbridge::quote::AssetAllocationItem) -> String {
+fn allocation_item_name(item: &longbridge::fundamental::AssetAllocationItem) -> String {
     let locale = crate::locale::get();
     let keys: &[&str] = match locale {
         "zh-CN" => &["zh-CN", "zh-HK"],
@@ -3356,20 +3370,26 @@ fn allocation_item_name(item: &longbridge::quote::AssetAllocationItem) -> String
     item.name.clone()
 }
 
-pub async fn cmd_etf_asset_allocation(symbol: String, format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
-    let resp = ctx.etf_asset_allocation(symbol.clone()).await?;
-
+/// Render an ETF asset-allocation response for the `constituent` command.
+///
+/// Holdings rows are capped at `limit`; the other groups (Regional / Asset Class /
+/// Industry) are shown in full as they are already weight-ranked summaries.
+///
+/// The `--sort` / `--order` flags do not apply to this data source — the API
+/// returns each group pre-sorted by weight — so they are intentionally ignored.
+fn render_etf_asset_allocation(
+    resp: &longbridge::fundamental::AssetAllocationResponse,
+    symbol: &str,
+    limit: i32,
+    format: &OutputFormat,
+) {
     match format {
         OutputFormat::Json => {
-            let value = serde_json::to_value(&resp)?;
-            print_json(&value);
+            if let Ok(value) = serde_json::to_value(resp) {
+                print_json(&value);
+            }
         }
         OutputFormat::Pretty => {
-            if resp.info.is_empty() {
-                println!("No ETF asset allocation data found for {symbol}.");
-                return Ok(());
-            }
             println!("ETF Asset Allocation — {symbol}\n");
             for group in &resp.info {
                 let label = asset_allocation_type_label(group.asset_type);
@@ -3378,13 +3398,17 @@ pub async fn cmd_etf_asset_allocation(symbol: String, format: &OutputFormat) -> 
                     println!("  (no elements)\n");
                     continue;
                 }
-                let is_holdings =
-                    matches!(group.asset_type, longbridge::quote::ElementType::Holdings);
+                let is_holdings = matches!(
+                    group.asset_type,
+                    longbridge::fundamental::ElementType::Holdings
+                );
                 if is_holdings {
                     let headers = ["name", "symbol", "weight", "industry"];
+                    let take = usize::try_from(limit).unwrap_or(usize::MAX);
                     let rows: Vec<Vec<String>> = group
                         .lists
                         .iter()
+                        .take(take)
                         .map(|item| {
                             let industry = item
                                 .holding_detail
@@ -3418,7 +3442,6 @@ pub async fn cmd_etf_asset_allocation(symbol: String, format: &OutputFormat) -> 
             }
         }
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -15,6 +15,9 @@ pub static TRADE_CTX: OnceLock<longbridge::trade::TradeContext> = OnceLock::new(
 /// Global `ContentContext` for news and topics
 pub static CONTENT_CTX: OnceLock<longbridge::ContentContext> = OnceLock::new();
 
+/// Global `FundamentalContext` for fundamental data (ratings, dividends, ETF allocation, etc.)
+pub static FUNDAMENTAL_CTX: OnceLock<longbridge::FundamentalContext> = OnceLock::new();
+
 /// Global `HttpClient` for making authenticated requests to the Longbridge `OpenAPI`
 pub static HTTP_CLIENT: OnceLock<longbridge::httpclient::HttpClient> = OnceLock::new();
 
@@ -184,6 +187,11 @@ pub async fn init_contexts() -> Result<(
         .set(statement_ctx)
         .map_err(|_| anyhow::anyhow!("AssetContext already initialized"))?;
 
+    let fundamental_ctx = longbridge::FundamentalContext::new(Arc::clone(&config));
+    FUNDAMENTAL_CTX
+        .set(fundamental_ctx)
+        .map_err(|_| anyhow::anyhow!("FundamentalContext already initialized"))?;
+
     // Also inject into the standalone HttpClient used for direct REST calls.
     let mut http_client = longbridge::httpclient::HttpClient::new(http_client_config);
     http_client = http_client.header("user-agent", user_agent);
@@ -258,6 +266,13 @@ pub fn content() -> &'static longbridge::ContentContext {
     CONTENT_CTX
         .get()
         .expect("ContentContext not initialized, please call init_contexts() first")
+}
+
+/// Get global `FundamentalContext` for fundamental data
+pub fn fundamental() -> &'static longbridge::FundamentalContext {
+    FUNDAMENTAL_CTX
+        .get()
+        .expect("FundamentalContext not initialized, please call init_contexts() first")
 }
 
 /// Get the global authenticated `HttpClient` for direct `OpenAPI` requests

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -8,6 +8,7 @@ pub mod search;
 pub mod wrapper;
 
 pub use context::{
-    content, http_client, init_contexts, quote, quote_limited, statement, trade, trade_limited,
+    content, fundamental, http_client, init_contexts, quote, quote_limited, statement, trade,
+    trade_limited,
 };
 pub use rate_limiter::global_rate_limiter;

--- a/src/utils/counter.rs
+++ b/src/utils/counter.rs
@@ -52,6 +52,14 @@ pub fn symbol_to_counter_id(symbol: &str) -> String {
     }
 }
 
+/// Whether a user-supplied symbol resolves to an ETF (e.g. `QQQ.US`, `SPY.US`).
+///
+/// Determined by checking the embedded special `counter_id` set: a symbol is an ETF
+/// when `symbol_to_counter_id` maps it to an `ETF/...` `counter_id`.
+pub fn is_etf(symbol: &str) -> bool {
+    symbol_to_counter_id(symbol).starts_with("ETF/")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -59,6 +67,19 @@ mod tests {
     #[test]
     fn stock_us() {
         assert_eq!(symbol_to_counter_id("TSLA.US"), "ST/US/TSLA");
+    }
+
+    #[test]
+    fn is_etf_us() {
+        assert!(is_etf("QQQ.US"));
+        assert!(is_etf("SPY.US"));
+    }
+
+    #[test]
+    fn is_etf_non_etf() {
+        assert!(!is_etf("TSLA.US"));
+        assert!(!is_etf("HSI.HK"));
+        assert!(!is_etf("700.HK"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `constituent` now detects ETF symbols (via `is_etf()` — embedded special counter_id set) and switches to the new SDK API `FundamentalContext::etf_asset_allocation` (openapi PR [longbridge/openapi#535](https://github.com/longbridge/openapi/pull/535))
- ETF output: four grouped tables (Holdings / Regional / Asset Class / Industry) with `report_date`, percentage-formatted weights, locale-aware names; `--format json` serializes the full `AssetAllocationResponse`
- `--limit` caps Holdings rows; `--sort`/`--order` are ignored for the pre-ranked allocation data
- Fallback: if an ETF returns empty allocation `info`, falls through to the original `/v1/quote/index-constituents` source; index symbols are completely unchanged
- No standalone `etf-asset-allocation` command — folded into `constituent` per review feedback

## Usage

```
longbridge constituent QQQ.US             # ETF → asset allocation groups
longbridge constituent QQQ.US --format json
longbridge constituent HSI.HK             # index → constituents (unchanged)
```

## Dependency note

`Cargo.toml` temporarily points `longbridge` at the openapi `etf-allocation` branch (rev `f449901`, FundamentalContext API) — **revert to `main` after longbridge/openapi#535 merges** (TODO comment in place).

## Verification (staging)

- `constituent QQQ.US`: four grouped tables rendered correctly
- `constituent QQQ.US --format json`: valid `AssetAllocationResponse` JSON (4 groups, 10 holdings)
- `constituent HSI.HK --limit 5`: original index-constituents table unchanged
- `constituent 2800.HK`: takes original path, no error
- `cargo build` / clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)