### PR TITLE
cli: Fetch full ETF holdings from SEC N-PORT in constituent

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ longbridge capital TSLA.US                          # Capital distribution snaps
 longbridge capital TSLA.US --flow                   # Intraday capital flow time series (large/medium/small money in vs out)
 longbridge market-temp [HK|US|CN|SG]                # Market sentiment temperature index (0–100, higher = more bullish)
 longbridge constituent .SPX.US [--sort market-cap]  # Index constituent stocks (US indexes need a leading dot, e.g. .DJI.US, .SPX.US)
-longbridge constituent QQQ.US                       # For an ETF, shows asset allocation breakdown (holdings, regional, asset class, industry)
+longbridge constituent IVV.US [--limit 0]           # For a US ETF, full holdings from SEC N-PORT (--limit 0 = all); falls back to platform asset allocation when SEC data is unavailable (e.g. SPY)
 longbridge trading session                          # Trading session schedule (open/close times) for all markets
 longbridge trading days HK                          # Trading days and half-trading days for a market
 longbridge security-list HK                         # Full list of securities available in a market

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,6 +21,7 @@ pub mod quote;
 pub mod run_script;
 pub mod screener;
 pub mod search;
+pub mod sec_edgar;
 pub mod sharelist;
 pub mod statement;
 pub mod topic;
@@ -883,18 +884,20 @@ pub enum Commands {
     ///
     /// For an index, lists its member stocks. US index symbols require a leading
     /// dot (e.g. .DJI.US, .SPX.US, .IXIC.US); HK indexes use the plain code (e.g.
-    /// HSI.HK). For an ETF, shows its asset allocation breakdown (holdings,
-    /// regional, asset class, industry) instead; --sort/--order are ignored for
-    /// ETFs since the data is already weight-ranked.
+    /// HSI.HK). For a US ETF, fetches full holdings from SEC EDGAR (N-PORT) by
+    /// default, falling back to the platform asset-allocation summary when SEC
+    /// data is unavailable (e.g. UIT funds like SPY, or very new tickers). For
+    /// non-US ETFs the platform asset-allocation breakdown is used. --sort/--order
+    /// are ignored for ETFs since the data is already weight-ranked.
     ///
     /// Example: longbridge constituent HSI.HK
     /// Example: longbridge constituent .SPX.US --sort market-cap --order asc
     /// Example: longbridge constituent HSI.HK --limit 20 --sort change
-    /// Example: longbridge constituent QQQ.US
+    /// Example: longbridge constituent IVV.US --limit 0   (full SEC holdings)
     Constituent {
-        /// Index or ETF symbol in <CODE>.<MARKET> format (e.g. HSI.HK, .SPX.US, QQQ.US)
+        /// Index or ETF symbol in <CODE>.<MARKET> format (e.g. HSI.HK, .SPX.US, IVV.US)
         symbol: String,
-        /// Number of results to return
+        /// Number of results to return (0 = all, for ETF SEC holdings)
         #[arg(long, default_value = "50")]
         limit: i32,
         /// Sort indicator

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -332,32 +332,34 @@ pub async fn cmd_quote(symbols: Vec<String>, format: &OutputFormat) -> Result<()
                     }
                     sessions
                         .iter()
-                        .map(|(label, opt)| match opt.as_ref().filter(|p| pre_post_has_data(p)) {
-                            Some(pmq) => vec![
-                                q.symbol.clone(),
-                                label.to_string(),
-                                fmt_dec(pmq.last_done),
-                                change_val(pmq.last_done, pmq.prev_close),
-                                change_pct(pmq.last_done, pmq.prev_close).unwrap_or_default(),
-                                fmt_dec(pmq.high),
-                                fmt_dec(pmq.low),
-                                pmq.volume.to_string(),
-                                fmt_dec(pmq.prev_close),
-                                crate::utils::datetime::fmt_rfc3339(pmq.timestamp),
-                            ],
-                            None => vec![
-                                q.symbol.clone(),
-                                label.to_string(),
-                                "--".to_string(),
-                                "--".to_string(),
-                                "--".to_string(),
-                                "--".to_string(),
-                                "--".to_string(),
-                                "--".to_string(),
-                                "--".to_string(),
-                                "--".to_string(),
-                            ],
-                        })
+                        .map(
+                            |(label, opt)| match opt.as_ref().filter(|p| pre_post_has_data(p)) {
+                                Some(pmq) => vec![
+                                    q.symbol.clone(),
+                                    label.to_string(),
+                                    fmt_dec(pmq.last_done),
+                                    change_val(pmq.last_done, pmq.prev_close),
+                                    change_pct(pmq.last_done, pmq.prev_close).unwrap_or_default(),
+                                    fmt_dec(pmq.high),
+                                    fmt_dec(pmq.low),
+                                    pmq.volume.to_string(),
+                                    fmt_dec(pmq.prev_close),
+                                    crate::utils::datetime::fmt_rfc3339(pmq.timestamp),
+                                ],
+                                None => vec![
+                                    q.symbol.clone(),
+                                    label.to_string(),
+                                    "--".to_string(),
+                                    "--".to_string(),
+                                    "--".to_string(),
+                                    "--".to_string(),
+                                    "--".to_string(),
+                                    "--".to_string(),
+                                    "--".to_string(),
+                                    "--".to_string(),
+                                ],
+                            },
+                        )
                         .collect::<Vec<_>>()
                 })
                 .collect();
@@ -2280,10 +2282,32 @@ pub async fn cmd_constituent(
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
-    // ETF symbols expose their composition via the fundamental asset-allocation
-    // endpoint rather than the index-constituents endpoint. Non-ETF symbols
-    // (indexes) keep the original index-constituents behaviour unchanged.
+    // ETF symbols expose their composition via SEC N-PORT full holdings (US
+    // ETFs, default) or the fundamental asset-allocation endpoint. Non-ETF
+    // symbols (indexes) keep the original index-constituents behaviour.
     if crate::utils::counter::is_etf(&symbol) {
+        // For US ETFs, prefer SEC EDGAR full holdings (N-PORT). This is the
+        // authoritative full constituent list rather than a top-10 summary.
+        if symbol.to_uppercase().ends_with(".US") {
+            match crate::cli::sec_edgar::fetch_etf_holdings(&symbol).await {
+                Ok(holdings) => {
+                    render_sec_holdings(&holdings, &symbol, limit, format);
+                    return Ok(());
+                }
+                Err(e) => {
+                    // SEC unavailable (UIT funds like SPY, too-new tickers,
+                    // network/parse errors) — fall back to platform data.
+                    if matches!(format, OutputFormat::Pretty) {
+                        println!(
+                            "SEC N-PORT data unavailable for {symbol} (falling back to platform data)"
+                        );
+                        if verbose {
+                            eprintln!("  reason: {e}");
+                        }
+                    }
+                }
+            }
+        }
         let resp = crate::openapi::fundamental()
             .etf_asset_allocation(symbol.clone())
             .await?;
@@ -3356,6 +3380,99 @@ fn allocation_item_name(item: &longbridge::fundamental::AssetAllocationItem) -> 
         }
     }
     item.name.clone()
+}
+
+/// Format a weight percentage (e.g. `7.564` -> `7.564%`), capped to 3 places.
+fn fmt_weight_pct(weight: Option<f64>) -> String {
+    match weight {
+        Some(w) => format!("{w:.3}%"),
+        None => "-".to_string(),
+    }
+}
+
+/// Render SEC N-PORT full ETF holdings for the `constituent` command.
+///
+/// `limit` controls the number of rows shown in pretty mode (`0` = all). JSON
+/// mode always emits the full, untruncated holdings list.
+fn render_sec_holdings(
+    holdings: &crate::cli::sec_edgar::EtfHoldings,
+    symbol: &str,
+    limit: i32,
+    format: &OutputFormat,
+) {
+    let total = holdings.holdings.len();
+    match format {
+        OutputFormat::Json => {
+            let value = serde_json::json!({
+                "symbol": symbol,
+                "series_name": holdings.series_name,
+                "report_period": holdings.report_period,
+                "filed_date": holdings.filed_date,
+                "total_holdings": total,
+                "holdings": holdings.holdings,
+            });
+            print_json(&value);
+        }
+        OutputFormat::Pretty => {
+            let name = if holdings.series_name.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", holdings.series_name)
+            };
+            println!("ETF Holdings — {symbol}{name}");
+            println!(
+                "Source: SEC N-PORT, report period {}, filed {}, {total} holdings\n",
+                if holdings.report_period.is_empty() {
+                    "-"
+                } else {
+                    &holdings.report_period
+                },
+                if holdings.filed_date.is_empty() {
+                    "-"
+                } else {
+                    &holdings.filed_date
+                },
+            );
+
+            if total == 0 {
+                println!("No holdings found.");
+                return;
+            }
+
+            // limit == 0 means "show all"; otherwise cap the displayed rows.
+            let take = if limit <= 0 {
+                total
+            } else {
+                usize::try_from(limit).unwrap_or(total).min(total)
+            };
+
+            let headers = ["#", "name", "cusip", "weight", "shares", "value(USD)"];
+            let rows: Vec<Vec<String>> = holdings
+                .holdings
+                .iter()
+                .take(take)
+                .enumerate()
+                .map(|(i, h)| {
+                    vec![
+                        (i + 1).to_string(),
+                        h.name.clone(),
+                        h.cusip.clone().unwrap_or_else(|| "-".to_string()),
+                        fmt_weight_pct(h.weight),
+                        h.shares
+                            .map_or_else(|| "-".to_string(), |s| format_with_commas(s as i64)),
+                        h.value_usd
+                            .map_or_else(|| "-".to_string(), |v| format_with_commas(v as i64)),
+                    ]
+                })
+                .collect();
+            print_table(&headers, rows, format);
+
+            if take < total {
+                let more = total - take;
+                println!("\n... and {more} more (use --limit 0 for all)");
+            }
+        }
+    }
 }
 
 /// Render an ETF asset-allocation response for the `constituent` command.

--- a/src/cli/sec_edgar.rs
+++ b/src/cli/sec_edgar.rs
@@ -1,0 +1,389 @@
+//! SEC EDGAR N-PORT holdings retrieval for US ETFs.
+//!
+//! For a US-listed ETF, this module resolves the fund's CIK and series id from
+//! the public mutual-fund ticker map, locates the latest `NPORT-P` filing, and
+//! parses the full portfolio holdings out of the filing's `primary_doc.xml`.
+//!
+//! All requests use a contact-identifying `User-Agent` as required by SEC fair
+//! access policy. The ticker map is cached on disk for 7 days.
+
+use anyhow::{anyhow, Result};
+use roxmltree::Document;
+use serde::Serialize;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+// SEC EDGAR fair-access policy requires a declared automated-tool User-Agent
+// that includes contact info. SEC's WAF rejects UAs containing a parenthesized
+// URL, so we use the documented "Organization Application contact-email" form.
+const SEC_UA: &str = concat!(
+    "Longbridge longbridge-terminal/",
+    env!("CARGO_PKG_VERSION"),
+    " support@longbridge.com"
+);
+
+// Mutual-fund / ETF ticker map. ~28k rows, refreshed roughly daily upstream.
+const TICKER_MAP_URL: &str = "https://www.sec.gov/files/company_tickers_mf.json";
+
+// On-disk cache time-to-live for the ticker map.
+const TICKER_MAP_TTL: Duration = Duration::from_hours(7 * 24);
+
+/// A single portfolio holding parsed from an N-PORT filing.
+#[derive(Debug, Clone, Serialize)]
+pub struct Holding {
+    pub name: String,
+    pub lei: Option<String>,
+    pub cusip: Option<String>,
+    pub isin: Option<String>,
+    /// Number of shares / units held (`balance`).
+    pub shares: Option<f64>,
+    /// Market value in USD (`valUSD`).
+    pub value_usd: Option<f64>,
+    /// Percentage of the fund's net assets (`pctVal`), e.g. `7.564` means 7.564%.
+    pub weight: Option<f64>,
+}
+
+/// Full set of holdings for an ETF, parsed from a single N-PORT filing.
+#[derive(Debug, Clone, Serialize)]
+pub struct EtfHoldings {
+    /// Series / fund name from the filing (`seriesName`).
+    pub series_name: String,
+    /// Reporting period end date (`repPdDate`), e.g. `2026-03-31`.
+    pub report_period: String,
+    /// EDGAR filing date of the N-PORT report, e.g. `2026-05-28`.
+    pub filed_date: String,
+    pub holdings: Vec<Holding>,
+}
+
+fn sec_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .user_agent(SEC_UA)
+        .timeout(Duration::from_mins(1))
+        .build()
+        .expect("failed to build HTTP client")
+}
+
+/// Strip the `.US` / `.HK` market suffix and uppercase the ticker.
+fn normalize_ticker(symbol: &str) -> String {
+    match symbol.rfind('.') {
+        Some(i) => symbol[..i].to_uppercase(),
+        None => symbol.to_uppercase(),
+    }
+}
+
+fn cache_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| {
+        h.join(".longbridge")
+            .join("sec")
+            .join("company_tickers_mf.json")
+    })
+}
+
+/// Return the cached ticker-map bytes when present and younger than the TTL.
+fn read_fresh_cache(path: &PathBuf) -> Option<Vec<u8>> {
+    let meta = std::fs::metadata(path).ok()?;
+    let modified = meta.modified().ok()?;
+    let age = SystemTime::now().duration_since(modified).ok()?;
+    if age <= TICKER_MAP_TTL {
+        std::fs::read(path).ok()
+    } else {
+        None
+    }
+}
+
+/// Fetch the mutual-fund ticker map, preferring a fresh on-disk cache.
+async fn load_ticker_map(client: &reqwest::Client) -> Result<Vec<u8>> {
+    let path = cache_path();
+    if let Some(p) = &path {
+        if let Some(bytes) = read_fresh_cache(p) {
+            return Ok(bytes);
+        }
+    }
+    let resp = client.get(TICKER_MAP_URL).send().await?;
+    if !resp.status().is_success() {
+        return Err(anyhow!("SEC ticker map returned HTTP {}", resp.status()));
+    }
+    let bytes = resp.bytes().await?.to_vec();
+    if let Some(p) = &path {
+        if let Some(parent) = p.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(p, &bytes);
+    }
+    Ok(bytes)
+}
+
+/// Resolve `(cik, series_id)` for a ticker from the mutual-fund ticker map.
+///
+/// The map is shaped as `{"fields":["cik","seriesId","classId","symbol"],
+/// "data":[[1100663,"S000004310","C000012040","IVV"], ...]}`.
+fn resolve_series(bytes: &[u8], ticker: &str) -> Option<(u64, String)> {
+    let v: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let fields = v.get("fields")?.as_array()?;
+    let idx = |name: &str| fields.iter().position(|f| f.as_str() == Some(name));
+    let cik_i = idx("cik")?;
+    let series_i = idx("seriesId")?;
+    let symbol_i = idx("symbol")?;
+    let data = v.get("data")?.as_array()?;
+    for row in data {
+        let row = row.as_array()?;
+        let sym = row.get(symbol_i).and_then(serde_json::Value::as_str);
+        if sym.map(str::to_uppercase).as_deref() == Some(ticker) {
+            let cik = row.get(cik_i).and_then(serde_json::Value::as_u64)?;
+            let series = row.get(series_i).and_then(serde_json::Value::as_str)?;
+            return Some((cik, series.to_string()));
+        }
+    }
+    None
+}
+
+/// Locate the latest `NPORT-P` filing for a series via the EDGAR Atom feed.
+/// Returns `(filing_href, filing_date)`.
+async fn latest_nport_filing(
+    client: &reqwest::Client,
+    series_id: &str,
+) -> Result<(String, String)> {
+    let url = format!(
+        "https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK={series_id}\
+         &type=NPORT-P&dateb=&owner=include&count=5&output=atom"
+    );
+    let resp = client.get(&url).send().await?;
+    if !resp.status().is_success() {
+        return Err(anyhow!("SEC EDGAR returned HTTP {}", resp.status()));
+    }
+    let xml = resp.text().await?;
+    let doc = Document::parse(&xml).map_err(|e| anyhow!("failed to parse EDGAR Atom feed: {e}"))?;
+
+    let href = doc
+        .descendants()
+        .find(|n| n.has_tag_name("filing-href"))
+        .and_then(|n| n.text())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow!("no NPORT-P filing found for series {series_id}"))?
+        .to_string();
+    let date = doc
+        .descendants()
+        .find(|n| n.has_tag_name("filing-date"))
+        .and_then(|n| n.text())
+        .map_or_else(String::new, |s| s.trim().to_string());
+    Ok((href, date))
+}
+
+/// Build the `primary_doc.xml` URL from an index page href by replacing the
+/// trailing `*-index.htm` segment.
+fn primary_doc_url(filing_href: &str) -> String {
+    match filing_href.rfind('/') {
+        Some(i) => format!("{}/primary_doc.xml", &filing_href[..i]),
+        None => filing_href.to_string(),
+    }
+}
+
+fn parse_f64(s: &str) -> Option<f64> {
+    let t = s.trim();
+    if t.is_empty() {
+        None
+    } else {
+        t.parse().ok()
+    }
+}
+
+/// Parse holdings out of an N-PORT `primary_doc.xml` document.
+fn parse_nport(xml: &str) -> Result<EtfHoldings> {
+    let doc = Document::parse(xml).map_err(|e| anyhow!("failed to parse N-PORT XML: {e}"))?;
+
+    let gen_info = doc.descendants().find(|n| n.has_tag_name("genInfo"));
+    let child_text = |parent: &roxmltree::Node, tag: &str| -> String {
+        parent
+            .descendants()
+            .find(|n| n.has_tag_name(tag))
+            .and_then(|n| n.text())
+            .unwrap_or("")
+            .trim()
+            .to_string()
+    };
+
+    let (series_name, report_period) = match gen_info {
+        Some(g) => (child_text(&g, "seriesName"), child_text(&g, "repPdDate")),
+        None => (String::new(), String::new()),
+    };
+
+    let mut holdings = Vec::new();
+    for sec in doc.descendants().filter(|n| n.has_tag_name("invstOrSec")) {
+        // Direct-child lookup keeps nested blocks (e.g. derivative legs that
+        // also carry <name>) from polluting the top-level fields.
+        let field = |tag: &str| -> Option<String> {
+            sec.children()
+                .find(|n| n.has_tag_name(tag))
+                .and_then(|n| n.text())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        };
+
+        let name = field("name").unwrap_or_default();
+        let lei = field("lei");
+        let cusip = field("cusip");
+
+        // <isin> may carry the value as a `value="US..."` attribute or as text.
+        let isin = sec
+            .children()
+            .find(|n| n.has_tag_name("isin"))
+            .and_then(|n| {
+                n.attribute("value")
+                    .map(str::to_string)
+                    .or_else(|| n.text().map(|t| t.trim().to_string()))
+            })
+            .filter(|s| !s.is_empty());
+
+        let shares = field("balance").and_then(|s| parse_f64(&s));
+        let value_usd = field("valUSD").and_then(|s| parse_f64(&s));
+        let weight = field("pctVal").and_then(|s| parse_f64(&s));
+
+        // Skip rows with no identifying name at all.
+        if name.is_empty() && cusip.is_none() && isin.is_none() {
+            continue;
+        }
+
+        holdings.push(Holding {
+            name,
+            lei,
+            cusip,
+            isin,
+            shares,
+            value_usd,
+            weight,
+        });
+    }
+
+    // Sort by weight descending; rows with a missing weight sink to the bottom.
+    holdings.sort_by(|a, b| {
+        let aw = a.weight.unwrap_or(f64::NEG_INFINITY);
+        let bw = b.weight.unwrap_or(f64::NEG_INFINITY);
+        bw.partial_cmp(&aw).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    Ok(EtfHoldings {
+        series_name,
+        report_period,
+        filed_date: String::new(),
+        holdings,
+    })
+}
+
+/// Fetch full ETF holdings from SEC EDGAR for a US ticker symbol.
+///
+/// `symbol` may carry a market suffix (e.g. `IVV.US`); it is normalized
+/// internally. Returns an error if the ticker is not present in the mutual-fund
+/// map (e.g. UIT-structured funds like SPY) or if any request/parse step fails.
+pub async fn fetch_etf_holdings(symbol: &str) -> Result<EtfHoldings> {
+    let ticker = normalize_ticker(symbol);
+    let client = sec_client();
+
+    let map = load_ticker_map(&client).await?;
+    let (_cik, series_id) = resolve_series(&map, &ticker)
+        .ok_or_else(|| anyhow!("ticker '{ticker}' not found in SEC mutual-fund map"))?;
+
+    let (filing_href, filed_date) = latest_nport_filing(&client, &series_id).await?;
+    let doc_url = primary_doc_url(&filing_href);
+
+    let resp = client.get(&doc_url).send().await?;
+    if !resp.status().is_success() {
+        return Err(anyhow!(
+            "SEC N-PORT document returned HTTP {} for {doc_url}",
+            resp.status()
+        ));
+    }
+    let xml = resp.text().await?;
+    let mut parsed = parse_nport(&xml)?;
+    parsed.filed_date = filed_date;
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+    <edgarSubmission>
+      <formData>
+        <genInfo>
+          <seriesName>iShares Core S&amp;P 500 ETF</seriesName>
+          <repPdDate>2026-03-31</repPdDate>
+        </genInfo>
+        <invstOrSecs>
+          <invstOrSec>
+            <name>Apple Inc</name>
+            <lei>HWUPKR0MPOU8FGXBT394</lei>
+            <cusip>037833100</cusip>
+            <isin value="US0378331005"/>
+            <balance>100.5</balance>
+            <valUSD>20000.25</valUSD>
+            <pctVal>6.123</pctVal>
+          </invstOrSec>
+          <invstOrSec>
+            <name>NVIDIA Corp</name>
+            <cusip>67066G104</cusip>
+            <isin>US67066G1040</isin>
+            <balance>200</balance>
+            <valUSD>30000</valUSD>
+            <pctVal>7.564</pctVal>
+          </invstOrSec>
+          <invstOrSec>
+            <name>Some Cash Position</name>
+            <balance>5</balance>
+          </invstOrSec>
+        </invstOrSecs>
+      </formData>
+    </edgarSubmission>
+    "#;
+
+    #[test]
+    fn parses_and_sorts_by_weight() {
+        let h = parse_nport(SAMPLE).unwrap();
+        assert_eq!(h.series_name, "iShares Core S&P 500 ETF");
+        assert_eq!(h.report_period, "2026-03-31");
+        assert_eq!(h.holdings.len(), 3);
+
+        // NVIDIA (7.564) sorts above Apple (6.123); the weightless row sinks last.
+        assert_eq!(h.holdings[0].name, "NVIDIA Corp");
+        assert_eq!(h.holdings[0].weight, Some(7.564));
+        assert_eq!(h.holdings[1].name, "Apple Inc");
+        assert_eq!(h.holdings[2].name, "Some Cash Position");
+        assert_eq!(h.holdings[2].weight, None);
+    }
+
+    #[test]
+    fn isin_attribute_and_text_forms() {
+        let h = parse_nport(SAMPLE).unwrap();
+        let apple = h.holdings.iter().find(|x| x.name == "Apple Inc").unwrap();
+        assert_eq!(apple.isin.as_deref(), Some("US0378331005"));
+        assert_eq!(apple.cusip.as_deref(), Some("037833100"));
+        let nvda = h.holdings.iter().find(|x| x.name == "NVIDIA Corp").unwrap();
+        assert_eq!(nvda.isin.as_deref(), Some("US67066G1040"));
+    }
+
+    #[test]
+    fn resolve_series_matches_symbol() {
+        let map = br#"{"fields":["cik","seriesId","classId","symbol"],
+            "data":[[1100663,"S000004310","C000012040","IVV"],
+                    [1067839,"S000101292","C000300000","QQQ"]]}"#;
+        assert_eq!(
+            resolve_series(map, "IVV"),
+            Some((1_100_663, "S000004310".to_string()))
+        );
+        assert_eq!(
+            resolve_series(map, "QQQ"),
+            Some((1_067_839, "S000101292".to_string()))
+        );
+        assert_eq!(resolve_series(map, "SPY"), None);
+    }
+
+    #[test]
+    fn primary_doc_url_replaces_index_segment() {
+        let href = "https://www.sec.gov/Archives/edgar/data/1100663/000207169126012459/0002071691-26-012459-index.htm";
+        assert_eq!(
+            primary_doc_url(href),
+            "https://www.sec.gov/Archives/edgar/data/1100663/000207169126012459/primary_doc.xml"
+        );
+    }
+}


### PR DESCRIPTION
## What

For **US ETFs**, the `constituent` command now fetches the **complete portfolio holdings** from SEC EDGAR (N-PORT filings) by default, replacing the platform's top-N asset-allocation summary as the primary data source.

```
$ longbridge constituent IVV.US
ETF Holdings — IVV.US (iShares Core S&P 500 ETF)
Source: SEC N-PORT, report period 2026-03-31, filed 2026-05-28, 507 holdings

| #  | name           | cusip     | weight | shares      | value(USD)     |
|----|----------------|-----------|--------|-------------|----------------|
| 1  | NVIDIA Corp.   | 67066G104 | 7.564% | 312,526,688 | 54,504,654,387 |
| 2  | Apple, Inc.    | 037833100 | 6.650% | 188,816,321 | 47,919,694,106 |
...
... and 457 more (use --limit 0 for all)
```

## How

A new `src/cli/sec_edgar.rs` module orchestrates three public SEC requests:

1. **Ticker → CIK/series**: `company_tickers_mf.json` (cached 7 days under `~/.longbridge/sec/`).
2. **Latest filing**: EDGAR Atom feed (`type=NPORT-P`) → first `filing-href` + `filing-date`.
3. **Holdings**: the filing's `primary_doc.xml`, parsed via `roxmltree` (handles XML entity unescaping and the `<isin value="..."/>` attribute form). Each `invstOrSec` yields name, LEI, CUSIP, ISIN, shares, USD value, and `pctVal` weight, sorted by weight descending.

All requests carry a contact-identifying `User-Agent` per SEC fair-access policy.

## Default behaviour & fallback chain

- US ETF → **SEC N-PORT full holdings** (default).
- SEC unavailable → **platform asset allocation** (top-N summary). Triggers: UIT-structured funds (e.g. SPY), tickers absent from the mutual-fund map, very new ETFs, non-US markets, or any network/parse failure. Pretty mode prints a one-line notice.
- Still empty → **index constituents** (unchanged).
- Non-ETF indexes (e.g. `HSI.HK`, `.SPX.US`) → behaviour entirely unchanged.

`--limit 0` shows all holdings in pretty mode; JSON mode (`--format json`) always emits the full untruncated holdings list as `{ symbol, series_name, report_period, filed_date, total_holdings, holdings: [...] }`.

## Data timeliness limitation

N-PORT is a **fiscal-quarter-end snapshot filed with up to ~60 days' delay** (e.g. a 2026-03-31 portfolio filed 2026-05-28). It is the authoritative full holdings list but is not real-time.

## Verification

| Command | Result |
|---|---|
| `constituent IVV.US` | SEC, 507 holdings, NVDA 7.564% top |
| `constituent IVV.US --format json` | structured JSON, all 507 holdings |
| `constituent QQQ.US` | SEC, 102 holdings |
| `constituent SPY.US` | fallback → platform asset allocation (UIT) |
| `constituent DRAM.US` | fallback → platform asset allocation |
| `constituent HSI.HK` | index constituents, unchanged |

`cargo build` / `cargo clippy` clean (one pre-existing warning in unrelated `cli-candlestick-chart`); 4 unit tests for XML parsing / ticker resolution / URL building pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)