### PR TITLE
cli: Log WS quote operations via `/v1/quote/cmd` beacon

### DIFF
--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -307,7 +307,7 @@ async fn fetch_account_channel_from_positions() -> Option<String> {
 async fn fetch_account_info(market: &str) -> Result<AccountInfo> {
     let account_channel = crate::auth::account_channel_or_default();
     let (member_id, level_center, statement_info, account_channel) = tokio::join!(
-        crate::openapi::quote().member_id(),
+        crate::openapi::quote_cmd().member_id(),
         fetch_my_quotes(market, &account_channel),
         fetch_account_info_from_statement(),
         fetch_account_channel_from_positions(),

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -94,7 +94,7 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
         token_ok = false;
         token_detail = e.to_string();
     } else {
-        let ctx = crate::openapi::quote();
+        let ctx = crate::openapi::quote_cmd();
         match ctx.market_temperature(longbridge::Market::HK).await {
             Ok(temp) => {
                 token_ok = true;

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -1481,7 +1481,7 @@ pub async fn cmd_finance_calendar(
     if let Some(ref src) = filter {
         match src.as_str() {
             "watchlist" => {
-                let ctx = crate::openapi::quote();
+                let ctx = crate::openapi::quote_cmd();
                 let groups = ctx.watchlist().await?;
                 let mut seen = std::collections::HashSet::new();
                 for group in groups {

--- a/src/cli/ipo.rs
+++ b/src/cli/ipo.rs
@@ -253,7 +253,7 @@ fn transform_order_item(item: &Value) -> Value {
 }
 
 async fn member_id() -> Result<i64> {
-    crate::openapi::quote()
+    crate::openapi::quote_cmd()
         .member_id()
         .await
         .map_err(anyhow::Error::from)

--- a/src/cli/news.rs
+++ b/src/cli/news.rs
@@ -76,7 +76,7 @@ pub async fn cmd_news(symbol: String, count: usize, format: &OutputFormat) -> Re
 
 /// Fetch regulatory filings for a symbol.
 pub async fn cmd_filings(symbol: String, count: usize, format: &OutputFormat) -> Result<()> {
-    let items = crate::openapi::quote().filings(&symbol).await?;
+    let items = crate::openapi::quote_cmd().filings(&symbol).await?;
 
     if items.is_empty() {
         println!("No filings found for {symbol}.");
@@ -139,7 +139,7 @@ pub async fn cmd_filing_detail(
     list_files: bool,
     file_index: usize,
 ) -> Result<()> {
-    let items = crate::openapi::quote().filings(&symbol).await?;
+    let items = crate::openapi::quote_cmd().filings(&symbol).await?;
 
     let filing = items
         .into_iter()

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -243,7 +243,7 @@ pub async fn cmd_quote(symbols: Vec<String>, format: &OutputFormat) -> Result<()
     if symbols.is_empty() {
         bail!("At least one symbol is required");
     }
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let input = symbols.clone();
     let quotes = ctx.quote(symbols).await?;
 
@@ -390,7 +390,7 @@ pub async fn cmd_quote(symbols: Vec<String>, format: &OutputFormat) -> Result<()
 }
 
 pub async fn cmd_depth(symbol: String, format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let depth = ctx.depth(symbol.clone()).await?;
     if depth.asks.is_empty() && depth.bids.is_empty() {
         hint_symbol_do_you_mean(&symbol);
@@ -453,7 +453,7 @@ pub async fn cmd_depth(symbol: String, format: &OutputFormat) -> Result<()> {
 }
 
 pub async fn cmd_brokers(symbol: String, format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let brokers = ctx.brokers(symbol.clone()).await?;
 
     match format {
@@ -513,7 +513,7 @@ pub async fn cmd_brokers(symbol: String, format: &OutputFormat) -> Result<()> {
 }
 
 pub async fn cmd_trades(symbol: String, count: usize, format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let trades = ctx.trades(symbol.clone(), count).await?;
 
     let headers = &["Time", "Price", "Volume", "Direction", "Type"];
@@ -538,7 +538,7 @@ pub async fn cmd_trades(symbol: String, count: usize, format: &OutputFormat) -> 
 }
 
 pub async fn cmd_intraday(symbol: String, session: &str, format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let trade_sessions = parse_trade_sessions(session)?;
     let lines = ctx.intraday(symbol.clone(), trade_sessions).await?;
 
@@ -571,7 +571,7 @@ pub async fn cmd_kline(
     session: &str,
     format: &OutputFormat,
 ) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let p = parse_period(period)?;
     let adj = parse_adjust(adjust)?;
     let trade_sessions = parse_trade_sessions(session)?;
@@ -633,7 +633,7 @@ pub async fn cmd_kline_history(
     session: &str,
     format: &OutputFormat,
 ) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let p = parse_period(period)?;
     let adj = parse_adjust(adjust)?;
     let trade_sessions = parse_trade_sessions(session)?;
@@ -705,7 +705,7 @@ pub async fn cmd_static(symbols: Vec<String>, format: &OutputFormat) -> Result<(
     if symbols.is_empty() {
         bail!("At least one symbol is required");
     }
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let input = symbols.clone();
     let infos = ctx.static_info(symbols).await?;
 
@@ -772,7 +772,7 @@ pub async fn cmd_calc_index(
     if symbols.is_empty() {
         bail!("At least one symbol is required");
     }
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
 
     // Check if using stock defaults; if results are all empty, retry with option fields
     let is_stock_default =
@@ -850,7 +850,7 @@ pub async fn cmd_calc_index(
 }
 
 pub async fn cmd_capital_flow(symbol: String, format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let flows = ctx.capital_flow(symbol).await?;
 
     let headers = &["Time", "Inflow"];
@@ -864,7 +864,7 @@ pub async fn cmd_capital_flow(symbol: String, format: &OutputFormat) -> Result<(
 }
 
 pub async fn cmd_capital_dist(symbol: String, format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let dist = ctx.capital_distribution(symbol.clone()).await?;
 
     match format {
@@ -916,7 +916,7 @@ pub async fn cmd_market_temp(
     _granularity: &str,
     format: &OutputFormat,
 ) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let m = parse_market(market)?;
 
     if history {
@@ -971,7 +971,7 @@ pub async fn cmd_market_temp(
 }
 
 pub async fn cmd_trading_session(format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let sessions = ctx.trading_session().await?;
 
     match format {
@@ -1016,7 +1016,7 @@ pub async fn cmd_trading_days(
     end: Option<String>,
     format: &OutputFormat,
 ) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let m = parse_market(market)?;
 
     let now = time::OffsetDateTime::now_utc().date();
@@ -1074,7 +1074,7 @@ pub async fn cmd_security_list(
     if page == 0 {
         bail!("Page number must be >= 1");
     }
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let m = parse_market(market)?;
     let cat = parse_security_list_category(category);
     let securities = ctx.security_list(m, cat).await?;
@@ -1120,7 +1120,7 @@ pub async fn cmd_security_list(
 }
 
 pub async fn cmd_participants(format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let participants = ctx.participants().await?;
 
     let headers = &["Broker ID", "Name EN", "Name CN"];
@@ -1144,7 +1144,7 @@ pub async fn cmd_participants(format: &OutputFormat) -> Result<()> {
 }
 
 pub async fn cmd_subscriptions(format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let subs = ctx.subscriptions().await?;
 
     let headers = &["Symbol", "Sub Types", "Candlestick Periods"];
@@ -1171,7 +1171,7 @@ pub async fn cmd_option_quote(symbols: Vec<String>, format: &OutputFormat) -> Re
     if symbols.is_empty() {
         bail!("At least one symbol is required");
     }
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let quotes = ctx.option_quote(symbols).await?;
 
     match format {
@@ -1258,7 +1258,7 @@ pub async fn cmd_option_chain(
     date: Option<String>,
     format: &OutputFormat,
 ) -> Result<()> {
-    let api = LbQuoteApi::new(crate::openapi::quote());
+    let api = LbQuoteApi::new(crate::openapi::quote_cmd());
     run_option_chain(&api, symbol, date, format).await
 }
 
@@ -1266,7 +1266,7 @@ pub async fn cmd_warrant_quote(symbols: Vec<String>, format: &OutputFormat) -> R
     if symbols.is_empty() {
         bail!("At least one symbol is required");
     }
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let quotes = ctx.warrant_quote(symbols).await?;
 
     let headers = &[
@@ -1296,7 +1296,7 @@ pub async fn cmd_warrant_quote(symbols: Vec<String>, format: &OutputFormat) -> R
 }
 
 pub async fn cmd_warrant_list(symbol: String, format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let warrants = ctx
         .warrant_list(
             symbol,
@@ -1330,7 +1330,7 @@ pub async fn cmd_warrant_list(symbol: String, format: &OutputFormat) -> Result<(
 }
 
 pub async fn cmd_warrant_issuers(format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let issuers = ctx.warrant_issuers().await?;
 
     let headers = &["ID", "Name EN", "Name CN"];

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -126,7 +126,7 @@ async fn cmd_detail(id: String, format: &OutputFormat) -> Result<()> {
                     .collect();
 
                 let quote_map: HashMap<String, (String, String)> = {
-                    let ctx = crate::openapi::quote();
+                    let ctx = crate::openapi::quote_cmd();
                     ctx.quote(symbols)
                         .await
                         .unwrap_or_default()

--- a/src/cli/trade.rs
+++ b/src/cli/trade.rs
@@ -767,6 +767,9 @@ pub async fn cmd_max_qty(
 }
 
 pub async fn cmd_portfolio(format: &OutputFormat) -> Result<()> {
+    // Portfolio reaches QuoteContext (WS) through the shared `account` helper, so
+    // record the WS quote operation here at the CLI entry point.
+    crate::openapi::track_quote_cmd();
     let portfolio = crate::openapi::account::fetch_portfolio().await?;
 
     print_account_banner(format);

--- a/src/cli/watchlist.rs
+++ b/src/cli/watchlist.rs
@@ -31,7 +31,7 @@ fn sorted_securities(
 }
 
 async fn cmd_list(format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let groups = ctx.watchlist().await?;
 
     match format {
@@ -76,7 +76,7 @@ async fn cmd_list(format: &OutputFormat) -> Result<()> {
 }
 
 async fn cmd_show(group: String, format: &OutputFormat) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let groups = ctx.watchlist().await?;
 
     // Match by numeric ID first, then fall back to name (case-insensitive)
@@ -152,7 +152,7 @@ async fn cmd_pin(securities: Vec<String>, remove: Vec<String>) -> Result<()> {
 }
 
 async fn cmd_create(name: String) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     let req = RequestCreateWatchlistGroup {
         name: name.clone(),
         securities: None,
@@ -175,7 +175,7 @@ async fn cmd_delete(id: i64, purge: bool, yes: bool) -> Result<()> {
         }
     }
 
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
     ctx.delete_watchlist_group(id, purge).await?;
     println!("Deleted watchlist group {id}.");
     Ok(())
@@ -189,7 +189,7 @@ async fn cmd_update(
     mode: &str,
     _format: &OutputFormat,
 ) -> Result<()> {
-    let ctx = crate::openapi::quote();
+    let ctx = crate::openapi::quote_cmd();
 
     let update_mode = match mode {
         "remove" => SecuritiesUpdateMode::Remove,

--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -254,6 +254,46 @@ pub fn trade() -> &'static longbridge::trade::TradeContext {
         .expect("TradeContext not initialized, please call init_contexts() first")
 }
 
+/// Server-side beacon endpoint. Quote operations flow over the WebSocket quote
+/// channel and never reach the HTTP access log; a request to this fake path lets
+/// the server record (and count) that a WS-backed quote command ran. The path
+/// only needs to exist server-side to be logged.
+pub(crate) const QUOTE_CMD_PATH: &str = "/v1/quote/cmd";
+
+/// Send the tracking beacon over `client`. The (empty) body and any transport
+/// error are ignored — the server only needs the access-log entry. Extracted as
+/// its own awaitable function so the integration test can drive it against a
+/// local server deterministically.
+pub(crate) async fn send_quote_cmd(client: &longbridge::httpclient::HttpClient) {
+    let _ = client
+        .request(reqwest::Method::GET, QUOTE_CMD_PATH)
+        .response::<String>()
+        .send()
+        .await;
+}
+
+/// Fire a best-effort `GET /v1/quote/cmd` so the server records a log entry for a
+/// WS-backed quote operation. It reuses the global `HttpClient`, which already
+/// carries the tracking headers (`user-agent`, `x-cli-cmd`, `x-cli-args`) and the
+/// OAuth token, so no extra payload is needed. Fire-and-forget: spawned on the
+/// runtime with its result and errors ignored, never blocking or delaying the
+/// real quote call. Call this directly at CLI quote entry points that reach
+/// `QuoteContext` only through shared helpers (e.g. portfolio via `account`).
+pub fn track_quote_cmd() {
+    let Some(client) = HTTP_CLIENT.get() else {
+        return;
+    };
+    tokio::spawn(send_quote_cmd(client));
+}
+
+/// Get the global `QuoteContext` and record the WS quote operation server-side.
+/// Use this at every CLI quote command entry point instead of [`quote`] so the
+/// otherwise-unlogged WebSocket request is counted. See [`track_quote_cmd`].
+pub fn quote_cmd() -> &'static longbridge::quote::QuoteContext {
+    track_quote_cmd();
+    quote()
+}
+
 /// Get rate-limited `QuoteContext` (recommended for all API calls)
 pub fn quote_limited() -> &'static RateLimitedQuoteContext {
     RATE_LIMITED_QUOTE_CTX
@@ -294,4 +334,126 @@ pub fn statement() -> &'static longbridge::AssetContext {
     STATEMENT_CTX
         .get()
         .expect("AssetContext not initialized, please call init_contexts() first")
+}
+
+#[cfg(test)]
+mod quote_cmd_tests {
+    use super::{send_quote_cmd, QUOTE_CMD_PATH};
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Start a throwaway HTTP server on an ephemeral port that captures the raw
+    /// bytes of the first request, replies `200`, and hands the request back over
+    /// a oneshot channel. A real socket — no HTTP mocking — so the test exercises
+    /// the actual SDK `HttpClient` send path and survives future refactors.
+    async fn spawn_capture_server() -> (u16, tokio::sync::oneshot::Receiver<String>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = [0u8; 4096];
+            let mut data = Vec::new();
+            // Read until the end of the request headers.
+            while !data.windows(4).any(|w| w == b"\r\n\r\n") {
+                match socket.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => data.extend_from_slice(&buf[..n]),
+                }
+            }
+            let _ = socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .await;
+            let _ = socket.flush().await;
+            let _ = tx.send(String::from_utf8_lossy(&data).into_owned());
+        });
+        (port, rx)
+    }
+
+    /// `send_quote_cmd` must issue `GET /v1/quote/cmd` and carry whatever tracking
+    /// headers the client was built with, so the server can attribute the
+    /// otherwise-invisible WS quote operation.
+    #[tokio::test]
+    async fn send_quote_cmd_hits_endpoint_with_tracking_headers() {
+        let (port, rx) = spawn_capture_server().await;
+
+        // Build a client the same way production does (token + tracking headers),
+        // but pointed at the local capture server.
+        let oauth = longbridge::oauth::OAuth::from_token("test-token");
+        let config = longbridge::httpclient::HttpClientConfig::from_oauth(oauth)
+            .http_url(format!("http://127.0.0.1:{port}"));
+        let client = longbridge::httpclient::HttpClient::new(config)
+            .header("user-agent", "longbridge-cli/test")
+            .header("x-cli-cmd", "quote");
+
+        send_quote_cmd(&client).await;
+
+        let request = tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("capture server did not receive a request in time")
+            .expect("capture server dropped the request");
+
+        let request_line = request.lines().next().unwrap_or_default();
+        assert!(
+            request_line.starts_with(&format!("GET {QUOTE_CMD_PATH}")),
+            "expected `GET {QUOTE_CMD_PATH}`, got request line: {request_line}"
+        );
+
+        let lower = request.to_lowercase();
+        assert!(
+            lower.contains("user-agent: longbridge-cli/test"),
+            "tracking user-agent header missing; request was:\n{request}"
+        );
+        assert!(
+            lower.contains("x-cli-cmd: quote"),
+            "x-cli-cmd tracking header missing; request was:\n{request}"
+        );
+    }
+
+    /// Recursively collect `.rs` files under `dir`.
+    fn rs_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut out = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    out.extend(rs_files(&path));
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    out.push(path);
+                }
+            }
+        }
+        out
+    }
+
+    /// Guard: every `QuoteContext` access inside `src/cli/` must go through the
+    /// tracking accessor `quote_cmd()` (which fires the `/v1/quote/cmd` beacon),
+    /// never the raw `quote()`. This turns "did we remember to track every
+    /// command" from manual review into an enforced invariant — a new CLI
+    /// command that reaches for `openapi::quote()` directly fails this test.
+    ///
+    /// Blind spot: commands that touch `QuoteContext` only through shared helpers
+    /// in `src/openapi/` (e.g. portfolio via `account`) are not visible here;
+    /// those fire the beacon explicitly at their CLI entry via `track_quote_cmd`.
+    #[test]
+    fn cli_uses_only_tracking_quote_accessor() {
+        let cli_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/cli");
+        let mut offenders = Vec::new();
+        for file in rs_files(&cli_dir) {
+            let src = std::fs::read_to_string(&file).unwrap();
+            for (i, line) in src.lines().enumerate() {
+                if line.contains("openapi::quote()") {
+                    offenders.push(format!("{}:{}", file.display(), i + 1));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "CLI must use `openapi::quote_cmd()` (fires the /v1/quote/cmd beacon), \
+             not raw `openapi::quote()`. Untracked QuoteContext access at:\n{}",
+            offenders.join("\n")
+        );
+    }
 }

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -8,7 +8,7 @@ pub mod search;
 pub mod wrapper;
 
 pub use context::{
-    content, fundamental, http_client, init_contexts, quote, quote_limited, statement, trade,
-    trade_limited,
+    content, fundamental, http_client, init_contexts, quote, quote_cmd, quote_limited, statement,
+    track_quote_cmd, trade, trade_limited,
 };
 pub use rate_limiter::global_rate_limiter;


### PR DESCRIPTION
## What

CLI quote commands talk to Longbridge over the WebSocket quote channel, which produces no HTTP access-log entry — so server-side request statistics lose all WS-backed quote usage.

This fires a best-effort `GET /v1/quote/cmd` beacon once per CLI quote command. The request carries the existing tracking headers (`user-agent`, `x-cli-cmd`, `x-cli-args`) and OAuth token, giving the server a log entry to attribute the otherwise-invisible call. It is fire-and-forget: spawned on the runtime, errors ignored, and never blocks or delays the real command.

## Coverage

- All `src/cli/` quote commands now use `openapi::quote_cmd()` instead of the raw `quote()`.
- Commands that reach `QuoteContext` only through shared helpers (e.g. `portfolio`) fire `track_quote_cmd()` at their CLI entry.
- TUI and shared `openapi/` helpers are intentionally left unchanged.

## Tests

- Integration test stands up a real local HTTP server and asserts the beacon hits `GET /v1/quote/cmd` with the tracking headers (no HTTP mocking, survives refactors).
- Guard test fails if any `src/cli/` file uses the raw `openapi::quote()`, enforcing that every quote command stays tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
