### PR TITLE
chore: Fix logger panic, env race, and clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,6 +2770,7 @@ dependencies = [
  "sec2md",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "strum 0.26.3",
  "tabled",
@@ -4632,6 +4633,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ whoami = "1.5"
 
 [dev-dependencies]
 mockall = "0.13"
+serial_test = "3"
 
 [features]
 integration = []

--- a/crates/cli-candlestick-chart/src/chart_data.rs
+++ b/crates/cli-candlestick-chart/src/chart_data.rs
@@ -43,7 +43,7 @@ impl ChartData {
             self.main_candle_set
                 .candles
                 .iter()
-                .skip((nb_candles as i64 - nb_visible_candles as i64).max(0) as usize)
+                .skip((nb_candles as i64 - nb_visible_candles).max(0) as usize)
                 .cloned()
                 .collect::<Vec<Candle>>(),
         );

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -4,13 +4,13 @@ use std::path::PathBuf;
 pub fn default_log_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
-        let mut path = dirs::home_dir().expect("Unable to get user home directory");
+        let mut path = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
         path.push("Library/Logs/Longbridge");
         path
     }
     #[cfg(target_os = "windows")]
     {
-        let mut path = dirs::data_local_dir().expect("Unable to get local data directory");
+        let mut path = dirs::data_local_dir().unwrap_or_else(|| PathBuf::from("."));
         path.push("Longbridge\\Logs");
         path
     }
@@ -18,7 +18,7 @@ pub fn default_log_dir() -> PathBuf {
     {
         let mut path = dirs::data_local_dir()
             .or_else(|| dirs::home_dir().map(|p| p.join(".local/share")))
-            .expect("Unable to get data directory");
+            .unwrap_or_else(|| PathBuf::from("."));
         path.push("longbridge/logs");
         path
     }
@@ -37,13 +37,29 @@ pub fn init() -> impl Any {
     let log_dir = default_log_dir();
     std::fs::create_dir_all(&log_dir).ok();
 
-    let writer = RollingFileAppender::builder()
+    let writer = match RollingFileAppender::builder()
         .filename_prefix("longbridge")
         .filename_suffix("log")
         .max_log_files(5)
         .rotation(Rotation::DAILY)
-        .build(log_dir)
-        .expect("fail to create log file");
+        .build(&log_dir)
+    {
+        Ok(writer) => writer,
+        Err(e) => {
+            eprintln!(
+                "Warning: Failed to create log file in {}: {e}",
+                log_dir.display()
+            );
+            // Fallback to current directory
+            RollingFileAppender::builder()
+                .filename_prefix("longbridge")
+                .filename_suffix("log")
+                .max_log_files(5)
+                .rotation(Rotation::DAILY)
+                .build(".")
+                .expect("Failed to create log file in current directory")
+        }
+    };
     let (writer, guard) = tracing_appender::non_blocking(writer);
 
     let timer = fmt::time::OffsetTime::new(

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,5 +1,8 @@
 use std::any::Any;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+type LogWriter = tracing_subscriber::fmt::writer::BoxMakeWriter;
+type LogGuard = Option<tracing_appender::non_blocking::WorkerGuard>;
 
 pub fn default_log_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
@@ -28,39 +31,78 @@ fn local_offset() -> time::UtcOffset {
     time::UtcOffset::current_local_offset().unwrap_or(time::UtcOffset::UTC)
 }
 
+fn build_rolling_file_appender(
+    log_dir: &Path,
+) -> Result<tracing_appender::rolling::RollingFileAppender, tracing_appender::rolling::InitError> {
+    use tracing_appender::rolling::{RollingFileAppender, Rotation};
+
+    RollingFileAppender::builder()
+        .filename_prefix("longbridge")
+        .filename_suffix("log")
+        .max_log_files(5)
+        .rotation(Rotation::DAILY)
+        .build(log_dir)
+}
+
+fn non_blocking_log_writer(
+    writer: tracing_appender::rolling::RollingFileAppender,
+) -> (LogWriter, LogGuard) {
+    let (writer, guard) = tracing_appender::non_blocking(writer);
+    (
+        tracing_subscriber::fmt::writer::BoxMakeWriter::new(writer),
+        Some(guard),
+    )
+}
+
+fn build_log_writer(log_dir: &Path, fallback_dir: &Path) -> (LogWriter, LogGuard) {
+    match build_rolling_file_appender(log_dir) {
+        Ok(writer) => non_blocking_log_writer(writer),
+        Err(e) => {
+            eprintln!(
+                "Warning: Failed to create log file in {}: {e}",
+                log_dir.display()
+            );
+            match build_rolling_file_appender(fallback_dir) {
+                Ok(writer) => non_blocking_log_writer(writer),
+                Err(e) => {
+                    eprintln!(
+                        "Warning: Failed to create fallback log file in {}: {e}",
+                        fallback_dir.display()
+                    );
+                    (
+                        tracing_subscriber::fmt::writer::BoxMakeWriter::new(std::io::sink),
+                        None,
+                    )
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_writer_falls_back_without_guard_when_file_appenders_fail() {
+        let primary = tempfile::NamedTempFile::new().expect("primary temp file");
+        let fallback = tempfile::NamedTempFile::new().expect("fallback temp file");
+
+        let (_writer, guard) = build_log_writer(primary.path(), fallback.path());
+
+        assert!(guard.is_none());
+    }
+}
+
 #[must_use]
 pub fn init() -> impl Any {
-    use tracing_appender::rolling::{RollingFileAppender, Rotation};
     use tracing_subscriber::fmt;
     use tracing_subscriber::prelude::*;
 
     let log_dir = default_log_dir();
     std::fs::create_dir_all(&log_dir).ok();
 
-    let writer = match RollingFileAppender::builder()
-        .filename_prefix("longbridge")
-        .filename_suffix("log")
-        .max_log_files(5)
-        .rotation(Rotation::DAILY)
-        .build(&log_dir)
-    {
-        Ok(writer) => writer,
-        Err(e) => {
-            eprintln!(
-                "Warning: Failed to create log file in {}: {e}",
-                log_dir.display()
-            );
-            // Fallback to current directory
-            RollingFileAppender::builder()
-                .filename_prefix("longbridge")
-                .filename_suffix("log")
-                .max_log_files(5)
-                .rotation(Rotation::DAILY)
-                .build(".")
-                .expect("Failed to create log file in current directory")
-        }
-    };
-    let (writer, guard) = tracing_appender::non_blocking(writer);
+    let (writer, guard) = build_log_writer(&log_dir, Path::new("."));
 
     let timer = fmt::time::OffsetTime::new(
         local_offset(),

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -19,12 +19,16 @@ pub struct FileGuard {
 
 impl Drop for FileGuard {
     fn drop(&mut self) {
-        unlock(&self.file).unwrap();
+        _ = unlock(&self.file);
     }
 }
 
 pub fn flock(path: &Path) -> Result<FileGuard> {
-    let file = OpenOptions::new().write(true).create(true).open(path)?;
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)?;
     lock_file(&file, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY)?;
     Ok(FileGuard { file })
 }
@@ -38,7 +42,7 @@ fn lock_file(file: &File, flags: u32) -> Result<()> {
             0,
             !0,
             !0,
-            &mut overlapped,
+            &raw mut overlapped,
         );
         if ret == 0 {
             Err(Error::last_os_error())

--- a/src/secure_storage.rs
+++ b/src/secure_storage.rs
@@ -132,6 +132,7 @@ pub fn try_delete(client_id: &str) {
 }
 
 /// Set file permissions to 0600 on Unix.
+#[allow(unused_variables)]
 pub fn harden_file_permissions(path: &Path) {
     #[cfg(target_family = "unix")]
     {

--- a/src/update.rs
+++ b/src/update.rs
@@ -593,6 +593,7 @@ pub fn check_and_show_release_notes() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn test_is_newer() {
@@ -616,6 +617,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_release_notes_url_respects_region() {
         // Force global
         std::env::set_var("LONGBRIDGE_REGION", "global");
@@ -637,6 +639,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_last_run_version_roundtrip() {
         let path = last_run_version_path().expect("home dir should exist");
         let backup = std::fs::read_to_string(&path).ok();


### PR DESCRIPTION
@
## Changes

### 1. Fix logger startup panic

`src/logger.rs` — Replace `expect()` calls with `unwrap_or_else()` and add fallback to current directory if log file creation fails. This prevents crashes in Docker/CI environments where home directory may not exist.

```rust
// Before
dirs::home_dir().expect("Unable to get user home directory")

// After
dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))
```

### 2. Fix environment variable data race in tests

`src/update.rs` — Tests using `std::env::set_var` are unsafe when run in parallel (Rust 1.66+). Added `serial_test` crate and `#[serial]` attribute to affected tests.

**Added dependency:**
```toml
[dev-dependencies]
serial_test = "3"
```

### 3. Fix clippy warnings (same as PR #242)

- **Drop panic** — `src/os/windows.rs`: Replace `unlock(...).unwrap()` with `_ = unlock(...)`
- **suspicious_open_options** — Add `.truncate(true)` to `OpenOptions`
- **borrow_as_ptr** — Use `&raw mut overlapped` for explicit raw pointer
- **unnecessary cast** — Remove redundant `as i64` in `chart_data.rs`
- **unused variable** — Add `#[allow(unused_variables)]` to `harden_file_permissions()`

## Verification

```bash
cargo fmt && cargo clippy  → 0 warnings, 0 errors
cargo build                → success
cargo test                 → 175 passed, 0 failed
```
@