### PR TITLE
将 scoop 发布脚本 CDN 域名切换为 open.longbridge.com

### DIFF
--- a/.github/workflows/update-scoop.yml
+++ b/.github/workflows/update-scoop.yml
@@ -76,7 +76,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           GITHUB_URL="https://github.com/${REPO}/releases/download/${TAG}/longbridge-terminal-windows-amd64.zip"
-          CDN_URL="https://open.longbridge.cn/github/release/longbridge-terminal/v${VERSION}/longbridge-terminal-windows-amd64.zip"
+          CDN_URL="https://open.longbridge.com/github/release/longbridge-terminal/v${VERSION}/longbridge-terminal-windows-amd64.zip"
 
           # Update .scoop/longbridge.json (GitHub URL, committed back to repo)
           jq \


### PR DESCRIPTION
## 合入判断
**[APPROVE]** — 仅改 scoop 发布脚本中的 CDN 域名（.cn → .com），无代码逻辑变更
> 1 file · +1 / -1 · `.github/workflows`

---
## 变更概要
- `update-scoop.yml` 中 `CDN_URL` 域名由 `open.longbridge.cn` 改为 `open.longbridge.com`
- 影响：发版时上传到 OSS 的 `longbridge.json` 内 `architecture.64bit.url` 指向 `.com` 域
- 不影响仓库内 `.scoop/longbridge.json`（仍指向 GitHub Releases）

---
## 风险分析
| 风险点 | 等级 | 缓解措施 |
|--------|------|---------|
| 国内访问 .com 域速度/可用性 | 🟡 | 确认 open.longbridge.com 在国内有可用回源/加速；若不可用需保留 .cn 镜像 |
| CDN 路径 rewrite 是否就绪 | 🟢 | 路径 `/github/release/longbridge-terminal/...` 已在 .cn 上验证过；.com 需确认相同 rewrite 规则已配 |

---
## 代码关注点
1. **[需判断]** CDN 域名单一化的回退策略 (`.github/workflows/update-scoop.yml:79`)
   切到单一 `.com` 域后，国内用户走的是同一入口；如果之前 `.cn` 是为国内加速保留的，请确认这次切换是有意收敛（而非误改）。

---
## 验证状态
📋 需验证：发版后 `https://open.longbridge.com/github/release/longbridge-terminal/v<version>/longbridge-terminal-windows-amd64.zip` 可正常下载；上传到 OSS 的 `longbridge.json` 内 url 字段已变为 `.com`
