### PR TITLE
chore: Fix clippy warnings and Drop panic on Windows

### DIFF
--- a/crates/cli-candlestick-chart/src/chart_data.rs
+++ b/crates/cli-candlestick-chart/src/chart_data.rs
@@ -43,7 +43,7 @@ impl ChartData {
             self.main_candle_set
                 .candles
                 .iter()
-                .skip((nb_candles as i64 - nb_visible_candles as i64).max(0) as usize)
+                .skip((nb_candles as i64 - nb_visible_candles).max(0) as usize)
                 .cloned()
                 .collect::<Vec<Candle>>(),
         );

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -19,12 +19,16 @@ pub struct FileGuard {
 
 impl Drop for FileGuard {
     fn drop(&mut self) {
-        unlock(&self.file).unwrap();
+        _ = unlock(&self.file);
     }
 }
 
 pub fn flock(path: &Path) -> Result<FileGuard> {
-    let file = OpenOptions::new().write(true).create(true).open(path)?;
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)?;
     lock_file(&file, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY)?;
     Ok(FileGuard { file })
 }
@@ -38,7 +42,7 @@ fn lock_file(file: &File, flags: u32) -> Result<()> {
             0,
             !0,
             !0,
-            &mut overlapped,
+            &raw mut overlapped,
         );
         if ret == 0 {
             Err(Error::last_os_error())

--- a/src/secure_storage.rs
+++ b/src/secure_storage.rs
@@ -132,7 +132,8 @@ pub fn try_delete(client_id: &str) {
 }
 
 /// Set file permissions to 0600 on Unix.
-pub fn harden_file_permissions(_path: &Path) {
+#[allow(unused_variables)]
+pub fn harden_file_permissions(path: &Path) {
     #[cfg(target_family = "unix")]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/src/secure_storage.rs
+++ b/src/secure_storage.rs
@@ -132,7 +132,7 @@ pub fn try_delete(client_id: &str) {
 }
 
 /// Set file permissions to 0600 on Unix.
-pub fn harden_file_permissions(path: &Path) {
+pub fn harden_file_permissions(_path: &Path) {
     #[cfg(target_family = "unix")]
     {
         use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
@
## Changes

Fix all `cargo clippy` warnings and a potential panic in `Drop` implementation on Windows.

### 1. Fix `Drop` panic in `FileGuard` (Windows)

`src/os/windows.rs` — `FileGuard::drop()` called `unlock(...).unwrap()`, which panics if the unlock operation fails (e.g., file handle already closed). This could cause an abort during cleanup.

```rust
// Before
unlock(&self.file).unwrap();

// After
_ = unlock(&self.file);
```

The Unix counterpart already handles this correctly with `_ = fcntl::flock(...)`.

### 2. Fix `suspicious_open_options` clippy error

`src/os/windows.rs` — `OpenOptions::new().write(true).create(true)` without specifying truncate behavior is flagged by `clippy::suspicious_open_options`. Added `.truncate(true)` to match the Unix implementation and the intended use as a lock file.

### 3. Fix `borrow_as_ptr` clippy error

`src/os/windows.rs` — In `lock_file()`, `&mut overlapped` implicitly coerces to `*mut OVERLAPPED`. Replaced with `&raw mut overlapped` for explicit raw pointer creation as required by `clippy::pedantic`.

### 4. Fix unnecessary cast warning

`crates/cli-candlestick-chart/src/chart_data.rs` — `nb_visible_candles` is already `i64`, so `nb_visible_candles as i64` is a no-op cast. Removed the redundant cast.

### 5. Fix unused variable warning

`src/secure_storage.rs` — The `path` parameter in `harden_file_permissions()` is unused on Windows (the function body is `#[cfg(target_family = "unix")]` only). Prefixed with `_` to suppress the warning.

## Verification

```bash
cargo fmt && cargo clippy
cargo build
```

Result: 0 warnings, 0 errors.
@