### PR TITLE
cli: Support `auth login --auth-code <CODE>` via /connect authorization code exchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,8 +2608,8 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "longbridge"
-version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#89e44368eba0d1ba107fd98d5988ab3a2ee0e7ec"
+version = "4.3.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2634,8 +2643,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-candlesticks"
-version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#89e44368eba0d1ba107fd98d5988ab3a2ee0e7ec"
+version = "4.3.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2646,16 +2655,16 @@ dependencies = [
 
 [[package]]
 name = "longbridge-geo"
-version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#89e44368eba0d1ba107fd98d5988ab3a2ee0e7ec"
+version = "4.3.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
 dependencies = [
  "reqwest 0.12.28",
 ]
 
 [[package]]
 name = "longbridge-httpcli"
-version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#89e44368eba0d1ba107fd98d5988ab3a2ee0e7ec"
+version = "4.3.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -2676,8 +2685,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-oauth"
-version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#89e44368eba0d1ba107fd98d5988ab3a2ee0e7ec"
+version = "4.3.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2693,8 +2702,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-proto"
-version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#89e44368eba0d1ba107fd98d5988ab3a2ee0e7ec"
+version = "4.3.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2715,6 +2724,7 @@ dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bitflags 2.10.0",
+ "bs58",
  "bytemuck",
  "clap 4.5.60",
  "clap_complete",
@@ -2768,8 +2778,8 @@ dependencies = [
 
 [[package]]
 name = "longbridge-wscli"
-version = "4.2.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#89e44368eba0d1ba107fd98d5988ab3a2ee0e7ec"
+version = "4.3.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#573846945971adf7586376292c318dc389b16552"
 dependencies = [
  "byteorder",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ ansi-parser = "0.9.1"
 ansi-to-tui = "8.0.1"
 anyhow = "1.0"
 base64 = "0.22"
+bs58 = "0.5"
 arrayvec = "0.7"
 atomic = "0.6.0"
 bevy_app = "0.11"
@@ -109,3 +110,4 @@ needless_pass_by_value = "allow"
 pedantic = { level = "deny", priority = -1 }
 too_many_arguments = "allow"
 too_many_lines = "allow"
+

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,37 +5,22 @@ use longbridge::oauth::TokenStorage as _;
 use std::fs;
 use std::path::PathBuf;
 
-const OAUTH_CLIENT_ID: &str = "fd52fbc5-02a9-47f5-ad30-0842c841aae9";
-const OAUTH_PATH: &str = "/oauth2";
-
-const OAUTH_TEST_CLIENT_ID: &str = "37435cdf-c7e4-4de9-8715-b20d33416196";
-
 pub const CALLBACK_PORT: u16 = 60355;
-
-/// Whether the staging environment is active (`LONGBRIDGE_ENV=staging`).
-pub fn is_test_env() -> bool {
-    std::env::var("LONGBRIDGE_ENV").is_ok_and(|v| v == "staging")
-}
-
-/// Return the OAuth client ID for the current environment.
-pub fn client_id() -> &'static str {
-    if is_test_env() {
-        OAUTH_TEST_CLIENT_ID
-    } else {
-        OAUTH_CLIENT_ID
-    }
-}
 
 /// Return the OAuth base URL for the current environment and region.
 fn oauth_base_url() -> String {
-    let host = if is_test_env() {
-        crate::region::HTTP_URL_TEST
-    } else if crate::region::is_cn_cached() {
-        crate::region::HTTP_URL_CN
-    } else {
-        crate::region::HTTP_URL_GLOBAL
-    };
-    format!("{host}{OAUTH_PATH}")
+    format!("{}/oauth2", crate::region::http_url())
+}
+
+/// `/connect` reverse-authorization page URL for the current region.
+fn connect_url() -> String {
+    format!("{}/connect", crate::region::open_url())
+}
+
+/// Redirect URI registered for the "AI Agent" client. Must exactly match the
+/// `redirect_uri` bound to the authorization code generated at [`connect_url`].
+fn agent_redirect_uri() -> String {
+    format!("{}/connect/done", crate::region::open_url())
 }
 
 pub fn token_file_path() -> Result<PathBuf> {
@@ -71,7 +56,8 @@ fn decode_jwt_payload(token: &str) -> Option<serde_json::Value> {
 
 /// Read the logged-in user's `account_channel` from the local access token.
 pub fn account_channel() -> Option<String> {
-    let full = crate::secure_storage::EncryptedFileTokenStorage::load_full(client_id())?;
+    let full =
+        crate::secure_storage::EncryptedFileTokenStorage::load_full(crate::region::client_id())?;
     let claims = decode_jwt_payload(full["access_token"].as_str()?)?;
     let sub_str = claims["sub"].as_str()?;
     let sub: serde_json::Value = serde_json::from_str(sub_str).ok()?;
@@ -126,7 +112,7 @@ pub async fn device_login(verbose: bool) -> Result<()> {
     use std::time::{Duration, Instant};
 
     let oauth_base = oauth_base_url();
-    let client_id = client_id();
+    let client_id = crate::region::client_id();
     let http_client = reqwest::Client::new();
     let invite_code = read_invite_code();
 
@@ -260,7 +246,8 @@ pub async fn refresh_if_expired() -> Result<()> {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     let storage = crate::secure_storage::EncryptedFileTokenStorage;
-    let Some(full) = crate::secure_storage::EncryptedFileTokenStorage::load_full(client_id())
+    let Some(full) =
+        crate::secure_storage::EncryptedFileTokenStorage::load_full(crate::region::client_id())
     else {
         return Ok(());
     };
@@ -301,7 +288,7 @@ pub async fn refresh_if_expired() -> Result<()> {
         .form(&[
             ("grant_type", "refresh_token"),
             ("refresh_token", refresh_token.as_str()),
-            ("client_id", client_id()),
+            ("client_id", crate::region::client_id()),
         ])
         .send()
         .await
@@ -325,7 +312,7 @@ pub async fn refresh_if_expired() -> Result<()> {
         let new_refresh = token_resp["refresh_token"].as_str().map(str::to_owned);
 
         let token = longbridge::oauth::StoredToken {
-            client_id: client_id().to_string(),
+            client_id: crate::region::client_id().to_string(),
             access_token: access_token.to_string(),
             refresh_token: new_refresh,
             expires_at: now + expires_in,
@@ -359,7 +346,7 @@ pub async fn auth_code_login() -> Result<()> {
     println!("Listening on localhost:{CALLBACK_PORT} for the OAuth callback.");
     let invite_code = read_invite_code();
 
-    let oauth_result = longbridge::oauth::OAuthBuilder::new(client_id())
+    let oauth_result = longbridge::oauth::OAuthBuilder::new(crate::region::client_id())
         .callback_port(CALLBACK_PORT)
         .token_storage(crate::secure_storage::EncryptedFileTokenStorage)
         .build(|url| {
@@ -382,6 +369,157 @@ pub async fn auth_code_login() -> Result<()> {
             Ok(())
         }
         Err(e) => Err(anyhow::anyhow!("OAuth authorization failed: {e}")),
+    }
+}
+
+/// Restore a chat-pasted authorization code to the standard base64 form the
+/// token endpoint expects. The connect page displays codes in a chat-safe
+/// base64url form without padding (`+` -> `-`, `/` -> `_`, trailing `=`
+/// stripped) because raw base64 gets escaped or truncated by chat apps.
+/// Surrounding whitespace, quotes, and backticks picked up while copying are
+/// stripped as well.
+fn normalize_auth_code(input: &str) -> String {
+    let stripped = input
+        .trim()
+        .trim_matches(|c| matches!(c, '"' | '\'' | '`'));
+    let mut code = stripped.replace('-', "+").replace('_', "/");
+    while !code.is_empty() && code.len() % 4 != 0 {
+        code.push('=');
+    }
+    code
+}
+
+/// Agent Auth Code reverse-authorization flow.
+///
+/// Exchanges a standard OAuth authorization code — generated by the user at
+/// <https://open.longbridge.com/connect> (5-minute, single-use) — for an
+/// access/refresh token in a single synchronous call. No browser, no polling,
+/// no local callback server.
+///
+/// The pasted code is first restored from the chat-safe base64url display
+/// form via [`normalize_auth_code`]; the string as pasted is kept as a
+/// fallback candidate (a rejected lookup does not consume the one-time code,
+/// so a second attempt is safe).
+///
+/// The resulting tokens are written to the same encrypted token cache used by
+/// every other login path, so subsequent refresh logic is fully shared.
+pub async fn auth_code_exchange_login(code: &str) -> Result<()> {
+    let raw = code
+        .trim()
+        .trim_matches(|c| matches!(c, '"' | '\'' | '`'))
+        .to_string();
+    let normalized = normalize_auth_code(code);
+    if normalized.is_empty() {
+        anyhow::bail!(
+            "Empty authorization code. Generate one at {} and pass it as \
+             `longbridge auth login --auth-code <CODE>`.",
+            connect_url()
+        );
+    }
+    let mut candidates = vec![normalized];
+    if !raw.is_empty() && !candidates.contains(&raw) {
+        candidates.push(raw);
+    }
+
+    let url = format!("{}/token", oauth_base_url());
+    let http_client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .context("Failed to build HTTP client for authorization code exchange")?;
+
+    // Public client: token endpoint auth method `none` (no client_secret),
+    // no PKCE (no code_verifier).
+    let redirect_uri = agent_redirect_uri();
+    let mut last_rejection: Option<(reqwest::StatusCode, serde_json::Value)> = None;
+    for candidate in &candidates {
+        tracing::debug!("Exchanging authorization code via {url}");
+        let send_result = http_client
+            .post(&url)
+            .form(&[
+                ("grant_type", "authorization_code"),
+                ("code", candidate.as_str()),
+                ("redirect_uri", redirect_uri.as_str()),
+                ("client_id", crate::region::agent_client_id()),
+            ])
+            .send()
+            .await;
+        let resp = match send_result {
+            Ok(resp) => resp,
+            // Keep the first definitive rejection instead of failing on a
+            // transport error from the fallback attempt.
+            Err(_) if last_rejection.is_some() => break,
+            Err(e) => {
+                return Err(anyhow::Error::new(e).context(
+                    "Authorization request failed — check your network connection and try again.",
+                ));
+            }
+        };
+
+        let status = resp.status();
+        if !status.is_success() {
+            let err_resp = resp.json::<serde_json::Value>().await.unwrap_or_default();
+            last_rejection = Some((status, err_resp));
+            continue;
+        }
+
+        let token_resp = resp
+            .json::<serde_json::Value>()
+            .await
+            .context("Failed to parse token response")?;
+
+        let access_token = token_resp["access_token"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("No access_token in token response"))?;
+        let expires_in = token_resp["expires_in"].as_u64().unwrap_or(3600);
+        let refresh_token = token_resp["refresh_token"].as_str().map(str::to_owned);
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        // Persist under the regular runtime client_id (not the agent client_id):
+        // the token cache is a single shared file and the existing refresh path
+        // (`refresh_if_expired`) posts `client_id()`, so storing it this way lets
+        // refresh be reused as-is. The agent client_id is only used to *exchange*
+        // the authorization code above.
+        let token = longbridge::oauth::StoredToken {
+            client_id: crate::region::client_id().to_string(),
+            access_token: access_token.to_string(),
+            refresh_token,
+            expires_at: now + expires_in,
+        };
+        crate::secure_storage::EncryptedFileTokenStorage
+            .save(&token)
+            .map_err(|e| anyhow::anyhow!("Failed to save token: {e}"))?;
+
+        println!("Successfully authenticated.");
+        return Ok(());
+    }
+
+    // Surface a self-healing hint: an invalid/expired/used code means the agent
+    // should ask the user to regenerate one.
+    let (status, err_resp) = last_rejection.unwrap_or_default();
+    let error = err_resp["error"].as_str().unwrap_or("unknown");
+    let description = err_resp["error_description"].as_str().unwrap_or("");
+
+    match error {
+        "invalid_grant" | "invalid_request" | "expired_token" | "access_denied" => {
+            anyhow::bail!(
+                "Authorization code is invalid, expired, or already used. \
+                 Please generate a new one at {} \
+                 and run `longbridge auth login --auth-code <CODE>` again.",
+                connect_url()
+            )
+        }
+        _ => {
+            let detail = if description.is_empty() {
+                error.to_string()
+            } else {
+                format!("{error}: {description}")
+            };
+            anyhow::bail!("Authorization code exchange failed ({status}): {detail}")
+        }
     }
 }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -372,21 +372,38 @@ pub async fn auth_code_login() -> Result<()> {
     }
 }
 
-/// Restore a chat-pasted authorization code to the standard base64 form the
-/// token endpoint expects. The connect page displays codes in a chat-safe
-/// base64url form without padding (`+` -> `-`, `/` -> `_`, trailing `=`
-/// stripped) because raw base64 gets escaped or truncated by chat apps.
-/// Surrounding whitespace, quotes, and backticks picked up while copying are
-/// stripped as well.
-fn normalize_auth_code(input: &str) -> String {
-    let stripped = input
+/// Build the ordered exchange candidates for a user-pasted authorization
+/// code. The connect page displays codes in a pure-alphanumeric base58 form
+/// (raw standard-base64 codes get escaped or truncated by chat apps); legacy
+/// pages used an unpadded base64url form. Candidate order: base58-decoded,
+/// base64url-restored, the string as pasted. A rejected lookup does not
+/// consume the one-time code, so later attempts are safe.
+///
+/// Mirrors the hosted MCP server's `authenticate` tool — keep the two in
+/// sync (both repos pin the same shared test vector).
+fn auth_code_candidates(input: &str) -> Vec<String> {
+    use base64::Engine as _;
+    let raw = input
         .trim()
-        .trim_matches(|c| matches!(c, '"' | '\'' | '`'));
-    let mut code = stripped.replace('-', "+").replace('_', "/");
-    while !code.is_empty() && code.len() % 4 != 0 {
-        code.push('=');
+        .trim_matches(|c| matches!(c, '"' | '\'' | '`'))
+        .to_string();
+    if raw.is_empty() {
+        return Vec::new();
     }
-    code
+    let mut candidates: Vec<String> = Vec::new();
+    if let Ok(bytes) = bs58::decode(&raw).into_vec() {
+        candidates.push(base64::engine::general_purpose::STANDARD.encode(bytes));
+    }
+    if let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(&raw) {
+        let restored = base64::engine::general_purpose::STANDARD.encode(bytes);
+        if !candidates.contains(&restored) {
+            candidates.push(restored);
+        }
+    }
+    if !candidates.contains(&raw) {
+        candidates.push(raw);
+    }
+    candidates
 }
 
 /// Agent Auth Code reverse-authorization flow.
@@ -396,29 +413,21 @@ fn normalize_auth_code(input: &str) -> String {
 /// access/refresh token in a single synchronous call. No browser, no polling,
 /// no local callback server.
 ///
-/// The pasted code is first restored from the chat-safe base64url display
-/// form via [`normalize_auth_code`]; the string as pasted is kept as a
-/// fallback candidate (a rejected lookup does not consume the one-time code,
-/// so a second attempt is safe).
+/// The pasted code is restored from its chat-safe display form via
+/// [`auth_code_candidates`] (base58 / legacy base64url / raw, in order); a
+/// rejected lookup does not consume the one-time code, so trying multiple
+/// candidates is safe.
 ///
 /// The resulting tokens are written to the same encrypted token cache used by
 /// every other login path, so subsequent refresh logic is fully shared.
 pub async fn auth_code_exchange_login(code: &str) -> Result<()> {
-    let raw = code
-        .trim()
-        .trim_matches(|c| matches!(c, '"' | '\'' | '`'))
-        .to_string();
-    let normalized = normalize_auth_code(code);
-    if normalized.is_empty() {
+    let candidates = auth_code_candidates(code);
+    if candidates.is_empty() {
         anyhow::bail!(
             "Empty authorization code. Generate one at {} and pass it as \
              `longbridge auth login --auth-code <CODE>`.",
             connect_url()
         );
-    }
-    let mut candidates = vec![normalized];
-    if !raw.is_empty() && !candidates.contains(&raw) {
-        candidates.push(raw);
     }
 
     let url = format!("{}/token", oauth_base_url());
@@ -531,4 +540,45 @@ pub fn clear_token() -> Result<()> {
         tracing::debug!("OAuth token deleted: {}", path.display());
     }
     Ok(())
+}
+
+
+#[cfg(test)]
+mod auth_code_tests {
+    use super::*;
+
+    // Shared vector with longbridge-mcp: the connect page displays
+    // `RKBXES26iL0CdQL85vXz+tSNeoHeqyUuLEz3nVWgqVU=` as
+    // `5ctXgj3mEtEHoUBRwJnyURf4EkfA1924fY3o9Njev2zp` (base58).
+    const ORIGINAL: &str = "RKBXES26iL0CdQL85vXz+tSNeoHeqyUuLEz3nVWgqVU=";
+    const BASE58_FORM: &str = "5ctXgj3mEtEHoUBRwJnyURf4EkfA1924fY3o9Njev2zp";
+    const BASE64URL_FORM: &str = "RKBXES26iL0CdQL85vXz-tSNeoHeqyUuLEz3nVWgqVU";
+
+    #[test]
+    fn base58_display_form_decodes_to_original_code() {
+        assert_eq!(auth_code_candidates(BASE58_FORM)[0], ORIGINAL);
+    }
+
+    #[test]
+    fn legacy_base64url_form_is_restored() {
+        assert!(auth_code_candidates(BASE64URL_FORM).contains(&ORIGINAL.to_string()));
+    }
+
+    #[test]
+    fn original_base64_passes_through() {
+        assert!(auth_code_candidates(ORIGINAL).contains(&ORIGINAL.to_string()));
+    }
+
+    #[test]
+    fn chat_copy_junk_is_stripped() {
+        assert_eq!(
+            auth_code_candidates(&format!("  `{BASE58_FORM}`  "))[0],
+            ORIGINAL
+        );
+    }
+
+    #[test]
+    fn empty_input_yields_no_candidates() {
+        assert!(auth_code_candidates("   ").is_empty());
+    }
 }

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -89,7 +89,7 @@ fn read_token_state() -> Result<TokenState> {
     }
 
     let Some(full) =
-        crate::secure_storage::EncryptedFileTokenStorage::load_full(crate::auth::client_id())
+        crate::secure_storage::EncryptedFileTokenStorage::load_full(crate::region::client_id())
     else {
         return Ok(TokenState {
             status: "decrypt_failed",

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -8,9 +8,6 @@ use crate::region;
 
 const CONNECT_TIMEOUT_SECS: u64 = 5;
 const PROBE_COUNT: usize = 10;
-const GLOBAL_HTTP_URL: &str = "https://openapi.longbridge.com";
-const GLOBAL_PROBE_URL: &str = "https://openapi.longbridge.com/health";
-const CN_PROBE_URL: &str = "https://openapi.longbridge.cn/health";
 
 // ANSI colors
 const GREEN: &str = "\x1b[32m";
@@ -114,7 +111,9 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
     }
 
     // ── Connectivity (concurrent) ─────────────────────────────────────────────
-    let (global, cn) = tokio::join!(probe(GLOBAL_PROBE_URL), probe(CN_PROBE_URL),);
+    let global_probe_url = format!("{}/health", region::HTTP_URL_GLOBAL);
+    let cn_probe_url = format!("{}/health", region::HTTP_URL_CN);
+    let (global, cn) = tokio::join!(probe(&global_probe_url), probe(&cn_probe_url),);
 
     match format {
         OutputFormat::Json => {
@@ -128,7 +127,7 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
                     "active": if is_cn { "CN" } else { "Global" },
                 },
                 "connectivity": {
-                    "global": { "url": GLOBAL_HTTP_URL, "ok": global.ok, "ms": global.ms },
+                    "global": { "url": region::HTTP_URL_GLOBAL, "ok": global.ok, "ms": global.ms },
                     "cn":     { "url": region::HTTP_URL_CN, "ok": cn.ok, "ms": cn.ms },
                 },
             });
@@ -161,7 +160,7 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
 
             println!();
             println!("Connectivity {DIM}(avg of {PROBE_COUNT}){RESET}");
-            println!("{}", probe_line("global", &global, GLOBAL_HTTP_URL));
+            println!("{}", probe_line("global", &global, region::HTTP_URL_GLOBAL));
             println!("{}", probe_line("cn", &cn, region::HTTP_URL_CN));
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2948,13 +2948,22 @@ pub enum AuthCmd {
     /// CLI polls until authorization is complete. Works on any machine including
     /// SSH sessions and headless servers.
     ///
-    /// Use `--auth-code` for the Authorization Code flow: opens a browser on this
-    /// machine and listens on `localhost:60355` for the OAuth callback.
+    /// Pass `--auth-code <CODE>` to exchange an authorization code generated at
+    /// <https://open.longbridge.com/connect> — a single synchronous call with no
+    /// browser, polling, or local callback server. Ideal for AI agents.
+    ///
+    /// Pass `--auth-code` with no value for the browser Authorization Code flow:
+    /// opens a browser on this machine and listens on `localhost:60355` for the
+    /// OAuth callback.
     Login {
-        /// Authorization Code flow: opens a browser and handles the localhost callback.
-        /// Requires the browser to be on the same machine (local use only).
-        #[arg(long)]
-        auth_code: bool,
+        /// Authorize using a code instead of the device flow.
+        ///
+        /// With a value (`--auth-code <CODE>`): exchange an authorization code
+        /// from <https://open.longbridge.com/connect> in one synchronous call.
+        /// Without a value (`--auth-code`): run the browser Authorization Code
+        /// flow that handles the localhost callback (local use only).
+        #[arg(long, value_name = "CODE", num_args = 0..=1, default_missing_value = "")]
+        auth_code: Option<String>,
         /// Print request/response details for each OAuth step.
         #[arg(short, long)]
         verbose: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,11 +167,21 @@ async fn main() {
         }
 
         Some(cli::Commands::Auth {
-            cmd: cli::AuthCmd::Login {
-                auth_code: true, ..
-            },
+            cmd:
+                cli::AuthCmd::Login {
+                    auth_code: Some(code),
+                    ..
+                },
         }) => {
-            if let Err(e) = auth::auth_code_login().await {
+            // `--auth-code <CODE>` (non-empty): exchange an authorization code in
+            // a single synchronous call. `--auth-code` with no value falls back to
+            // the browser Authorization Code flow.
+            let result = if code.is_empty() {
+                auth::auth_code_login().await
+            } else {
+                auth::auth_code_exchange_login(&code).await
+            };
+            if let Err(e) = result {
                 eprintln!("Authentication failed: {e:#}");
                 std::process::exit(1);
             }
@@ -180,7 +190,7 @@ async fn main() {
         Some(cli::Commands::Auth {
             cmd:
                 cli::AuthCmd::Login {
-                    auth_code: false,
+                    auth_code: None,
                     verbose,
                 },
         }) => {

--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -62,7 +62,7 @@ pub async fn init_contexts() -> Result<(
     } else {
         tracing::info!("No API key env vars found, using OAuth authentication");
         // Migrate legacy plaintext token to encrypted storage on first run after upgrade.
-        crate::secure_storage::migrate_legacy_token(crate::auth::client_id());
+        crate::secure_storage::migrate_legacy_token(crate::region::client_id());
 
         // If no token file exists, refuse to start a browser/callback-server flow.
         // CLI commands require a stored token; users must run `longbridge auth login` first.
@@ -74,7 +74,7 @@ pub async fn init_contexts() -> Result<(
         }
         // If the token file exists but cannot be decrypted (e.g. machine ID
         // changed), fail fast rather than hanging in the OAuth browser flow.
-        if crate::secure_storage::EncryptedFileTokenStorage::load_full(crate::auth::client_id())
+        if crate::secure_storage::EncryptedFileTokenStorage::load_full(crate::region::client_id())
             .is_none()
         {
             return Err(anyhow::anyhow!(
@@ -88,7 +88,7 @@ pub async fn init_contexts() -> Result<(
         // the SDK would trigger when its own refresh fallback fires.
         crate::auth::refresh_if_expired().await?;
 
-        let oauth_result = longbridge::oauth::OAuthBuilder::new(crate::auth::client_id())
+        let oauth_result = longbridge::oauth::OAuthBuilder::new(crate::region::client_id())
             .callback_port(crate::auth::CALLBACK_PORT)
             .token_storage(crate::secure_storage::EncryptedFileTokenStorage)
             .build(|_url| {
@@ -123,7 +123,7 @@ pub async fn init_contexts() -> Result<(
     // If LONGBRIDGE_ENV=staging, override all endpoints to test environment.
     // This takes highest priority over region detection.
     let effective_http_url;
-    if crate::auth::is_test_env() {
+    if crate::region::is_test_env() {
         tracing::info!("Using TEST environment endpoints (openapi.longbridge.xyz)");
         config_builder = config_builder
             .http_url(crate::region::HTTP_URL_TEST)
@@ -144,7 +144,7 @@ pub async fn init_contexts() -> Result<(
         http_client_config = http_client_config.http_url(crate::region::HTTP_URL_CN);
         effective_http_url = crate::region::HTTP_URL_CN;
     } else {
-        effective_http_url = "https://openapi.longbridge.com";
+        effective_http_url = crate::region::HTTP_URL_GLOBAL;
     }
 
     // Extract x-cli-cmd and x-cli-args from process arguments.

--- a/src/region.rs
+++ b/src/region.rs
@@ -10,16 +10,73 @@ const GEOTEST_TIMEOUT_SECS: u64 = 3;
 
 // Global endpoint URLs
 pub const HTTP_URL_GLOBAL: &str = "https://openapi.longbridge.com";
+pub const OPEN_URL_GLOBAL: &str = "https://open.longbridge.com";
 
 // CN endpoint URLs
 pub const HTTP_URL_CN: &str = "https://openapi.longbridge.cn";
 pub const QUOTE_WS_URL_CN: &str = "wss://openapi-quote.longbridge.cn/v2";
 pub const TRADE_WS_URL_CN: &str = "wss://openapi-trade.longbridge.cn/v2";
+pub const OPEN_URL_CN: &str = "https://open.longbridge.cn";
 
 // Test environment URLs (openapi.longbridge.xyz)
 pub const HTTP_URL_TEST: &str = "https://openapi.longbridge.xyz";
 pub const QUOTE_WS_URL_TEST: &str = "wss://openapi-quote.longbridge.xyz/v2";
 pub const TRADE_WS_URL_TEST: &str = "wss://openapi-trade.longbridge.xyz/v2";
+
+// OAuth client IDs (shared between Global and CN: the `.cn` and `.com`
+// endpoints share user data and token validation, differing only in routing)
+pub const CLIENT_ID: &str = "fd52fbc5-02a9-47f5-ad30-0842c841aae9";
+pub const CLIENT_ID_TEST: &str = "37435cdf-c7e4-4de9-8715-b20d33416196";
+
+// Dedicated "AI Agent" public client (token endpoint auth method `none`,
+// no client_secret, no PKCE) used exclusively by the
+// `longbridge auth login --auth-code <CODE>` reverse-authorization flow.
+pub const AGENT_CLIENT_ID: &str = "c91cd252-2f89-4024-9c5d-7b1340fc3bd1";
+pub const AGENT_CLIENT_ID_TEST: &str = "c0c3ae51-dd73-4706-8d29-601ae376034c";
+
+/// Whether the staging environment is active (`LONGBRIDGE_ENV=staging`).
+pub fn is_test_env() -> bool {
+    std::env::var("LONGBRIDGE_ENV").is_ok_and(|v| v == "staging")
+}
+
+/// `OpenAPI` HTTP base URL for the current environment and region.
+pub fn http_url() -> &'static str {
+    if is_test_env() {
+        HTTP_URL_TEST
+    } else if is_cn_cached() {
+        HTTP_URL_CN
+    } else {
+        HTTP_URL_GLOBAL
+    }
+}
+
+/// Developer portal host (`open.longbridge.*`) for the current region:
+/// release CDN, docs, and the `/connect` reverse-authorization page.
+pub fn open_url() -> &'static str {
+    if is_cn_cached() {
+        OPEN_URL_CN
+    } else {
+        OPEN_URL_GLOBAL
+    }
+}
+
+/// CLI OAuth client ID for the current environment.
+pub fn client_id() -> &'static str {
+    if is_test_env() {
+        CLIENT_ID_TEST
+    } else {
+        CLIENT_ID
+    }
+}
+
+/// "AI Agent" OAuth client ID for the current environment.
+pub fn agent_client_id() -> &'static str {
+    if is_test_env() {
+        AGENT_CLIENT_ID_TEST
+    } else {
+        AGENT_CLIENT_ID
+    }
+}
 
 fn cache_file_path() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".longbridge").join("openapi").join("region-cache"))

--- a/src/update.rs
+++ b/src/update.rs
@@ -13,8 +13,6 @@ const CHECK_INTERVAL_SECS: u64 = 86400; // 24 hours
 const FETCH_TIMEOUT_SECS: u64 = 5;
 const DOWNLOAD_TIMEOUT_SECS: u64 = 300;
 
-const HOST_GLOBAL: &str = "https://open.longbridge.com";
-const HOST_CN: &str = "https://open.longbridge.cn";
 const RELEASE_PATH: &str = "/github/release/longbridge-terminal";
 const RELEASE_NOTES_PATH: &str = "/docs/cli/release-notes.md";
 
@@ -156,11 +154,7 @@ async fn fetch_latest_version() -> Option<String> {
 }
 
 fn get_host() -> &'static str {
-    if crate::region::is_cn_cached() {
-        HOST_CN
-    } else {
-        HOST_GLOBAL
-    }
+    crate::region::open_url()
 }
 
 async fn fetch_latest_version_for_update() -> anyhow::Result<String> {


### PR DESCRIPTION
## Summary

- `longbridge auth login --auth-code <CODE>` now accepts an authorization code generated at https://open.longbridge.com/connect and exchanges it for tokens in a single synchronous call — no browser, no polling, no local callback server. Ideal for AI agents and headless environments.
- `--auth-code` with no value keeps the existing browser Authorization Code flow unchanged.
- Pasted codes are normalized from the chat-safe base64url display form (whitespace/quotes/backticks stripped, `-`/`_` restored, padding re-added), with the raw paste kept as a fallback candidate.
- Invalid/expired/used codes produce a self-healing error message pointing the user back to the `/connect` page to regenerate one.
- Centralized environment/region endpoint and OAuth client ID selection in `src/region.rs` (`http_url()`, `open_url()`, `client_id()`, `agent_client_id()`, `is_test_env()`), replacing duplicated host constants in `auth.rs`, `check.rs`, and `update.rs`.

## Test plan

- [ ] Generate a code at https://open.longbridge.com/connect and run `longbridge auth login --auth-code <CODE>`; verify token saved and subsequent commands work
- [ ] Verify `longbridge auth login --auth-code` (no value) still runs the browser flow
- [ ] Verify an expired/reused code shows the regenerate hint
- [ ] `longbridge check --format json` still probes both regions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)