### PR TITLE
chore: Propagate CDN URL to scoop autoupdate template

### DIFF
--- a/.github/workflows/update-scoop.yml
+++ b/.github/workflows/update-scoop.yml
@@ -75,8 +75,10 @@ jobs:
           SHA256: ${{ steps.checksum.outputs.windows_amd64_sha256 }}
           REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
           GITHUB_URL="https://github.com/${REPO}/releases/download/${TAG}/longbridge-terminal-windows-amd64.zip"
-          CDN_URL="https://open.longbridge.com/github/release/longbridge-terminal/v${VERSION}/longbridge-terminal-windows-amd64.zip"
+          CDN_URL="https://assets.lbkrs.com/github/release/longbridge-terminal/v${VERSION}/longbridge-terminal-windows-amd64.zip"
+          CDN_AUTOUPDATE_URL='https://assets.lbkrs.com/github/release/longbridge-terminal/v$version/longbridge-terminal-windows-amd64.zip'
 
           # Update .scoop/longbridge.json (GitHub URL, committed back to repo)
           jq \
@@ -87,12 +89,16 @@ jobs:
             .scoop/longbridge.json > .scoop/longbridge.json.tmp
           mv .scoop/longbridge.json.tmp .scoop/longbridge.json
 
-          # Generate longbridge.json for OSS (CDN URL)
+          # Generate longbridge.json for OSS (CDN URL for both current download and autoupdate template)
           jq \
-            --arg version "$VERSION" \
-            --arg url     "$CDN_URL" \
-            --arg hash    "$SHA256" \
-            '.version = $version | .architecture["64bit"].url = $url | .architecture["64bit"].hash = $hash' \
+            --arg version    "$VERSION" \
+            --arg url        "$CDN_URL" \
+            --arg hash       "$SHA256" \
+            --arg autourl    "$CDN_AUTOUPDATE_URL" \
+            '.version = $version
+             | .architecture["64bit"].url = $url
+             | .architecture["64bit"].hash = $hash
+             | .autoupdate.architecture["64bit"].url = $autourl' \
             .scoop/longbridge.json > longbridge.json
 
           echo "--- Updated manifest (.scoop/longbridge.json) ---"


### PR DESCRIPTION
## Merge Verdict
**[APPROVE]** — CI-only change: revert CDN domain and propagate CDN URL into the OSS manifest's autoupdate template.
> 1 file · +11 / -6 · `.github/workflows`

---
## Summary
- Revert `CDN_URL` host from `open.longbridge.com` back to `assets.lbkrs.com` (undoes #246).
- Add `CDN_AUTOUPDATE_URL` (single-quoted to keep literal `$version` placeholder) and write it into `.autoupdate.architecture["64bit"].url` of the OSS-uploaded `longbridge.json` so future `scoop checkver -u` regenerations stay on CDN.
- Add `set -euo pipefail` to the manifest update step so a `jq` failure aborts before the stale `longbridge.json` is uploaded to OSS.
- In-repo `.scoop/longbridge.json` is untouched and still points to GitHub Releases (dual-source strategy preserved).

---
## Risk Analysis
| Risk | Level | Mitigation |
|------|-------|-----------|
| `$version` placeholder accidentally expanded by shell | ✅ | Single quotes prevent shell expansion |
| `$version` accidentally interpolated by jq | ✅ | jq does not perform `$var` interpolation on assigned string values; only `\(...)` inside double-quoted filter literals does |
| CDN domain revert (`open.longbridge.com` → `assets.lbkrs.com`) is intentional | 🟡 | Confirm with the original switch author whether the `.com` rollout was rolled back deliberately |
| Existing CDN-installed users get a new `autoupdate.url` template | 🟢 | End-user `scoop update` only consumes `.architecture.url`; the template field is bucket-maintainer metadata |

---
## Design Decisions
- **Single-quoted `CDN_AUTOUPDATE_URL`**: cleanest way to keep `$version` as a literal scoop placeholder through both shell and jq.
- **Multi-line jq filter**: keeps four assignments readable; jq treats newlines as whitespace inside the filter.
- **Only the OSS manifest gets CDN autoupdate**: the in-repo manifest stays GitHub-pointing so a `scoop bucket add` against this repo still resolves to canonical release assets.

---
## Code Concerns
1. **[需判断]** Intentional revert of CDN host? (`.github/workflows/update-scoop.yml:80`)
   Commit #246 just switched to `open.longbridge.com`; this PR reverts to `assets.lbkrs.com`. Confirm the rollback is intended (e.g. `.com` rewrite not ready) and not a merge artifact.

---
## Verification Status
📋 To verify after next release: download `https://assets.lbkrs.com/github/release/longbridge-terminal/longbridge.json` and confirm `.autoupdate.architecture["64bit"].url` is literally `https://assets.lbkrs.com/github/release/longbridge-terminal/v$version/longbridge-terminal-windows-amd64.zip` (the `$version` token remains as a placeholder, not a concrete version).
