### PR TITLE
cli: Add attached order (take-profit/stop-loss) support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[env]
+# clap generates stack-heavy parsing code for large subcommand structs;
+# raise the default 2MB test thread stack to avoid overflow.
+RUST_MIN_STACK = "8388608"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,7 +2620,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#3c995f576e245c5b3235a88f1aad5d4c2343a6c2"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fattached-orders#e996b05f0c162a4894e983844408428e9bd47c9d"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#3c995f576e245c5b3235a88f1aad5d4c2343a6c2"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fattached-orders#e996b05f0c162a4894e983844408428e9bd47c9d"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#3c995f576e245c5b3235a88f1aad5d4c2343a6c2"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fattached-orders#e996b05f0c162a4894e983844408428e9bd47c9d"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#3c995f576e245c5b3235a88f1aad5d4c2343a6c2"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fattached-orders#e996b05f0c162a4894e983844408428e9bd47c9d"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#3c995f576e245c5b3235a88f1aad5d4c2343a6c2"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fattached-orders#e996b05f0c162a4894e983844408428e9bd47c9d"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#3c995f576e245c5b3235a88f1aad5d4c2343a6c2"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fattached-orders#e996b05f0c162a4894e983844408428e9bd47c9d"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2794,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#3c995f576e245c5b3235a88f1aad5d4c2343a6c2"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fattached-orders#e996b05f0c162a4894e983844408428e9bd47c9d"
 dependencies = [
  "byteorder",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 dashmap = "6.1"
 dirs = "5.0"
 csv = "1"
-longbridge = { git = "https://github.com/longbridge/openapi.git", branch = "main" }
+longbridge = { git = "https://github.com/longbridge/openapi.git", branch = "feat/attached-orders" }
 futures = "0.3.28"
 open = "5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "brotli"] }

--- a/README.md
+++ b/README.md
@@ -292,9 +292,11 @@ longbridge sharelist popular [--count 10]                         # Get popular 
 ```bash
 longbridge order                                           # Today's orders, or historical with --history
 longbridge order --history [--start 2024-01-01]            # Historical orders (use --symbol to filter)
-longbridge order detail <order_id>                         # Full detail for a single order including charges and history
+longbridge order detail <order_id>                         # Full detail for a single order including charges, history, and attached orders
+longbridge order detail <attached-order-id> --is-attached  # Query attached sub-order's own detail (charge_detail is null for attached orders)
 longbridge order executions                                # Today's trade executions (fills), or historical with --history
 longbridge order buy TSLA.US 100 --price 250.00            # Submit a buy order (prompts for confirmation)
+longbridge order buy TSLA.US 100 --price 250 --attached-type bracket --attached-profit-taker-price 270 --attached-stop-loss-price 240  # Buy with bracket (take-profit + stop-loss)
 longbridge order sell TSLA.US 100 --price 260.00           # Submit a sell order (prompts for confirmation)
 longbridge order cancel <order_id>                         # Cancel a pending order (prompts for confirmation)
 longbridge order replace <order_id> --qty 200 --price 255.00 # Modify quantity or price of a pending order

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -84,7 +84,6 @@ pub struct Cli {
 }
 
 #[derive(Subcommand)]
-#[allow(clippy::large_enum_variant)]
 pub enum Commands {
     /// Authenticate or clear credentials
     ///
@@ -688,7 +687,7 @@ pub enum Commands {
         #[arg(long)]
         symbol: Option<String>,
         #[command(subcommand)]
-        cmd: Option<OrderCmd>,
+        cmd: Option<Box<OrderCmd>>,
     },
 
     /// Account asset overview — net assets, cash, buy power, margins, and per-currency breakdown
@@ -3396,7 +3395,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             end,
             symbol,
             cmd,
-        } => match cmd {
+        } => match cmd.map(|c| *c) {
             Some(OrderCmd::Detail { order_id, is_attached }) => {
                 trade::cmd_order_detail(order_id, is_attached, format).await
             }
@@ -4415,27 +4414,25 @@ mod tests {
     #[test]
     fn test_order_detail_subcommand() {
         let cli = parse(&["longbridge", "order", "detail", "order-123"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Some(Commands::Order {
-                cmd: Some(OrderCmd::Detail { order_id, .. }),
-                ..
-            }) if order_id == "order-123"
-        ));
+        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
+            panic!("expected Order command");
+        };
+        let OrderCmd::Detail { order_id, .. } = *cmd else {
+            panic!("expected Detail subcommand");
+        };
+        assert_eq!(order_id, "order-123");
     }
 
     #[test]
     fn test_order_executions_subcommand() {
         let cli = parse(&["longbridge", "order", "executions"]).unwrap();
-        if let Some(Commands::Order {
-            cmd: Some(OrderCmd::Executions { history, .. }),
-            ..
-        }) = cli.command
-        {
-            assert!(!history);
-        } else {
-            panic!("expected Order Executions command");
-        }
+        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
+            panic!("expected Order command");
+        };
+        let OrderCmd::Executions { history, .. } = *cmd else {
+            panic!("expected Executions subcommand");
+        };
+        assert!(!history);
     }
 
     #[test]
@@ -4450,27 +4447,25 @@ mod tests {
             "250.00",
         ])
         .unwrap();
-        if let Some(Commands::Order {
-            cmd:
-                Some(OrderCmd::Buy {
-                    symbol,
-                    quantity,
-                    price,
-                    order_type,
-                    tif,
-                    ..
-                }),
+        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
+            panic!("expected Order command");
+        };
+        let OrderCmd::Buy {
+            symbol,
+            quantity,
+            price,
+            order_type,
+            tif,
             ..
-        }) = cli.command
-        {
-            assert_eq!(symbol, "TSLA.US");
-            assert_eq!(quantity, 100);
-            assert_eq!(price, Some("250.00".to_string()));
-            assert_eq!(order_type, "LO");
-            assert_eq!(tif, "day");
-        } else {
-            panic!("expected Order Buy command");
-        }
+        } = *cmd
+        else {
+            panic!("expected Buy subcommand");
+        };
+        assert_eq!(symbol, "TSLA.US");
+        assert_eq!(quantity, 100);
+        assert_eq!(price, Some("250.00".to_string()));
+        assert_eq!(order_type, "LO");
+        assert_eq!(tif, "day");
     }
 
     #[test]
@@ -4485,35 +4480,33 @@ mod tests {
             "260.00",
         ])
         .unwrap();
-        if let Some(Commands::Order {
-            cmd:
-                Some(OrderCmd::Sell {
-                    symbol,
-                    quantity,
-                    price,
-                    ..
-                }),
+        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
+            panic!("expected Order command");
+        };
+        let OrderCmd::Sell {
+            symbol,
+            quantity,
+            price,
             ..
-        }) = cli.command
-        {
-            assert_eq!(symbol, "TSLA.US");
-            assert_eq!(quantity, 50);
-            assert_eq!(price, Some("260.00".to_string()));
-        } else {
-            panic!("expected Order Sell command");
-        }
+        } = *cmd
+        else {
+            panic!("expected Sell subcommand");
+        };
+        assert_eq!(symbol, "TSLA.US");
+        assert_eq!(quantity, 50);
+        assert_eq!(price, Some("260.00".to_string()));
     }
 
     #[test]
     fn test_order_cancel_subcommand() {
         let cli = parse(&["longbridge", "order", "cancel", "order-456"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Some(Commands::Order {
-                cmd: Some(OrderCmd::Cancel { order_id, .. }),
-                ..
-            }) if order_id == "order-456"
-        ));
+        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
+            panic!("expected Order command");
+        };
+        let OrderCmd::Cancel { order_id, .. } = *cmd else {
+            panic!("expected Cancel subcommand");
+        };
+        assert_eq!(order_id, "order-456");
     }
 
     #[test]
@@ -4529,23 +4522,21 @@ mod tests {
             "255.00",
         ])
         .unwrap();
-        if let Some(Commands::Order {
-            cmd:
-                Some(OrderCmd::Replace {
-                    order_id,
-                    qty,
-                    price,
-                    ..
-                }),
+        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
+            panic!("expected Order command");
+        };
+        let OrderCmd::Replace {
+            order_id,
+            qty,
+            price,
             ..
-        }) = cli.command
-        {
-            assert_eq!(order_id, "order-789");
-            assert_eq!(qty, Some(200));
-            assert_eq!(price, Some("255.00".to_string()));
-        } else {
-            panic!("expected Order Replace command");
-        }
+        } = *cmd
+        else {
+            panic!("expected Replace subcommand");
+        };
+        assert_eq!(order_id, "order-789");
+        assert_eq!(qty, Some(200));
+        assert_eq!(price, Some("255.00".to_string()));
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -84,6 +84,7 @@ pub struct Cli {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum Commands {
     /// Authenticate or clear credentials
     ///
@@ -687,7 +688,7 @@ pub enum Commands {
         #[arg(long)]
         symbol: Option<String>,
         #[command(subcommand)]
-        cmd: Option<Box<OrderCmd>>,
+        cmd: Option<OrderCmd>,
     },
 
     /// Account asset overview — net assets, cash, buy power, margins, and per-currency breakdown
@@ -3395,7 +3396,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             end,
             symbol,
             cmd,
-        } => match cmd.map(|c| *c) {
+        } => match cmd {
             Some(OrderCmd::Detail { order_id, is_attached }) => {
                 trade::cmd_order_detail(order_id, is_attached, format).await
             }
@@ -4414,25 +4415,27 @@ mod tests {
     #[test]
     fn test_order_detail_subcommand() {
         let cli = parse(&["longbridge", "order", "detail", "order-123"]).unwrap();
-        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
-            panic!("expected Order command");
-        };
-        let OrderCmd::Detail { order_id, .. } = *cmd else {
-            panic!("expected Detail subcommand");
-        };
-        assert_eq!(order_id, "order-123");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Order {
+                cmd: Some(OrderCmd::Detail { ref order_id, .. }),
+                ..
+            }) if order_id == "order-123"
+        ));
     }
 
     #[test]
     fn test_order_executions_subcommand() {
         let cli = parse(&["longbridge", "order", "executions"]).unwrap();
-        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
-            panic!("expected Order command");
-        };
-        let OrderCmd::Executions { history, .. } = *cmd else {
-            panic!("expected Executions subcommand");
-        };
-        assert!(!history);
+        if let Some(Commands::Order {
+            cmd: Some(OrderCmd::Executions { history, .. }),
+            ..
+        }) = cli.command
+        {
+            assert!(!history);
+        } else {
+            panic!("expected Order Executions command");
+        }
     }
 
     #[test]
@@ -4447,25 +4450,27 @@ mod tests {
             "250.00",
         ])
         .unwrap();
-        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
-            panic!("expected Order command");
-        };
-        let OrderCmd::Buy {
-            symbol,
-            quantity,
-            price,
-            order_type,
-            tif,
+        if let Some(Commands::Order {
+            cmd:
+                Some(OrderCmd::Buy {
+                    ref symbol,
+                    quantity,
+                    ref price,
+                    ref order_type,
+                    ref tif,
+                    ..
+                }),
             ..
-        } = *cmd
-        else {
-            panic!("expected Buy subcommand");
-        };
-        assert_eq!(symbol, "TSLA.US");
-        assert_eq!(quantity, 100);
-        assert_eq!(price, Some("250.00".to_string()));
-        assert_eq!(order_type, "LO");
-        assert_eq!(tif, "day");
+        }) = cli.command
+        {
+            assert_eq!(symbol, "TSLA.US");
+            assert_eq!(quantity, 100);
+            assert_eq!(price, &Some("250.00".to_string()));
+            assert_eq!(order_type, "LO");
+            assert_eq!(tif, "day");
+        } else {
+            panic!("expected Order Buy command");
+        }
     }
 
     #[test]
@@ -4480,33 +4485,35 @@ mod tests {
             "260.00",
         ])
         .unwrap();
-        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
-            panic!("expected Order command");
-        };
-        let OrderCmd::Sell {
-            symbol,
-            quantity,
-            price,
+        if let Some(Commands::Order {
+            cmd:
+                Some(OrderCmd::Sell {
+                    ref symbol,
+                    quantity,
+                    ref price,
+                    ..
+                }),
             ..
-        } = *cmd
-        else {
-            panic!("expected Sell subcommand");
-        };
-        assert_eq!(symbol, "TSLA.US");
-        assert_eq!(quantity, 50);
-        assert_eq!(price, Some("260.00".to_string()));
+        }) = cli.command
+        {
+            assert_eq!(symbol, "TSLA.US");
+            assert_eq!(quantity, 50);
+            assert_eq!(price, &Some("260.00".to_string()));
+        } else {
+            panic!("expected Order Sell command");
+        }
     }
 
     #[test]
     fn test_order_cancel_subcommand() {
         let cli = parse(&["longbridge", "order", "cancel", "order-456"]).unwrap();
-        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
-            panic!("expected Order command");
-        };
-        let OrderCmd::Cancel { order_id, .. } = *cmd else {
-            panic!("expected Cancel subcommand");
-        };
-        assert_eq!(order_id, "order-456");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Order {
+                cmd: Some(OrderCmd::Cancel { ref order_id, .. }),
+                ..
+            }) if order_id == "order-456"
+        ));
     }
 
     #[test]
@@ -4522,21 +4529,23 @@ mod tests {
             "255.00",
         ])
         .unwrap();
-        let Some(Commands::Order { cmd: Some(cmd), .. }) = cli.command else {
-            panic!("expected Order command");
-        };
-        let OrderCmd::Replace {
-            order_id,
-            qty,
-            price,
+        if let Some(Commands::Order {
+            cmd:
+                Some(OrderCmd::Replace {
+                    ref order_id,
+                    qty,
+                    ref price,
+                    ..
+                }),
             ..
-        } = *cmd
-        else {
-            panic!("expected Replace subcommand");
-        };
-        assert_eq!(order_id, "order-789");
-        assert_eq!(qty, Some(200));
-        assert_eq!(price, Some("255.00".to_string()));
+        }) = cli.command
+        {
+            assert_eq!(order_id, "order-789");
+            assert_eq!(qty, Some(200));
+            assert_eq!(price, &Some("255.00".to_string()));
+        } else {
+            panic!("expected Order Replace command");
+        }
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -84,6 +84,7 @@ pub struct Cli {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum Commands {
     /// Authenticate or clear credentials
     ///
@@ -2489,10 +2490,21 @@ pub enum OrderCmd {
     /// Full detail for a single order including charges and history
     ///
     /// Returns all fields from `order` plus `charge_detail`, `history_details`, msg.
+    ///
+    /// By default, `order_id` is treated as a main order ID.
+    /// Pass `--is-attached` when the ID is an attached sub-order ID (stop-loss/take-profit);
+    /// the server returns that sub-order's own detail. Note: `charge_detail` is always
+    /// null for attached orders.
+    /// Attached sub-order IDs are found in `order detail <parent-id>` under `attached_orders`.
     /// Example: longbridge order detail 20240101-123456789
+    /// Example: longbridge order detail <attached-order-id> --is-attached
     Detail {
-        /// Order ID (from `longbridge order` or returned by `order buy`/`order sell`)
+        /// Order ID to query
         order_id: String,
+        /// Treat `order_id` as an attached sub-order ID (stop-loss/take-profit order);
+        /// returns that sub-order's own detail. Note: `charge_detail` is null for attached orders.
+        #[arg(long)]
+        is_attached: bool,
     },
 
     /// Today's trade executions (fills), or historical with --history
@@ -2522,11 +2534,13 @@ pub enum OrderCmd {
     ///   (case-insensitive)
     /// Trailing orders (TSLPAMT/TSLPPCT) require --trailing-amount/--trailing-percent
     ///   and --limit-offset.
+    /// Attached orders: use --attached-type to attach a take-profit/stop-loss/bracket order.
     /// Example: longbridge order buy TSLA.US 100 --price 250.00
     /// Example: longbridge order buy 700.HK 1000 --price 300 --order-type ALO
     /// Example: longbridge order buy NVDA.US 10 --order-type MIT --trigger-price 177.89 --tif Day
     /// Example: longbridge order buy TSLA.US 10 --order-type TSLPPCT --trailing-percent 3 --limit-offset 1 --tif gtc
     /// Example: longbridge order buy AAPL.US 10 --price 180 --tif gtd --expire-date 2025-12-31
+    /// Example: longbridge order buy TSLA.US 100 --price 250 --attached-type bracket --attached-profit-taker-price 270 --attached-stop-loss-price 240
     Buy {
         /// Symbol in <CODE>.<MARKET> format
         symbol: String,
@@ -2556,6 +2570,30 @@ pub enum OrderCmd {
         /// Order remark (max 255 characters)
         #[arg(long)]
         remark: Option<String>,
+        /// Attached order type: profit-taker | stop-loss | bracket
+        #[arg(long)]
+        attached_type: Option<String>,
+        /// Attached order: take-profit trigger price
+        #[arg(long)]
+        attached_profit_taker_price: Option<String>,
+        /// Attached order: stop-loss trigger price
+        #[arg(long)]
+        attached_stop_loss_price: Option<String>,
+        /// Attached order: time in force: day | gtc | gtd
+        #[arg(long)]
+        attached_tif: Option<String>,
+        /// Attached order: take-profit limit price (when activated order type is LO)
+        #[arg(long)]
+        attached_profit_taker_submit_price: Option<String>,
+        /// Attached order: stop-loss limit price
+        #[arg(long)]
+        attached_stop_loss_submit_price: Option<String>,
+        /// Attached order: order type when triggered: LO | MO etc.
+        #[arg(long)]
+        attached_activate_order_type: Option<String>,
+        /// Attached order: RTH setting for activated order: `RTH_ONLY` | `ANY_TIME` | `OVERNIGHT`
+        #[arg(long)]
+        attached_activate_rth: Option<String>,
         /// Order type: LO ELO MO AO ALO ODD SLO LIT MIT TSLPAMT TSLPPCT
         ///   (case-insensitive, default: LO)
         #[arg(long, default_value = "LO")]
@@ -2590,6 +2628,7 @@ pub enum OrderCmd {
     /// Example: longbridge order sell NVDA.US 10 --order-type MIT --trigger-price 177.89 --tif Day
     /// Example: longbridge order sell TSLA.US 130 --order-type TSLPPCT --trailing-percent 3 --limit-offset 1 --tif gtc
     /// Example: longbridge order sell AAPL.US 10 --price 180 --tif gtd --expire-date 2025-12-31
+    /// Example: longbridge order sell TSLA.US 100 --price 260 --attached-type bracket --attached-profit-taker-price 280 --attached-stop-loss-price 250
     Sell {
         /// Symbol in <CODE>.<MARKET> format
         symbol: String,
@@ -2619,6 +2658,30 @@ pub enum OrderCmd {
         /// Order remark (max 255 characters)
         #[arg(long)]
         remark: Option<String>,
+        /// Attached order type: profit-taker | stop-loss | bracket
+        #[arg(long)]
+        attached_type: Option<String>,
+        /// Attached order: take-profit trigger price
+        #[arg(long)]
+        attached_profit_taker_price: Option<String>,
+        /// Attached order: stop-loss trigger price
+        #[arg(long)]
+        attached_stop_loss_price: Option<String>,
+        /// Attached order: time in force: day | gtc | gtd
+        #[arg(long)]
+        attached_tif: Option<String>,
+        /// Attached order: take-profit limit price (when activated order type is LO)
+        #[arg(long)]
+        attached_profit_taker_submit_price: Option<String>,
+        /// Attached order: stop-loss limit price
+        #[arg(long)]
+        attached_stop_loss_submit_price: Option<String>,
+        /// Attached order: order type when triggered: LO | MO etc.
+        #[arg(long)]
+        attached_activate_order_type: Option<String>,
+        /// Attached order: RTH setting for activated order: `RTH_ONLY` | `ANY_TIME` | `OVERNIGHT`
+        #[arg(long)]
+        attached_activate_rth: Option<String>,
         /// Order type: LO ELO MO AO ALO ODD SLO LIT MIT TSLPAMT TSLPPCT
         ///   (case-insensitive, default: LO)
         #[arg(long, default_value = "LO")]
@@ -3334,7 +3397,9 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             symbol,
             cmd,
         } => match cmd {
-            Some(OrderCmd::Detail { order_id }) => trade::cmd_order_detail(order_id, format).await,
+            Some(OrderCmd::Detail { order_id, is_attached }) => {
+                trade::cmd_order_detail(order_id, is_attached, format).await
+            }
             Some(OrderCmd::Executions {
                 history: h,
                 start: s,
@@ -3352,6 +3417,14 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                 expire_date,
                 outside_rth,
                 remark,
+                attached_type,
+                attached_profit_taker_price,
+                attached_stop_loss_price,
+                attached_tif,
+                attached_profit_taker_submit_price,
+                attached_stop_loss_submit_price,
+                attached_activate_order_type,
+                attached_activate_rth,
                 order_type,
                 tif,
                 yes,
@@ -3367,6 +3440,14 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                     expire_date,
                     outside_rth,
                     remark,
+                    attached_type,
+                    attached_profit_taker_price,
+                    attached_stop_loss_price,
+                    attached_tif,
+                    attached_profit_taker_submit_price,
+                    attached_stop_loss_submit_price,
+                    attached_activate_order_type,
+                    attached_activate_rth,
                     order_type,
                     tif,
                     longbridge::trade::OrderSide::Buy,
@@ -3386,6 +3467,14 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                 expire_date,
                 outside_rth,
                 remark,
+                attached_type,
+                attached_profit_taker_price,
+                attached_stop_loss_price,
+                attached_tif,
+                attached_profit_taker_submit_price,
+                attached_stop_loss_submit_price,
+                attached_activate_order_type,
+                attached_activate_rth,
                 order_type,
                 tif,
                 yes,
@@ -3401,6 +3490,14 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                     expire_date,
                     outside_rth,
                     remark,
+                    attached_type,
+                    attached_profit_taker_price,
+                    attached_stop_loss_price,
+                    attached_tif,
+                    attached_profit_taker_submit_price,
+                    attached_stop_loss_submit_price,
+                    attached_activate_order_type,
+                    attached_activate_rth,
                     order_type,
                     tif,
                     longbridge::trade::OrderSide::Sell,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4418,7 +4418,7 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Commands::Order {
-                cmd: Some(OrderCmd::Detail { order_id }),
+                cmd: Some(OrderCmd::Detail { order_id, .. }),
                 ..
             }) if order_id == "order-123"
         ));

--- a/src/cli/trade.rs
+++ b/src/cli/trade.rs
@@ -2,7 +2,8 @@ use anyhow::{bail, Result};
 use longbridge::trade::{
     EstimateMaxPurchaseQuantityOptions, GetCashFlowOptions, GetHistoryExecutionsOptions,
     GetHistoryOrdersOptions, GetTodayExecutionsOptions, GetTodayOrdersOptions, OrderSide,
-    OrderType, OutsideRTH, ReplaceOrderOptions, SubmitOrderOptions, TimeInForceType,
+    OrderType, OutsideRTH, ReplaceOrderOptions, SubmitAttachedParams, SubmitOrderOptions,
+    TimeInForceType,
 };
 use rust_decimal::Decimal;
 use std::fmt::Write as _;
@@ -43,6 +44,16 @@ fn parse_order_type(s: &str) -> Result<OrderType> {
         _ => {
             bail!("Unknown order type '{s}'. Use: LO MO ELO AO ALO ODD SLO LIT MIT TSLPAMT TSLPPCT")
         }
+    }
+}
+
+fn parse_attached_type(s: &str) -> Result<longbridge::trade::AttachedOrderType> {
+    use longbridge::trade::AttachedOrderType;
+    match s.to_lowercase().replace('-', "_").as_str() {
+        "profit_taker" => Ok(AttachedOrderType::ProfitTaker),
+        "stop_loss" => Ok(AttachedOrderType::StopLoss),
+        "bracket" => Ok(AttachedOrderType::Bracket),
+        _ => bail!("Invalid attached-type '{s}'. Use: profit-taker | stop-loss | bracket"),
     }
 }
 
@@ -120,9 +131,20 @@ pub async fn cmd_orders(
     Ok(())
 }
 
-pub async fn cmd_order_detail(order_id: String, format: &OutputFormat) -> Result<()> {
+pub async fn cmd_order_detail(
+    order_id: String,
+    is_attached: bool,
+    format: &OutputFormat,
+) -> Result<()> {
+    use longbridge::trade::GetOrderDetailOptions;
     let ctx = crate::openapi::trade();
-    let detail = ctx.order_detail(order_id).await?;
+    let opts = GetOrderDetailOptions::new(order_id);
+    let opts = if is_attached {
+        opts.is_attached()
+    } else {
+        opts
+    };
+    let detail = ctx.order_detail(opts).await?;
 
     let executed_amount = detail.executed_price.map(|p| p * detail.executed_quantity);
     let outside_rth = detail
@@ -141,6 +163,24 @@ pub async fn cmd_order_detail(order_id: String, format: &OutputFormat) -> Result
                         "price": h.price.to_string(),
                         "quantity": h.quantity.to_string(),
                         "msg": h.msg,
+                    })
+                })
+                .collect();
+            let attached_orders: Vec<serde_json::Value> = detail
+                .attached_orders
+                .iter()
+                .map(|a| {
+                    serde_json::json!({
+                        "order_id": a.order_id,
+                        "type": format!("{:?}", a.attached_type_display),
+                        "status": format!("{:?}", a.status),
+                        "trigger_price": a.trigger_price.map(|v| v.to_string()),
+                        "submit_price": a.submit_price.map(|v| v.to_string()),
+                        "executed_price": a.executed_price.map(|v| v.to_string()),
+                        "quantity": a.quantity.to_string(),
+                        "executed_qty": a.executed_qty.to_string(),
+                        "submitted_at": fmt_rfc3339(a.submitted_at),
+                        "updated_at": fmt_rfc3339(a.updated_at),
                     })
                 })
                 .collect();
@@ -163,6 +203,7 @@ pub async fn cmd_order_detail(order_id: String, format: &OutputFormat) -> Result
                 "updated_at": detail.updated_at.map(fmt_rfc3339).unwrap_or_default(),
                 "remark": detail.msg,
                 "history": history,
+                "attached_orders": attached_orders,
             });
             println!("{}", serde_json::to_string_pretty(&val)?);
         }
@@ -222,6 +263,36 @@ pub async fn cmd_order_detail(order_id: String, format: &OutputFormat) -> Result
                     })
                     .collect();
                 print_table(hist_headers, hist_rows, &OutputFormat::Pretty);
+            }
+
+            if !detail.attached_orders.is_empty() {
+                println!();
+                println!("Attached Orders");
+                let att_headers = &[
+                    "Order ID",
+                    "Type",
+                    "Status",
+                    "Trigger Price",
+                    "Submit Price",
+                    "Qty",
+                ];
+                let att_rows: Vec<Vec<String>> = detail
+                    .attached_orders
+                    .iter()
+                    .map(|a| {
+                        vec![
+                            a.order_id.clone(),
+                            format!("{:?}", a.attached_type_display),
+                            format!("{:?}", a.status),
+                            a.trigger_price
+                                .map_or_else(|| "-".to_string(), |v| v.to_string()),
+                            a.submit_price
+                                .map_or_else(|| "-".to_string(), |v| v.to_string()),
+                            a.quantity.to_string(),
+                        ]
+                    })
+                    .collect();
+                print_table(att_headers, att_rows, &OutputFormat::Pretty);
             }
         }
     }
@@ -323,6 +394,14 @@ pub async fn cmd_submit_order(
     expire_date: Option<String>,
     outside_rth: Option<String>,
     remark: Option<String>,
+    attached_type: Option<String>,
+    attached_profit_taker_price: Option<String>,
+    attached_stop_loss_price: Option<String>,
+    attached_tif: Option<String>,
+    attached_profit_taker_submit_price: Option<String>,
+    attached_stop_loss_submit_price: Option<String>,
+    attached_activate_order_type: Option<String>,
+    attached_activate_rth: Option<String>,
     order_type: String,
     tif: String,
     side: OrderSide,
@@ -374,6 +453,43 @@ pub async fn cmd_submit_order(
     if let Some(ref r) = remark {
         opts = opts.remark(r.clone());
     }
+    if let Some(ref at) = attached_type {
+        let mut ap = SubmitAttachedParams::new(parse_attached_type(at)?);
+        if let Some(ref v) = attached_profit_taker_price {
+            ap = ap.profit_taker_price(
+                Decimal::from_str(v)
+                    .map_err(|_| anyhow::anyhow!("Invalid attached-profit-taker-price: {v}"))?,
+            );
+        }
+        if let Some(ref v) = attached_stop_loss_price {
+            ap = ap.stop_loss_price(
+                Decimal::from_str(v)
+                    .map_err(|_| anyhow::anyhow!("Invalid attached-stop-loss-price: {v}"))?,
+            );
+        }
+        if let Some(ref v) = attached_tif {
+            ap = ap.time_in_force(parse_tif(v)?);
+        }
+        if let Some(ref v) = attached_profit_taker_submit_price {
+            ap =
+                ap.profit_taker_submit_price(Decimal::from_str(v).map_err(|_| {
+                    anyhow::anyhow!("Invalid attached-profit-taker-submit-price: {v}")
+                })?);
+        }
+        if let Some(ref v) = attached_stop_loss_submit_price {
+            ap = ap
+                .stop_loss_submit_price(Decimal::from_str(v).map_err(|_| {
+                    anyhow::anyhow!("Invalid attached-stop-loss-submit-price: {v}")
+                })?);
+        }
+        if let Some(ref v) = attached_activate_order_type {
+            ap = ap.activate_order_type(parse_order_type(v)?);
+        }
+        if let Some(ref v) = attached_activate_rth {
+            ap = ap.activate_rth(parse_outside_rth(v)?);
+        }
+        opts = opts.attached_params(ap);
+    }
 
     // Confirm before submitting
     let mut price_display = match (price.as_deref(), trigger_price.as_deref()) {
@@ -396,6 +512,16 @@ pub async fn cmd_submit_order(
     }
     if let Some(ref rth) = outside_rth {
         let _ = write!(price_display, " outside-rth: {rth}");
+    }
+    if let Some(ref at) = attached_type {
+        let _ = write!(price_display, " [attached:{at}");
+        if let Some(ref v) = attached_profit_taker_price {
+            let _ = write!(price_display, " tp:{v}");
+        }
+        if let Some(ref v) = attached_stop_loss_price {
+            let _ = write!(price_display, " sl:{v}");
+        }
+        let _ = write!(price_display, "]");
     }
     println!("Submitting {side:?} order: {quantity} {symbol} @ {price_display}");
     if !yes {


### PR DESCRIPTION
## Summary

- Bump SDK dependency to `feat/attached-orders` branch (PR [longbridge/openapi#549](https://github.com/longbridge/openapi/pull/549))
- `order buy` / `order sell`: add `--attached-type` (`profit-taker` | `stop-loss` | `bracket`) and related flags (`--attached-profit-taker-price`, `--attached-stop-loss-price`, `--attached-tif`, `--attached-profit-taker-submit-price`, `--attached-stop-loss-submit-price`, `--attached-activate-order-type`, `--attached-activate-rth`) to submit bracket/take-profit/stop-loss orders in one shot
- `order detail`: show `attached_orders` section in both JSON and Pretty output; add `--is-attached` flag to query an attached sub-order's own detail by its ID

## Usage

```bash
# Bracket order (take-profit + stop-loss attached)
longbridge order buy TSLA.US 100 --price 250 \
  --attached-type bracket \
  --attached-profit-taker-price 270 \
  --attached-stop-loss-price 240

# View main order (includes attached_orders list)
longbridge order detail <order-id>

# View attached sub-order's own detail
longbridge order detail <attached-order-id> --is-attached
```

## Notes

- `--is-attached` on `order detail` causes the server to look up the sub-order by its own ID; `charge_detail` is always `null` for attached orders
- Cargo.toml should be reverted to `branch = "main"` once openapi PR #549 is merged

## Test plan

- [ ] `cargo build` and `cargo clippy` pass
- [ ] `order buy` with `--attached-type bracket` submits correctly and returns `order_id`
- [ ] `order detail <parent-id>` shows `attached_orders` table
- [ ] `order detail <attached-id> --is-attached` returns sub-order detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)