### PR TITLE
cli: add JSON Schema introspection

### DIFF
--- a/src/cli/asset.rs
+++ b/src/cli/asset.rs
@@ -520,3 +520,68 @@ pub async fn cmd_short_margin(format: &OutputFormat, verbose: bool) -> Result<()
     }
     Ok(())
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::object;
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "exchange-rate" => object("Exchange rates", &["exchanges"]),
+        "portfolio short-margin" => object("Short-selling margin details", &["short_list"]),
+        "profit-analysis" => object("Account profit analysis", profit_analysis_schema_fields()),
+        "profit-analysis detail" => object(
+            "Stock profit analysis detail",
+            &[
+                "symbol",
+                "currency",
+                "profit",
+                "flows",
+                "position",
+                "updated_at",
+            ],
+        ),
+        "profit-analysis by-market" => object(
+            "Profit analysis by market",
+            &[
+                "currency",
+                "start",
+                "end",
+                "start_date",
+                "end_date",
+                "profit",
+                "stock_items",
+                "has_more",
+                "updated_at",
+                "updated_date",
+            ],
+        ),
+        _ => return None,
+    };
+    Some(schema)
+}
+
+fn profit_analysis_schema_fields() -> &'static [&'static str] {
+    &[
+        "currency",
+        "start_date",
+        "start_time",
+        "end_date",
+        "end_time",
+        "initial_asset_value",
+        "ending_asset_value",
+        "current_total_asset",
+        "invest_amount",
+        "sum_profit",
+        "sum_profit_rate",
+        "total_simple_earning_yield",
+        "total_time_earning_yield",
+        "trade_stock_num",
+        "trade_update_date",
+        "trade_update_time",
+        "updated_at",
+        "updated_date",
+        "is_traded",
+        "profits",
+        "sublist",
+    ]
+}

--- a/src/cli/atm.rs
+++ b/src/cli/atm.rs
@@ -309,3 +309,35 @@ pub async fn cmd_deposits(
     }
     Ok(())
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{array, object};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "bank-cards" => array(
+            "Withdrawal bank cards",
+            &[
+                "id",
+                "bank",
+                "bank_en",
+                "account",
+                "account_type",
+                "currency",
+                "swift_code",
+                "region",
+                "region_name",
+                "country",
+                "address",
+                "name",
+                "name_en",
+                "status",
+                "remark",
+            ],
+        ),
+        "withdrawals" => object("Withdrawal history", &["list", "total"]),
+        "deposits" => object("Deposit history", &["items", "total"]),
+        _ => return None,
+    };
+    Some(schema)
+}

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -572,3 +572,19 @@ pub async fn cmd_auth_status(format: &OutputFormat, market: &str) -> Result<()> 
 
     Ok(())
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{object, text};
+
+    let schema = match path {
+        [cmd, sub] if cmd == "auth" && sub == "login" => text("OAuth login flow status messages"),
+        [cmd, sub] if cmd == "auth" && sub == "logout" => {
+            text("OAuth credential removal status message")
+        }
+        [cmd, sub] if cmd == "auth" && sub == "status" => {
+            object("Authentication status", &["token", "account"])
+        }
+        _ => return None,
+    };
+    Some(schema)
+}

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -167,3 +167,22 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
 
     Ok(())
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{field, ResponseSchema, RootKind};
+
+    (path == ["check"]).then(|| ResponseSchema {
+        summary: "Check token validity, and API connectivity".to_string(),
+        root: RootKind::Object,
+        fields: vec![
+            field("session", "object", "Token validity details"),
+            field("region", "object", "Cached and active region details"),
+            field(
+                "connectivity",
+                "object",
+                "Global/CN connectivity probe results",
+            ),
+            field("status", "string", "Compatibility status summary"),
+        ],
+    })
+}

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -7,3 +7,7 @@ pub fn cmd_completion(shell: Shell) {
     let mut cmd = Cli::command();
     generate(shell, &mut cmd, "longbridge", &mut std::io::stdout());
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    (path == ["completion"]).then(|| super::schema::text("Shell completion script"))
+}

--- a/src/cli/dca.rs
+++ b/src/cli/dca.rs
@@ -455,3 +455,72 @@ async fn cmd_set_reminder(hours: &DcaReminderHours) -> Result<()> {
     println!("Reminder hours updated to {h}h before trade.");
     Ok(())
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{array, object, text};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "dca" => array("Recurring investment plans", dca_plan_schema_fields()),
+        "dca create" | "dca update" | "dca pause" | "dca resume" | "dca stop"
+        | "dca set-reminder" => text("Recurring investment mutation status message"),
+        "dca history" => array(
+            "Recurring investment trade history",
+            &[
+                "created_at",
+                "counter_id",
+                "order_id",
+                "status",
+                "action",
+                "executed_qty",
+                "executed_price",
+                "executed_amount",
+                "rejected_reason",
+            ],
+        ),
+        "dca stats" => object(
+            "Recurring investment statistics",
+            &[
+                "total_amount",
+                "total_profit",
+                "active_count",
+                "suspended_count",
+                "finished_count",
+                "rest_days",
+                "nearest_plans",
+            ],
+        ),
+        "dca calc-date" => object("Next recurring investment trade date", &["trade_date"]),
+        "dca check" => array(
+            "Recurring investment support by symbol",
+            &["counter_id", "support_regular_saving"],
+        ),
+        _ => return None,
+    };
+    Some(schema)
+}
+
+fn dca_plan_schema_fields() -> &'static [&'static str] {
+    &[
+        "plan_id",
+        "counter_id",
+        "stock_name",
+        "market",
+        "status",
+        "per_invest_amount",
+        "invest_frequency",
+        "invest_day_of_week",
+        "invest_day_of_month",
+        "next_trd_date",
+        "issue_number",
+        "cum_amount",
+        "cum_profit",
+        "average_cost",
+        "allow_margin_finance",
+        "alter_hours",
+        "display_account",
+        "member_id",
+        "created_at",
+        "updated_at",
+    ]
+}

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -3264,6 +3264,162 @@ pub async fn cmd_financial_report_snapshot(
     Ok(())
 }
 
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::object;
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "financial-report" => object("Financial statement report", &["report", "list"]),
+        "financial-report snapshot" => object(
+            "Financial report snapshot",
+            &[
+                "ticker",
+                "name",
+                "market",
+                "currency",
+                "report",
+                "report_desc",
+                "fiscal_year",
+                "fiscal_period",
+                "fp_start",
+                "fp_end",
+                "fo_revenue",
+                "fo_ebit",
+                "fo_eps",
+                "fr_revenue",
+                "fr_profit",
+                "fr_operate_cash",
+                "fr_invest_cash",
+                "fr_finance_cash",
+                "fr_total_assets",
+                "fr_total_liability",
+                "fr_roe_ttm",
+                "fr_profit_margin",
+                "fr_profit_margin_ttm",
+                "fr_asset_turn_ttm",
+                "fr_leverage_ttm",
+                "fr_debt_assets_ratio",
+                "opt_reports",
+            ],
+        ),
+        "business-segments" => object(
+            "Business segment breakdown or history",
+            &[
+                "date",
+                "report",
+                "report_txt",
+                "currency",
+                "total",
+                "business",
+                "regionals",
+                "bus_ids",
+                "reg_ids",
+                "yoy",
+                "fp_start",
+                "fp_end",
+                "rpt_date",
+                "historical",
+            ],
+        ),
+        "industry-rank" => object("Industry ranking list", &["items"]),
+        "industry-peers" => object("Industry peer group tree", &["chain", "top"]),
+        "institution-rating" => object("Institution rating summary", &["analyst", "instratings"]),
+        "institution-rating detail" => object(
+            "Institution rating detail",
+            &["ccy_symbol", "evaluate", "target"],
+        ),
+        "dividend" | "dividend detail" => object("Dividend history and detail", &["list"]),
+        "forecast-eps" => object("EPS forecasts", &["items"]),
+        "consensus" => object(
+            "Financial consensus detail",
+            &[
+                "currency",
+                "current_index",
+                "current_period",
+                "list",
+                "opt_periods",
+            ],
+        ),
+        "finance-calendar report"
+        | "finance-calendar dividend"
+        | "finance-calendar split"
+        | "finance-calendar ipo"
+        | "finance-calendar macrodata"
+        | "finance-calendar closed" => object(
+            "Finance calendar events",
+            &["date", "list", "next_date", "result"],
+        ),
+        "valuation" => object(
+            "Valuation detail or history",
+            &[
+                "overview", "history", "layouts", "peers", "stocks", "metrics", "range",
+            ],
+        ),
+        "shareholder" => object(
+            "Shareholder list, top holders, or detail",
+            &["shareholder_list", "total", "info", "periods", "items"],
+        ),
+        "company" => object(
+            "Company overview",
+            &[
+                "ticker",
+                "name",
+                "company_name",
+                "market",
+                "region",
+                "sector",
+                "category",
+                "profile",
+                "website",
+                "employees",
+                "listing_date",
+                "issue_price",
+                "founded",
+                "address",
+                "office_address",
+                "Phone",
+                "email",
+                "fax",
+                "zip_code",
+                "year_end",
+                "chairman",
+                "manager",
+                "secretary",
+                "legal_repr",
+                "securities_rep",
+                "accounting_firm",
+                "audit_inst",
+                "legal_counsel",
+                "bus_license",
+                "ads_ratio",
+                "shares_offered",
+                "icon",
+            ],
+        ),
+        "executive" => object("Company executives", &["professional_list"]),
+        "industry-valuation" => object("Industry valuation comparison", &["list"]),
+        "industry-valuation dist" => object("Industry valuation distribution", &["pe", "pb", "ps"]),
+        "operating" => object("Operating reviews", &["list"]),
+        "corp-action" => object("Corporate actions", &["items"]),
+        "invest-relation" => object(
+            "Investment relations",
+            &["total", "invest_securities", "forward_url"],
+        ),
+        "financial-statement" => object(
+            "Financial statement",
+            &["currency", "empty_fields", "list", "report"],
+        ),
+        "valuation-rank" => object(
+            "Valuation rank",
+            &["pe", "pb", "ps", "dvd", "kline_type", "max_num"],
+        ),
+        "compare" => object("Multi-stock valuation comparison", &["list"]),
+        "fund-holder" => object("Funds and ETFs holding a symbol", &["lists"]),
+        _ => return None,
+    };
+    Some(schema)
+}
+
 fn fmt_fo_row(label: &str, m: &Value) -> Vec<String> {
     let actual = val_str(&m["value"]);
     let yoy = val_str(&m["yoy"]);

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -5,3 +5,7 @@ pub fn cmd_init(invite_code: &str) -> Result<()> {
     println!("Initialized successfully.");
     Ok(())
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    (path == ["init"]).then(|| super::schema::text("Invite-code initialization status message"))
+}

--- a/src/cli/insider_trades.rs
+++ b/src/cli/insider_trades.rs
@@ -374,3 +374,23 @@ pub async fn cmd_insider_trades(symbol: &str, count: usize, format: &OutputForma
 
     Ok(())
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    (path == ["insider-trades"]).then(|| {
+        super::schema::array(
+            "SEC Form 4 insider transactions",
+            &[
+                "code",
+                "date",
+                "filing_date",
+                "owner",
+                "title",
+                "type",
+                "shares",
+                "price",
+                "value",
+                "shares_after",
+            ],
+        )
+    })
+}

--- a/src/cli/investors.rs
+++ b/src/cli/investors.rs
@@ -1195,3 +1195,46 @@ fn format_large_usd(usd: u64) -> String {
         format!("${usd}")
     }
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{json_schema, object};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "investors" => json_schema(
+            "SEC 13F investor list or holdings",
+            &[
+                "rank",
+                "name",
+                "aum_usd",
+                "period",
+                "cik",
+                "investor",
+                "firm",
+                "filing_date",
+                "accession_number",
+                "total_value_usd",
+                "total_holdings",
+                "holdings",
+            ],
+        ),
+        "investors changes" => object(
+            "SEC 13F position changes",
+            &[
+                "investor",
+                "firm",
+                "cik",
+                "period",
+                "filing_date",
+                "prev_report_date",
+                "new",
+                "added",
+                "reduced",
+                "exited",
+                "changes",
+            ],
+        ),
+        _ => return None,
+    };
+    Some(schema)
+}

--- a/src/cli/ipo.rs
+++ b/src/cli/ipo.rs
@@ -1320,3 +1320,81 @@ pub async fn cmd_ipo_us_listed(
     }
     Ok(())
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{array, object};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "ipo subscriptions" | "ipo wait-listing" | "ipo listed" => {
+            object("IPO stock lists grouped by market", &["hk", "us"])
+        }
+        "ipo calendar" => array(
+            "IPO calendar rows",
+            &[
+                "symbol",
+                "name",
+                "ipo_date",
+                "mart_date",
+                "sub_date",
+                "sub_end_date",
+                "result_date",
+                "state",
+                "tags",
+            ],
+        ),
+        "ipo detail" => object(
+            "IPO detail",
+            &["profile", "timeline", "eligibility", "holdings"],
+        ),
+        "ipo orders" => object("IPO orders", &["orders", "history"]),
+        "ipo orders detail" => object("IPO order detail", ipo_order_detail_schema_fields()),
+        "ipo profit-loss" => object("IPO profit/loss summary", &["summary", "items"]),
+        "ipo us-subscriptions" | "ipo us-wait-listing" | "ipo us-listed" => array(
+            "US IPO stock list",
+            &[
+                "symbol",
+                "name",
+                "market",
+                "issue_price",
+                "ipo_date",
+                "last_done",
+                "prev_close",
+                "sub_state",
+                "listed_day",
+                "win_qty",
+                "amount",
+                "description",
+                "icon",
+                "ipo_change",
+            ],
+        ),
+        _ => return None,
+    };
+    Some(schema)
+}
+
+fn ipo_order_detail_schema_fields() -> &'static [&'static str] {
+    &[
+        "id",
+        "batch_id",
+        "counter_id",
+        "code",
+        "name",
+        "market",
+        "currency",
+        "status",
+        "ipo_status",
+        "sub_qty",
+        "sub_amount",
+        "total_amount",
+        "current_amount",
+        "refund_amount",
+        "ipo_price",
+        "ipo_date",
+        "timeline",
+        "cards",
+        "doc",
+        "explanation",
+    ]
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,6 +19,7 @@ pub mod output;
 pub mod quant_render;
 pub mod quote;
 pub mod run_script;
+pub mod schema;
 pub mod screener;
 pub mod search;
 pub mod sec_edgar;
@@ -81,6 +82,10 @@ pub struct Cli {
     /// Defaults to system LANG env var, then en.
     #[arg(long, global = true)]
     pub lang: Option<String>,
+
+    /// Show response fields for this command and exit
+    #[arg(long, global = true)]
+    pub schema: bool,
 }
 
 #[derive(Subcommand)]

--- a/src/cli/news.rs
+++ b/src/cli/news.rs
@@ -353,6 +353,45 @@ pub async fn cmd_news_detail(id: String) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{array, text};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "news" => array(
+            "Latest news articles",
+            &[
+                "id",
+                "title",
+                "url",
+                "published_at",
+                "likes_count",
+                "comments_count",
+            ],
+        ),
+        "news detail" => text("Full news article Markdown content"),
+        "news search" => array(
+            "News search results",
+            &["id", "title", "url", "source_name", "time", "excerpt"],
+        ),
+        "filing" => array(
+            "Regulatory filing list",
+            &[
+                "id",
+                "title",
+                "description",
+                "file_name",
+                "file_count",
+                "file_urls",
+                "publish_at",
+            ],
+        ),
+        "filing detail" => text("Full regulatory filing Markdown content or file list"),
+        _ => return None,
+    };
+    Some(schema)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -3543,6 +3543,243 @@ fn render_etf_asset_allocation(
     }
 }
 
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{array, field, json_schema, object, schema, RootKind};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "quote" => schema(
+            "Real-time quotes for one or more symbols",
+            RootKind::Array,
+            vec![
+                field("symbol", "string", "Symbol in <CODE>.<MARKET> format"),
+                field("last", "string", "Last traded price"),
+                field("change_value", "string", "Price change value"),
+                field(
+                    "change_percentage",
+                    "string | null",
+                    "Price change percentage",
+                ),
+                field("prev_close", "string", "Previous close price"),
+                field("open", "string", "Open price"),
+                field("high", "string", "High price"),
+                field("low", "string", "Low price"),
+                field("volume", "number | string", "Traded volume"),
+                field("turnover", "string", "Traded turnover"),
+                field("status", "string", "Trading status"),
+                field(
+                    "post_market",
+                    "object",
+                    "US post-market quote when available",
+                ),
+                field("overnight", "object", "US overnight quote when available"),
+                field("pre_market", "object", "US pre-market quote when available"),
+            ],
+        ),
+        "depth" => schema(
+            "Level 2 order book depth (bid/ask ladder)",
+            RootKind::Object,
+            vec![
+                field("symbol", "string", "Symbol in <CODE>.<MARKET> format"),
+                field(
+                    "asks",
+                    "object[]",
+                    "Ask price levels with position, price, volume, and order_num",
+                ),
+                field(
+                    "bids",
+                    "object[]",
+                    "Bid price levels with position, price, volume, and order_num",
+                ),
+            ],
+        ),
+        "brokers" => object(
+            "Broker queue at each price level",
+            &["symbol", "asks", "bids"],
+        ),
+        "trades" => array(
+            "Recent tick-by-tick trades",
+            &["time", "price", "volume", "direction", "type"],
+        ),
+        "intraday" => array(
+            "Intraday minute-by-minute lines",
+            &["time", "price", "volume", "turnover", "avg_price"],
+        ),
+        "kline" | "kline history" => schema(
+            "Historical OHLCV candlestick data within a date range",
+            RootKind::Array,
+            vec![
+                field("time", "string", "Candle timestamp"),
+                field("open", "string", "Open price"),
+                field("high", "string", "High price"),
+                field("low", "string", "Low price"),
+                field("close", "string", "Close price"),
+                field("volume", "number | string", "Traded volume"),
+                field("turnover", "string", "Traded turnover"),
+                field(
+                    "timestamp",
+                    "string",
+                    "Alias used by schema consumers for candle time",
+                ),
+            ],
+        ),
+        "static" => array(
+            "Static reference info for securities",
+            &[
+                "symbol",
+                "name",
+                "exchange",
+                "currency",
+                "lot_size",
+                "total_shares",
+                "circ._shares",
+                "eps",
+                "eps_ttm",
+                "bps",
+                "dividend",
+            ],
+        ),
+        "calc-index" => array(
+            "Calculated financial indexes",
+            &["symbol", "pe", "pb", "dps_rate", "turnover_rate", "mktcap"],
+        ),
+        "capital" => json_schema(
+            "Intraday capital distribution snapshot or flow records",
+            &[
+                "symbol",
+                "timestamp",
+                "capital_in",
+                "capital_out",
+                "time",
+                "inflow",
+            ],
+        ),
+        "market-temp" => array(
+            "Market sentiment temperature snapshot or history",
+            &[
+                "field",
+                "value",
+                "time",
+                "temperature",
+                "description",
+                "sentiment",
+                "valuation",
+            ],
+        ),
+        "trading session" => array("Trading session schedule", &["market", "sessions"]),
+        "trading days" => object(
+            "Trading and half-trading days",
+            &["trading_days", "half_trading_days"],
+        ),
+        "security-list" => array(
+            "Overnight-eligible securities",
+            &["symbol", "name_en", "name_cn"],
+        ),
+        "participants" => array("Market participants", &["broker_id", "name_en", "name_cn"]),
+        "subscriptions" => array(
+            "Active real-time subscriptions",
+            &["symbol", "sub_types", "candlestick_periods"],
+        ),
+        "option chain" => array(
+            "Option expiry dates or strike rows",
+            &[
+                "expiry_date",
+                "strike",
+                "call_symbol",
+                "put_symbol",
+                "standard",
+            ],
+        ),
+        "option quote" => array("Real-time option quotes", option_quote_schema_fields()),
+        "option volume" => object(
+            "Real-time option call/put volume",
+            &["c", "p", "call_vol", "put_vol", "pc_ratio"],
+        ),
+        "option volume daily" => object("Daily option volume history", &["stats"]),
+        "warrant" => array(
+            "Warrant list for an underlying",
+            &["symbol", "name", "last", "leverage_ratio", "expiry", "type"],
+        ),
+        "warrant quote" => array("Real-time warrant quotes", warrant_quote_schema_fields()),
+        "warrant issuers" => array("Warrant issuer list", &["id", "name_en", "name_cn"]),
+        "constituent" => object(
+            "Index constituents or ETF holdings",
+            &[
+                "stocks",
+                "total",
+                "rise_num",
+                "fall_num",
+                "flat_num",
+                "symbol",
+                "series_name",
+                "report_period",
+                "filed_date",
+                "total_holdings",
+                "holdings",
+            ],
+        ),
+        "market-status" => array("Market open/close status", &["market", "status"]),
+        "broker-holding" => object(
+            "Broker holding top buy/sell",
+            &["buy", "sell", "updated_at"],
+        ),
+        "broker-holding detail" => object("Broker holding detail list", &["list", "updated_at"]),
+        "broker-holding daily" => object("Broker holding daily history", &["list"]),
+        "ah-premium" | "ah-premium intraday" => {
+            object("A/H premium kline or intraday data", &["klines"])
+        }
+        "trade-stats" => object("Trade statistics", &["statistics", "trades"]),
+        "anomaly" => object("Quote anomalies", &["changes", "all_off"]),
+        "top-movers" => object(
+            "Top movers with correlated news",
+            &["events", "next_params", "updated_at"],
+        ),
+        "rank" => json_schema(
+            "Popularity ranking tabs or ranking rows",
+            &["key", "name", "market", "bmp", "lists", "updated_at"],
+        ),
+        "short-positions" => object(
+            "Short selling open interest",
+            &["symbol", "data", "sources", "update_timestamp"],
+        ),
+        "short-trades" => object("Daily short-sale volume", &["symbol", "data", "sources"]),
+        _ => return None,
+    };
+    Some(schema)
+}
+
+fn option_quote_schema_fields() -> &'static [&'static str] {
+    &[
+        "symbol",
+        "last",
+        "strike",
+        "expiry",
+        "type",
+        "volume",
+        "open_interest",
+        "implied_volatility",
+        "delta",
+        "gamma",
+        "theta",
+        "vega",
+        "rho",
+        "underlying_symbol",
+    ]
+}
+
+fn warrant_quote_schema_fields() -> &'static [&'static str] {
+    &[
+        "symbol",
+        "name",
+        "last",
+        "prev_close",
+        "implied_volatility",
+        "leverage_ratio",
+        "expiry",
+        "type",
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cli/run_script.rs
+++ b/src/cli/run_script.rs
@@ -94,3 +94,14 @@ pub async fn cmd_run_script(
     }
     Ok(())
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    (path == ["quant", "run"]).then(|| {
+        super::schema::object(
+            "Quant script execution result",
+            &[
+                "symbol", "period", "bars", "plots", "series", "errors", "runtime",
+            ],
+        )
+    })
+}

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -1,0 +1,520 @@
+use anyhow::Result;
+use clap::{Command, CommandFactory};
+use serde_json::{json, Map, Value};
+use std::ffi::OsString;
+
+use super::{
+    asset, atm, auth, check, completion, dca, fundamental, init, insider_trades, investors, ipo,
+    news, quote, run_script, screener, sharelist, statement, topic, trade, watchlist, Cli,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RootKind {
+    Object,
+    Array,
+    Json,
+    Text,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResponseSchema {
+    pub(crate) summary: String,
+    pub(crate) root: RootKind,
+    pub(crate) fields: Vec<Field>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Field {
+    pub(crate) name: String,
+    pub(crate) ty: String,
+    pub(crate) description: String,
+}
+
+pub enum SchemaOutcome {
+    NotRequested,
+    Handled,
+    Error,
+}
+
+pub fn handle_schema_args(args: impl IntoIterator<Item = OsString>) -> Result<SchemaOutcome> {
+    let args = args.into_iter().collect::<Vec<_>>();
+    if !args.iter().any(|arg| arg == "--schema") {
+        return Ok(SchemaOutcome::NotRequested);
+    }
+
+    let mut root = Cli::command();
+    root.build();
+    let (selected, path) = selected_command_and_path_for_args(&root, args.iter().skip(1));
+
+    if path.is_empty() {
+        print_no_schema_error(&path);
+        return Ok(SchemaOutcome::Error);
+    }
+
+    if let Some(schema) = schema_for_path(&path) {
+        print_response_schema(&schema);
+        Ok(SchemaOutcome::Handled)
+    } else if selected.has_subcommands() {
+        let mut help_cmd = selected.clone();
+        help_cmd.print_help()?;
+        println!();
+        Ok(SchemaOutcome::Handled)
+    } else {
+        print_no_schema_error(&path);
+        Ok(SchemaOutcome::Error)
+    }
+}
+
+fn selected_command_and_path_for_args<'a, I>(
+    root: &'a Command,
+    args: I,
+) -> (&'a Command, Vec<String>)
+where
+    I: IntoIterator<Item = &'a OsString>,
+{
+    let mut current = root;
+    let mut path = Vec::new();
+    let mut skip_next_value = false;
+
+    for arg in args {
+        if arg == "--schema" {
+            break;
+        }
+        if skip_next_value {
+            skip_next_value = false;
+            continue;
+        }
+
+        if let Some(raw) = arg.to_str() {
+            if raw == "--" {
+                break;
+            }
+            if let Some(long) = raw.strip_prefix("--") {
+                let (name, has_inline_value) = long
+                    .split_once('=')
+                    .map_or((long, false), |(name, _)| (name, true));
+                skip_next_value = !has_inline_value && long_option_takes_value(current, name);
+                continue;
+            }
+            if raw.starts_with('-') && raw != "-" {
+                skip_next_value = short_option_takes_value(current, raw);
+                continue;
+            }
+        }
+
+        if let Some(subcommand) = current.find_subcommand(arg) {
+            if subcommand.get_name() == "help" {
+                break;
+            }
+            current = subcommand;
+            path.push(current.get_name().to_string());
+        }
+    }
+
+    (current, path)
+}
+
+fn long_option_takes_value(command: &Command, name: &str) -> bool {
+    command.get_arguments().any(|arg| {
+        !arg.is_positional()
+            && arg.get_action().takes_values()
+            && (arg.get_long() == Some(name)
+                || arg
+                    .get_all_aliases()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .any(|alias| alias == name))
+    })
+}
+
+fn short_option_takes_value(command: &Command, raw: &str) -> bool {
+    let mut chars = raw.trim_start_matches('-').chars().peekable();
+    while let Some(short) = chars.next() {
+        let Some(arg) = command.get_arguments().find(|arg| {
+            !arg.is_positional()
+                && (arg.get_short() == Some(short)
+                    || arg
+                        .get_all_short_aliases()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .any(|alias| alias == short))
+        }) else {
+            continue;
+        };
+
+        if arg.get_action().takes_values() {
+            return chars.peek().is_none();
+        }
+    }
+    false
+}
+
+fn print_response_schema(schema: &ResponseSchema) {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&response_json_schema(schema)).expect("schema JSON")
+    );
+}
+
+fn response_json_schema(schema: &ResponseSchema) -> Value {
+    let root = match schema.root {
+        RootKind::Object => object_json_schema(&schema.fields),
+        RootKind::Array => json!({
+            "type": "array",
+            "items": object_json_schema(&schema.fields),
+        }),
+        RootKind::Json => json!({
+            "anyOf": [
+                object_json_schema(&schema.fields),
+                {
+                    "type": "array",
+                    "items": object_json_schema(&schema.fields),
+                },
+            ],
+        }),
+        RootKind::Text => json!({
+            "type": "string",
+        }),
+    };
+
+    let mut root = root;
+    let root_obj = root
+        .as_object_mut()
+        .expect("root schema constructors produce objects");
+    root_obj.insert(
+        "$schema".to_string(),
+        Value::String("https://json-schema.org/draft/2020-12/schema".to_string()),
+    );
+    root_obj.insert("title".to_string(), Value::String(schema.summary.clone()));
+    root_obj.insert(
+        "description".to_string(),
+        Value::String(schema.summary.clone()),
+    );
+    root
+}
+
+fn object_json_schema(fields: &[Field]) -> Value {
+    let properties = fields
+        .iter()
+        .map(|field| (field.name.clone(), field_json_schema(field)))
+        .collect::<Map<_, _>>();
+
+    json!({
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": true,
+    })
+}
+
+fn field_json_schema(field: &Field) -> Value {
+    let mut schema = type_json_schema(&field.ty);
+    schema
+        .as_object_mut()
+        .expect("field schema constructors produce objects")
+        .insert(
+            "description".to_string(),
+            Value::String(field.description.clone()),
+        );
+    schema
+}
+
+fn type_json_schema(ty: &str) -> Value {
+    if let Some(item_ty) = ty.strip_suffix("[]") {
+        return json!({
+            "type": "array",
+            "items": type_json_schema(item_ty),
+        });
+    }
+
+    let variants = ty
+        .split('|')
+        .map(str::trim)
+        .filter(|variant| !variant.is_empty())
+        .collect::<Vec<_>>();
+
+    if variants.len() > 1 {
+        let mut types = Vec::new();
+        let mut has_object = false;
+        for variant in variants {
+            if variant == "object" {
+                has_object = true;
+            }
+            types.push(Value::String(json_schema_type_name(variant).to_string()));
+        }
+
+        let mut schema = Map::new();
+        schema.insert("type".to_string(), Value::Array(types));
+        if has_object {
+            schema.insert("additionalProperties".to_string(), Value::Bool(true));
+        }
+        return Value::Object(schema);
+    }
+
+    match ty {
+        "array" => json!({
+            "type": "array",
+        }),
+        "object" => json!({
+            "type": "object",
+            "additionalProperties": true,
+        }),
+        "string" | "number" | "boolean" | "null" => json!({
+            "type": ty,
+        }),
+        _ => json!({}),
+    }
+}
+
+fn json_schema_type_name(ty: &str) -> &'static str {
+    match ty {
+        "number" => "number",
+        "boolean" => "boolean",
+        "array" => "array",
+        "object" => "object",
+        "null" => "null",
+        _ => "string",
+    }
+}
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<ResponseSchema> {
+    let first = path.first()?.as_str();
+    match first {
+        "auth" => auth::schema_for_path(path),
+        "init" => init::schema_for_path(path),
+        "check" => check::schema_for_path(path),
+        "update" => crate::update::schema_for_path(path),
+        "tui" => crate::tui::schema_for_path(path),
+        "completion" => completion::schema_for_path(path),
+        "quote" | "depth" | "brokers" | "trades" | "intraday" | "kline" | "static"
+        | "calc-index" | "capital" | "market-temp" | "trading" | "security-list"
+        | "participants" | "subscriptions" | "option" | "warrant" | "constituent"
+        | "market-status" | "broker-holding" | "ah-premium" | "trade-stats" | "anomaly"
+        | "top-movers" | "rank" | "short-positions" | "short-trades" => {
+            quote::schema_for_path(path)
+        }
+        "financial-report"
+        | "business-segments"
+        | "industry-rank"
+        | "industry-peers"
+        | "institution-rating"
+        | "dividend"
+        | "forecast-eps"
+        | "consensus"
+        | "finance-calendar"
+        | "valuation"
+        | "shareholder"
+        | "company"
+        | "executive"
+        | "industry-valuation"
+        | "operating"
+        | "corp-action"
+        | "invest-relation"
+        | "fund-holder"
+        | "financial-statement"
+        | "valuation-rank"
+        | "compare" => fundamental::schema_for_path(path),
+        "news" | "filing" => news::schema_for_path(path),
+        "topic" => topic::schema_for_path(path),
+        "watchlist" => watchlist::schema_for_path(path),
+        "statement" => statement::schema_for_path(path),
+        "portfolio" if path.get(1).is_some_and(|sub| sub == "short-margin") => {
+            asset::schema_for_path(path)
+        }
+        "order" | "assets" | "cash-flow" | "portfolio" | "positions" | "fund-positions"
+        | "margin-ratio" | "max-qty" | "alert" => trade::schema_for_path(path),
+        "exchange-rate" | "profit-analysis" => asset::schema_for_path(path),
+        "insider-trades" => insider_trades::schema_for_path(path),
+        "investors" => investors::schema_for_path(path),
+        "dca" => dca::schema_for_path(path),
+        "sharelist" => sharelist::schema_for_path(path),
+        "quant" => run_script::schema_for_path(path),
+        "screener" => screener::schema_for_path(path),
+        "bank-cards" | "withdrawals" | "deposits" => atm::schema_for_path(path),
+        "ipo" => ipo::schema_for_path(path),
+        _ => None,
+    }
+}
+
+pub(crate) fn object(summary: &str, keys: &[&str]) -> ResponseSchema {
+    schema(summary, RootKind::Object, fields(keys))
+}
+
+pub(crate) fn array(summary: &str, keys: &[&str]) -> ResponseSchema {
+    schema(summary, RootKind::Array, fields(keys))
+}
+
+pub(crate) fn json_schema(summary: &str, keys: &[&str]) -> ResponseSchema {
+    schema(summary, RootKind::Json, fields(keys))
+}
+
+pub(crate) fn text(summary: &str) -> ResponseSchema {
+    schema(
+        summary,
+        RootKind::Text,
+        vec![field("output", "string", "Text written to stdout")],
+    )
+}
+
+pub(crate) fn schema(summary: &str, root: RootKind, fields: Vec<Field>) -> ResponseSchema {
+    ResponseSchema {
+        summary: summary.to_string(),
+        root,
+        fields,
+    }
+}
+
+pub(crate) fn fields(keys: &[&str]) -> Vec<Field> {
+    keys.iter()
+        .map(|key| field(key, inferred_type(key), "Response field"))
+        .collect()
+}
+
+pub(crate) fn field(name: &str, ty: &str, description: &str) -> Field {
+    Field {
+        name: name.to_string(),
+        ty: ty.to_string(),
+        description: description.to_string(),
+    }
+}
+
+fn inferred_type(key: &str) -> &'static str {
+    match key {
+        "trading_days" | "half_trading_days" | "opt_reports" | "opt_periods" | "empty_fields"
+        | "file_urls" | "tags" | "bus_ids" | "reg_ids" => "string[]",
+        "list" | "items" | "history" | "historical" | "stocks" | "holdings" | "market_accounts"
+        | "hk" | "us" => "array | object",
+        "pe" | "pb" | "ps" | "dvd" => "array | number | string | object | null",
+        "asks"
+        | "bids"
+        | "sessions"
+        | "securities"
+        | "business"
+        | "regionals"
+        | "events"
+        | "changes"
+        | "exchanges"
+        | "tickers"
+        | "hashtags"
+        | "images"
+        | "orders"
+        | "cash_infos"
+        | "cash_balances"
+        | "lists"
+        | "sharelists"
+        | "subscribed_sharelists"
+        | "professional_list"
+        | "shareholder_list"
+        | "invest_securities"
+        | "nearest_plans"
+        | "klines"
+        | "trades"
+        | "stats"
+        | "short_list"
+        | "scopes"
+        | "stock_topics"
+        | "stock_items"
+        | "plots"
+        | "series"
+        | "bars"
+        | "errors"
+        | "data"
+        | "infos"
+        | "records"
+        | "plans"
+        | "buy"
+        | "sell" => "object[]",
+        "id" | "rank" | "volume" | "quantity" | "available" | "shares" | "shares_after"
+        | "value" | "price" | "total" | "page" | "count" | "active_count" | "finished_count"
+        | "suspended_count" | "rest_days" | "trade_stock_num" | "total_holdings" | "win_qty"
+        | "amount" | "c" | "p" | "sources" => "number | string",
+        "enabled" | "is_traded" | "support_regular_saving" | "subscribed" | "all_off" | "bmp" => {
+            "boolean"
+        }
+        "overview" | "timeline" | "eligibility" | "summary" | "token" | "session"
+        | "connectivity" | "metrics" | "range" | "flows" | "position" | "group" | "sharelist"
+        | "statistics" | "next_params" => "object",
+        _ => "string | number | boolean | object | null",
+    }
+}
+
+fn print_no_schema_error(path: &[String]) {
+    let name = if path.is_empty() {
+        "longbridge".to_string()
+    } else {
+        format!("longbridge {}", path.join(" "))
+    };
+    eprintln!(
+        "{}",
+        json!({
+            "code": 0,
+            "error": format!("no response schema available for \"{name}\""),
+            "hint": "",
+            "status": 0
+        })
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn real_leaf_paths(command: &Command) -> Vec<Vec<String>> {
+        fn walk(command: &Command, prefix: &mut Vec<String>, out: &mut Vec<Vec<String>>) {
+            let real_subcommands = command
+                .get_subcommands()
+                .filter(|subcommand| subcommand.get_name() != "help")
+                .collect::<Vec<_>>();
+
+            if !prefix.is_empty() && real_subcommands.is_empty() {
+                out.push(prefix.clone());
+                return;
+            }
+
+            for subcommand in real_subcommands {
+                prefix.push(subcommand.get_name().to_string());
+                walk(subcommand, prefix, out);
+                prefix.pop();
+            }
+        }
+
+        let mut out = Vec::new();
+        walk(command, &mut Vec::new(), &mut out);
+        out
+    }
+
+    #[test]
+    fn schema_path_preparse_selects_nested_command_without_required_args() {
+        let mut root = Cli::command();
+        root.build();
+        let args = [
+            OsString::from("kline"),
+            OsString::from("history"),
+            OsString::from("--schema"),
+        ];
+
+        let (selected, path) = selected_command_and_path_for_args(&root, args.iter());
+
+        assert_eq!(selected.get_name(), "history");
+        assert_eq!(path, vec!["kline".to_string(), "history".to_string()]);
+    }
+
+    #[test]
+    fn every_real_leaf_command_has_schema_provider() {
+        let mut root = Cli::command();
+        root.build();
+        let paths = real_leaf_paths(&root);
+        assert_eq!(
+            paths.len(),
+            138,
+            "real command count changed; review schema coverage"
+        );
+
+        let missing = paths
+            .iter()
+            .filter(|path| schema_for_path(path).is_none())
+            .map(|path| path.join(" "))
+            .collect::<Vec<_>>();
+
+        assert!(missing.is_empty(), "missing schema coverage: {missing:#?}");
+    }
+}

--- a/src/cli/screener.rs
+++ b/src/cli/screener.rs
@@ -466,3 +466,22 @@ pub async fn cmd_screener_indicators(
     }
     Ok(())
 }
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{array, object};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "screener strategies" => array("Stock-selection strategies", &["id", "name", "type"]),
+        "screener run" | "screener filter" => object(
+            "Screener result page",
+            &["items", "market", "page", "total"],
+        ),
+        "screener indicators" => array(
+            "Screener indicators",
+            &["id", "key", "name", "unit", "min", "max"],
+        ),
+        _ => return None,
+    };
+    Some(schema)
+}

--- a/src/cli/sharelist.rs
+++ b/src/cli/sharelist.rs
@@ -251,6 +251,52 @@ async fn cmd_popular(count: u32, format: &OutputFormat) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{array, object, text};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "sharelist" => object(
+            "Sharelist groups",
+            &["sharelists", "subscribed_sharelists", "tail_mark"],
+        ),
+        "sharelist detail" => object(
+            "Sharelist detail",
+            &["sharelist", "group", "scopes", "stock_topics"],
+        ),
+        "sharelist create" | "sharelist delete" | "sharelist add" | "sharelist remove"
+        | "sharelist sort" => text("Sharelist mutation status message"),
+        "sharelist popular" => array("Popular sharelists", sharelist_schema_fields()),
+        _ => return None,
+    };
+    Some(schema)
+}
+
+fn sharelist_schema_fields() -> &'static [&'static str] {
+    &[
+        "id",
+        "group_id",
+        "stock_group_id",
+        "name",
+        "description",
+        "digest",
+        "cover",
+        "creator",
+        "sharelist_type",
+        "status",
+        "industry_code",
+        "stocks",
+        "stocks_count",
+        "subscribers_count",
+        "subscribed",
+        "created_at",
+        "edited_at",
+        "last_read_log_id",
+        "chg",
+        "this_year_chg",
+    ]
+}
+
 fn print_sharelist_table(sharelists: &[serde_json::Value], format: &OutputFormat) {
     let headers = &["ID", "Name", "Type", "Day Chg", "YTD Chg", "Subscribers"];
     let rows: Vec<Vec<String>> = sharelists

--- a/src/cli/statement.rs
+++ b/src/cli/statement.rs
@@ -1146,6 +1146,35 @@ fn section_file_name(section: &StatementSection) -> &'static str {
     }
 }
 
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{array, object};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "statement" | "statement list" => array("Available statements", &["date", "file_key"]),
+        "statement export" => object("Exported statement sections", statement_section_fields()),
+        _ => return None,
+    };
+    Some(schema)
+}
+
+fn statement_section_fields() -> &'static [&'static str] {
+    &[
+        "asset",
+        "account_balances",
+        "equity_holdings",
+        "account_balance_changes",
+        "stock_trades",
+        "equity_holding_changes",
+        "option_trades",
+        "fund_trades",
+        "ipo_trades",
+        "interests",
+        "corps",
+        "outstandings",
+    ]
+}
+
 impl SectionData<'_> {
     fn to_csv(&self) -> Result<String> {
         let mut wtr = csv::Writer::from_writer(vec![]);

--- a/src/cli/topic.rs
+++ b/src/cli/topic.rs
@@ -309,6 +309,107 @@ pub async fn cmd_create_topic(
     Ok(())
 }
 
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{array, object};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "topic" => array(
+            "Community topics for a symbol",
+            &[
+                "id",
+                "title",
+                "url",
+                "excerpt",
+                "published_at",
+                "likes_count",
+                "comments_count",
+                "shares_count",
+            ],
+        ),
+        "topic detail" => object(
+            "Community topic detail",
+            &[
+                "id",
+                "topic_type",
+                "title",
+                "description",
+                "body",
+                "author",
+                "tickers",
+                "hashtags",
+                "images",
+                "likes_count",
+                "comments_count",
+                "views_count",
+                "shares_count",
+                "detail_url",
+                "created_at",
+                "updated_at",
+            ],
+        ),
+        "topic mine" => array(
+            "Authenticated user's topics",
+            &[
+                "id",
+                "topic_type",
+                "title",
+                "url",
+                "tickers",
+                "hashtags",
+                "likes_count",
+                "comments_count",
+                "views_count",
+                "shares_count",
+                "created_at",
+                "updated_at",
+            ],
+        ),
+        "topic create" => object("Created topic identifier", &["id"]),
+        "topic replies" => array(
+            "Community topic replies",
+            &[
+                "id",
+                "topic_id",
+                "body",
+                "reply_to_id",
+                "author",
+                "likes_count",
+                "comments_count",
+                "created_at",
+            ],
+        ),
+        "topic create-reply" => object(
+            "Created topic reply",
+            &[
+                "id",
+                "topic_id",
+                "body",
+                "reply_to_id",
+                "author",
+                "likes_count",
+                "comments_count",
+                "created_at",
+            ],
+        ),
+        "topic search" => array(
+            "Community topic search results",
+            &[
+                "id",
+                "title",
+                "url",
+                "creator_name",
+                "time",
+                "excerpt",
+                "likes_count",
+                "comments_count",
+            ],
+        ),
+        _ => return None,
+    };
+    Some(schema)
+}
+
 #[cfg(test)]
 mod tests {
     use super::format_topic_contents;

--- a/src/cli/trade.rs
+++ b/src/cli/trade.rs
@@ -1466,6 +1466,105 @@ pub async fn cmd_alert_set_enabled(
     Ok(())
 }
 
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{array, object, text};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "order" => array("Order list", order_schema_fields()),
+        "order detail" => object("Order detail", &["order_id", "symbol", "side", "status"]),
+        "order executions" => array(
+            "Order executions",
+            &[
+                "order_id", "trade_id", "symbol", "price", "quantity", "time",
+            ],
+        ),
+        "order buy" | "order sell" => object("Submitted order", &["order_id"]),
+        "order cancel" | "order replace" => text("Order mutation status message"),
+        "assets" => array(
+            "Account asset overview",
+            &[
+                "currency",
+                "net_assets",
+                "total_cash",
+                "buy_power",
+                "max_finance_amount",
+                "remaining_finance_amount",
+                "init_margin",
+                "maintenance_margin",
+                "margin_call",
+                "risk_level",
+                "cash_infos",
+            ],
+        ),
+        "cash-flow" => array(
+            "Cash flow records",
+            &[
+                "flow_name",
+                "symbol",
+                "business_type",
+                "balance",
+                "currency",
+                "time",
+                "description",
+            ],
+        ),
+        "portfolio" => object(
+            "Portfolio overview",
+            &["overview", "holdings", "cash_balances", "market_accounts"],
+        ),
+        "positions" => array(
+            "Current stock positions",
+            &[
+                "symbol",
+                "name",
+                "quantity",
+                "available",
+                "cost_price",
+                "currency",
+                "market",
+            ],
+        ),
+        "fund-positions" => array(
+            "Current fund positions",
+            &[
+                "symbol",
+                "name",
+                "current_net_asset_value",
+                "cost_net_asset_value",
+                "currency",
+                "holding_units",
+            ],
+        ),
+        "margin-ratio" | "max-qty" => {
+            array("Key/value account calculation result", &["field", "value"])
+        }
+        "alert" => object("Price alert list", &["lists"]),
+        "alert add" | "alert delete" => {
+            object("Price alert mutation result", &["id", "status", "data"])
+        }
+        "alert enable" | "alert disable" => object("Price alert status update", &["id", "status"]),
+        _ => return None,
+    };
+    Some(schema)
+}
+
+fn order_schema_fields() -> &'static [&'static str] {
+    &[
+        "order_id",
+        "symbol",
+        "name",
+        "side",
+        "type",
+        "status",
+        "price",
+        "quantity",
+        "filled",
+        "submitted_at",
+        "updated_at",
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cli/watchlist.rs
+++ b/src/cli/watchlist.rs
@@ -269,6 +269,21 @@ pub async fn run_watchlist_update(
     Ok(())
 }
 
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{array, object, text};
+
+    let command = path.join(" ");
+    let schema = match command.as_str() {
+        "watchlist" => array("Watchlist groups", &["id", "name", "securities"]),
+        "watchlist show" => object("Watchlist group detail", &["id", "name", "securities"]),
+        "watchlist create" | "watchlist delete" | "watchlist update" | "watchlist pin" => {
+            text("Watchlist mutation status message")
+        }
+        _ => return None,
+    };
+    Some(schema)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -79,21 +79,6 @@ fn build_log_writer(log_dir: &Path, fallback_dir: &Path) -> (LogWriter, LogGuard
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn log_writer_falls_back_without_guard_when_file_appenders_fail() {
-        let primary = tempfile::NamedTempFile::new().expect("primary temp file");
-        let fallback = tempfile::NamedTempFile::new().expect("fallback temp file");
-
-        let (_writer, guard) = build_log_writer(primary.path(), fallback.path());
-
-        assert!(guard.is_none());
-    }
-}
-
 #[must_use]
 pub fn init() -> impl Any {
     use tracing_subscriber::fmt;
@@ -124,4 +109,19 @@ pub fn init() -> impl Any {
 
     tracing_subscriber::registry().with(subscriber).init();
     guard
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_writer_falls_back_without_guard_when_file_appenders_fail() {
+        let primary = tempfile::NamedTempFile::new().expect("primary temp file");
+        let fallback = tempfile::NamedTempFile::new().expect("fallback temp file");
+
+        let (_writer, guard) = build_log_writer(primary.path(), fallback.path());
+
+        assert!(guard.is_none());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,16 @@ fn print_cli_error(e: &anyhow::Error, using_api_key: bool) {
 
 #[tokio::main]
 async fn main() {
+    match cli::schema::handle_schema_args(std::env::args_os()) {
+        Ok(cli::schema::SchemaOutcome::NotRequested) => {}
+        Ok(cli::schema::SchemaOutcome::Handled) => return,
+        Ok(cli::schema::SchemaOutcome::Error) => std::process::exit(1),
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+
     let _guard = logger::init();
 
     // Clean up leftover .old binary from a previous Windows update.

--- a/src/secure_storage.rs
+++ b/src/secure_storage.rs
@@ -212,6 +212,34 @@ fn decrypt(data: &[u8]) -> Result<Vec<u8>, String> {
         .map_err(|e| format!("AES-GCM decrypt: {e}"))
 }
 
+fn machine_derived_key() -> Key<Aes256Gcm> {
+    let id = machine_id();
+    let hk = Hkdf::<sha2::Sha256>::new(None, id.as_bytes());
+    let mut key_bytes = [0u8; 32];
+    // HKDF expand is infallible for output lengths ≤ 255 * HashLen.
+    let _ = hk.expand(HKDF_INFO, &mut key_bytes);
+    *Key::<Aes256Gcm>::from_slice(&key_bytes)
+}
+
+/// Return a cached, stable machine-specific identifier.
+///
+/// Falls back to an empty string when the machine ID is unavailable (e.g.
+/// minimal Docker containers without `/etc/machine-id`). Encryption still
+/// works in that case; only the machine-binding property is lost.
+fn machine_id() -> &'static str {
+    MACHINE_ID
+        .get_or_init(|| match machine_uid::get() {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::warn!(
+                    "Could not obtain machine ID (token will not be machine-bound): {e}"
+                );
+                String::new()
+            }
+        })
+        .as_str()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -286,35 +314,7 @@ mod tests {
 
         assert_eq!(loaded.access_token, "at_test");
         assert_eq!(loaded.refresh_token.as_deref(), Some("rt_test"));
-        assert_eq!(loaded.expires_at, 9999999999);
+        assert_eq!(loaded.expires_at, 9_999_999_999);
         assert_eq!(loaded.logged_in_at, Some(1_700_000_000));
     }
-}
-
-fn machine_derived_key() -> Key<Aes256Gcm> {
-    let id = machine_id();
-    let hk = Hkdf::<sha2::Sha256>::new(None, id.as_bytes());
-    let mut key_bytes = [0u8; 32];
-    // HKDF expand is infallible for output lengths ≤ 255 * HashLen.
-    let _ = hk.expand(HKDF_INFO, &mut key_bytes);
-    *Key::<Aes256Gcm>::from_slice(&key_bytes)
-}
-
-/// Return a cached, stable machine-specific identifier.
-///
-/// Falls back to an empty string when the machine ID is unavailable (e.g.
-/// minimal Docker containers without `/etc/machine-id`). Encryption still
-/// works in that case; only the machine-binding property is lost.
-fn machine_id() -> &'static str {
-    MACHINE_ID
-        .get_or_init(|| match machine_uid::get() {
-            Ok(id) => id,
-            Err(e) => {
-                tracing::warn!(
-                    "Could not obtain machine ID (token will not be machine-bound): {e}"
-                );
-                String::new()
-            }
-        })
-        .as_str()
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -9,3 +9,7 @@ pub mod systems;
 pub mod ui;
 mod views;
 pub mod widgets;
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<crate::cli::schema::ResponseSchema> {
+    (path == ["tui"]).then(|| crate::cli::schema::text("Interactive terminal UI session"))
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -434,6 +434,10 @@ pub async fn cmd_update(verbose: bool, force: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub(crate) fn schema_for_path(path: &[String]) -> Option<crate::cli::schema::ResponseSchema> {
+    (path == ["update"]).then(|| crate::cli::schema::text("Update status or release-notes text"))
+}
+
 // ---------------------------------------------------------------------------
 // Release notes
 // ---------------------------------------------------------------------------

--- a/tests/schema_cli.rs
+++ b/tests/schema_cli.rs
@@ -1,0 +1,105 @@
+use std::process::Command;
+
+struct CliOutput {
+    status: i32,
+    stdout: String,
+    stderr: String,
+}
+
+fn run(args: &[&str]) -> CliOutput {
+    let output = Command::new(env!("CARGO_BIN_EXE_longbridge"))
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("run longbridge {args:?}: {e}"));
+
+    CliOutput {
+        status: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+fn schema(stdout: &str) -> serde_json::Value {
+    serde_json::from_str(stdout).expect("schema stdout should be valid JSON")
+}
+
+#[test]
+fn quote_schema_prints_json_schema_without_auth() {
+    let out = run(&["quote", "--schema"]);
+
+    assert_eq!(out.status, 0, "stderr: {}", out.stderr);
+    assert!(out.stderr.is_empty(), "stderr: {}", out.stderr);
+    let schema = schema(&out.stdout);
+    assert_eq!(
+        schema["$schema"],
+        "https://json-schema.org/draft/2020-12/schema"
+    );
+    assert_eq!(schema["type"], "array");
+    assert_eq!(schema["items"]["type"], "object");
+    assert_eq!(schema["items"]["properties"]["symbol"]["type"], "string");
+    assert_eq!(schema["items"]["properties"]["last"]["type"], "string");
+    assert_eq!(
+        schema["items"]["properties"]["pre_market"]["type"],
+        "object"
+    );
+}
+
+#[test]
+fn depth_schema_does_not_require_symbol() {
+    let out = run(&["depth", "--schema"]);
+
+    assert_eq!(out.status, 0, "stderr: {}", out.stderr);
+    assert!(out.stderr.is_empty(), "stderr: {}", out.stderr);
+    let schema = schema(&out.stdout);
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["properties"]["asks"]["type"], "array");
+    assert_eq!(schema["properties"]["asks"]["items"]["type"], "object");
+    assert_eq!(schema["properties"]["bids"]["type"], "array");
+}
+
+#[test]
+fn nested_command_schema_uses_nested_response_shape() {
+    let out = run(&["kline", "history", "--schema"]);
+
+    assert_eq!(out.status, 0, "stderr: {}", out.stderr);
+    assert!(out.stderr.is_empty(), "stderr: {}", out.stderr);
+    let schema = schema(&out.stdout);
+    assert_eq!(schema["type"], "array");
+    assert_eq!(schema["items"]["properties"]["timestamp"]["type"], "string");
+    assert_eq!(schema["items"]["properties"]["close"]["type"], "string");
+}
+
+#[test]
+fn command_group_schema_prints_help() {
+    let out = run(&["auth", "--schema"]);
+
+    assert_eq!(out.status, 0, "stderr: {}", out.stderr);
+    assert!(out.stderr.is_empty(), "stderr: {}", out.stderr);
+    assert!(out.stdout.contains("Usage: longbridge auth"));
+    assert!(out.stdout.contains("Commands:"));
+}
+
+#[test]
+fn operational_leaf_command_has_schema_too() {
+    let out = run(&["check", "--schema"]);
+
+    assert_eq!(out.status, 0, "stderr: {}", out.stderr);
+    assert!(out.stderr.is_empty(), "stderr: {}", out.stderr);
+    let schema = schema(&out.stdout);
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["properties"]["status"]["type"], "string");
+}
+
+#[test]
+fn root_schema_reports_no_response_schema() {
+    let out = run(&["--schema"]);
+
+    assert_eq!(out.status, 1);
+    assert!(out.stdout.is_empty());
+    let err: serde_json::Value =
+        serde_json::from_str(&out.stderr).expect("structured schema error");
+    assert_eq!(
+        err["error"],
+        "no response schema available for \"longbridge\""
+    );
+}

--- a/tests/schema_live.rs
+++ b/tests/schema_live.rs
@@ -1,0 +1,784 @@
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::process::Command;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Root {
+    Object,
+    Array,
+    Json,
+}
+
+struct Probe {
+    path: &'static [&'static str],
+    args: &'static [&'static str],
+}
+
+#[test]
+#[ignore = "requires authenticated Longbridge account and live read-only API access"]
+fn read_only_live_json_shapes_match_schema() {
+    for probe in read_only_probes() {
+        let schema = run_schema(probe.path);
+        let schema_root = parse_schema_root(&schema);
+        let schema_keys = parse_schema_keys(&schema);
+
+        let json = run_json(probe.args);
+        assert_root_matches(schema_root, &json, probe.path);
+
+        for key in top_level_keys(&json) {
+            assert!(
+                schema_keys.contains(key),
+                "schema for `{}` missing live JSON key `{key}`; stdout schema:\n{schema}",
+                probe.path.join(" "),
+                schema = serde_json::to_string_pretty(&schema).expect("format schema"),
+            );
+        }
+
+        for (key, value) in top_level_entries(&json) {
+            let field_schema = schema_for_key(&schema, key).unwrap_or_else(|| {
+                panic!(
+                    "schema for `{}` missing live JSON key `{key}`",
+                    probe.path.join(" ")
+                )
+            });
+            assert!(
+                schema_allows_value(field_schema, value),
+                "schema for `{}` has wrong type for live JSON key `{key}`: schema {}\nvalue type: {}\nvalue: {}",
+                probe.path.join(" "),
+                serde_json::to_string(field_schema).expect("format field schema"),
+                value_type(value),
+                serde_json::to_string(value).expect("format value"),
+            );
+        }
+    }
+}
+
+fn read_only_probes() -> Vec<Probe> {
+    vec![
+        p(&["auth", "status"], &["auth", "status", "--format", "json"]),
+        p(&["check"], &["check", "--format", "json"]),
+        p(&["quote"], &["quote", "TSLA.US", "--format", "json"]),
+        p(&["depth"], &["depth", "TSLA.US", "--format", "json"]),
+        p(&["brokers"], &["brokers", "700.HK", "--format", "json"]),
+        p(
+            &["trades"],
+            &["trades", "TSLA.US", "--count", "3", "--format", "json"],
+        ),
+        p(&["intraday"], &["intraday", "TSLA.US", "--format", "json"]),
+        p(
+            &["kline"],
+            &["kline", "TSLA.US", "--count", "3", "--format", "json"],
+        ),
+        p(
+            &["kline", "history"],
+            &[
+                "kline", "history", "TSLA.US", "--period", "day", "--format", "json",
+            ],
+        ),
+        p(&["static"], &["static", "TSLA.US", "--format", "json"]),
+        p(
+            &["calc-index"],
+            &[
+                "calc-index",
+                "TSLA.US",
+                "--fields",
+                "pe,pb,dps_rate,turnover_rate,mktcap",
+                "--format",
+                "json",
+            ],
+        ),
+        p(&["capital"], &["capital", "TSLA.US", "--format", "json"]),
+        p(
+            &["capital"],
+            &["capital", "TSLA.US", "--flow", "--format", "json"],
+        ),
+        p(&["market-temp"], &["market-temp", "HK", "--format", "json"]),
+        p(
+            &["trading", "session"],
+            &["trading", "session", "--format", "json"],
+        ),
+        p(
+            &["trading", "days"],
+            &[
+                "trading",
+                "days",
+                "HK",
+                "--start",
+                "2026-06-19",
+                "--end",
+                "2026-06-30",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["security-list"],
+            &["security-list", "US", "--count", "3", "--format", "json"],
+        ),
+        p(&["participants"], &["participants", "--format", "json"]),
+        p(&["subscriptions"], &["subscriptions", "--format", "json"]),
+        p(
+            &["option", "chain"],
+            &["option", "chain", "AAPL.US", "--format", "json"],
+        ),
+        p(
+            &["option", "quote"],
+            &[
+                "option",
+                "quote",
+                "AAPL260619C00200000.US",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["option", "volume"],
+            &["option", "volume", "AAPL.US", "--format", "json"],
+        ),
+        p(
+            &["option", "volume", "daily"],
+            &[
+                "option", "volume", "daily", "AAPL.US", "--count", "3", "--format", "json",
+            ],
+        ),
+        p(&["warrant"], &["warrant", "700.HK", "--format", "json"]),
+        p(
+            &["warrant", "issuers"],
+            &["warrant", "issuers", "--format", "json"],
+        ),
+        p(
+            &["financial-report"],
+            &[
+                "financial-report",
+                "AAPL.US",
+                "--kind",
+                "IS",
+                "--report",
+                "af",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["financial-report", "snapshot"],
+            &[
+                "financial-report",
+                "snapshot",
+                "AAPL.US",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["business-segments"],
+            &["business-segments", "AAPL.US", "--format", "json"],
+        ),
+        p(
+            &["industry-rank"],
+            &[
+                "industry-rank",
+                "--market",
+                "US",
+                "--indicator",
+                "market-cap",
+                "--limit",
+                "5",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["industry-peers"],
+            &["industry-peers", "BK/US/IN00258", "--format", "json"],
+        ),
+        p(
+            &["institution-rating"],
+            &["institution-rating", "AAPL.US", "--format", "json"],
+        ),
+        p(
+            &["institution-rating", "detail"],
+            &[
+                "institution-rating",
+                "detail",
+                "AAPL.US",
+                "--format",
+                "json",
+            ],
+        ),
+        p(&["dividend"], &["dividend", "AAPL.US", "--format", "json"]),
+        p(
+            &["dividend", "detail"],
+            &["dividend", "detail", "AAPL.US", "--format", "json"],
+        ),
+        p(
+            &["forecast-eps"],
+            &["forecast-eps", "AAPL.US", "--format", "json"],
+        ),
+        p(
+            &["consensus"],
+            &["consensus", "AAPL.US", "--format", "json"],
+        ),
+        p(
+            &["finance-calendar", "report"],
+            &[
+                "finance-calendar",
+                "report",
+                "--limit",
+                "3",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["valuation"],
+            &["valuation", "AAPL.US", "--format", "json"],
+        ),
+        p(
+            &["shareholder"],
+            &["shareholder", "AAPL.US", "--count", "5", "--format", "json"],
+        ),
+        p(&["company"], &["company", "AAPL.US", "--format", "json"]),
+        p(
+            &["executive"],
+            &["executive", "AAPL.US", "--format", "json"],
+        ),
+        p(
+            &["industry-valuation"],
+            &["industry-valuation", "AAPL.US", "--format", "json"],
+        ),
+        p(
+            &["industry-valuation", "dist"],
+            &["industry-valuation", "dist", "AAPL.US", "--format", "json"],
+        ),
+        p(&["operating"], &["operating", "700.HK", "--format", "json"]),
+        p(
+            &["corp-action"],
+            &["corp-action", "700.HK", "--format", "json"],
+        ),
+        p(
+            &["invest-relation"],
+            &["invest-relation", "700.HK", "--format", "json"],
+        ),
+        p(
+            &["financial-statement"],
+            &[
+                "financial-statement",
+                "AAPL.US",
+                "--kind",
+                "IS",
+                "--report",
+                "af",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["valuation-rank"],
+            &["valuation-rank", "AAPL.US", "--format", "json"],
+        ),
+        p(
+            &["compare"],
+            &["compare", "AAPL.US", "MSFT.US", "--format", "json"],
+        ),
+        p(
+            &["fund-holder"],
+            &["fund-holder", "AAPL.US", "--count", "5", "--format", "json"],
+        ),
+        p(
+            &["news"],
+            &["news", "AAPL.US", "--limit", "3", "--format", "json"],
+        ),
+        p(
+            &["news", "search"],
+            &["news", "search", "AAPL", "--limit", "3", "--format", "json"],
+        ),
+        p(
+            &["filing"],
+            &["filing", "AAPL.US", "--limit", "3", "--format", "json"],
+        ),
+        p(
+            &["topic"],
+            &["topic", "AAPL.US", "--limit", "3", "--format", "json"],
+        ),
+        p(
+            &["topic", "mine"],
+            &["topic", "mine", "--size", "3", "--format", "json"],
+        ),
+        p(
+            &["topic", "search"],
+            &[
+                "topic", "search", "AAPL", "--limit", "3", "--format", "json",
+            ],
+        ),
+        p(&["watchlist"], &["watchlist", "--format", "json"]),
+        p(
+            &["statement"],
+            &["statement", "--limit", "3", "--format", "json"],
+        ),
+        p(
+            &["statement", "list"],
+            &["statement", "list", "--limit", "3", "--format", "json"],
+        ),
+        p(&["order"], &["order", "--format", "json"]),
+        p(
+            &["order", "executions"],
+            &["order", "executions", "--format", "json"],
+        ),
+        p(&["assets"], &["assets", "--format", "json"]),
+        p(&["cash-flow"], &["cash-flow", "--format", "json"]),
+        p(&["portfolio"], &["portfolio", "--format", "json"]),
+        p(
+            &["portfolio", "short-margin"],
+            &["portfolio", "short-margin", "--format", "json"],
+        ),
+        p(&["positions"], &["positions", "--format", "json"]),
+        p(&["fund-positions"], &["fund-positions", "--format", "json"]),
+        p(
+            &["margin-ratio"],
+            &["margin-ratio", "TSLA.US", "--format", "json"],
+        ),
+        p(
+            &["max-qty"],
+            &[
+                "max-qty", "TSLA.US", "--side", "buy", "--price", "250", "--format", "json",
+            ],
+        ),
+        p(&["exchange-rate"], &["exchange-rate", "--format", "json"]),
+        p(&["alert"], &["alert", "--format", "json"]),
+        p(
+            &["profit-analysis"],
+            &["profit-analysis", "--format", "json"],
+        ),
+        p(
+            &["profit-analysis", "by-market"],
+            &["profit-analysis", "by-market", "US", "--format", "json"],
+        ),
+        p(
+            &["constituent"],
+            &["constituent", "HSI.HK", "--limit", "5", "--format", "json"],
+        ),
+        p(&["market-status"], &["market-status", "--format", "json"]),
+        p(
+            &["broker-holding"],
+            &["broker-holding", "700.HK", "--format", "json"],
+        ),
+        p(
+            &["broker-holding", "detail"],
+            &["broker-holding", "detail", "700.HK", "--format", "json"],
+        ),
+        p(
+            &["broker-holding", "daily"],
+            &[
+                "broker-holding",
+                "daily",
+                "700.HK",
+                "--broker",
+                "B01224",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["ah-premium"],
+            &["ah-premium", "939.HK", "--limit", "5", "--format", "json"],
+        ),
+        p(
+            &["ah-premium", "intraday"],
+            &["ah-premium", "intraday", "939.HK", "--format", "json"],
+        ),
+        p(
+            &["trade-stats"],
+            &["trade-stats", "700.HK", "--format", "json"],
+        ),
+        p(
+            &["anomaly"],
+            &[
+                "anomaly", "--market", "HK", "--limit", "5", "--format", "json",
+            ],
+        ),
+        p(
+            &["top-movers"],
+            &[
+                "top-movers",
+                "--market",
+                "HK",
+                "--limit",
+                "5",
+                "--format",
+                "json",
+            ],
+        ),
+        p(&["rank"], &["rank", "--market", "US", "--format", "json"]),
+        p(
+            &["rank"],
+            &[
+                "rank",
+                "--key",
+                "ib_hot_all-us",
+                "--limit",
+                "5",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["screener", "strategies"],
+            &[
+                "screener",
+                "strategies",
+                "--market",
+                "US",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["screener", "run"],
+            &["screener", "run", "42", "--limit", "5", "--format", "json"],
+        ),
+        p(
+            &["screener", "filter"],
+            &[
+                "screener",
+                "filter",
+                "pettm:10:50",
+                "--market",
+                "US",
+                "--limit",
+                "5",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["screener", "indicators"],
+            &["screener", "indicators", "--format", "json"],
+        ),
+        p(
+            &["insider-trades"],
+            &[
+                "insider-trades",
+                "TSLA.US",
+                "--limit",
+                "5",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["investors"],
+            &["investors", "--top", "5", "--format", "json"],
+        ),
+        p(
+            &["investors"],
+            &["investors", "0001067983", "--top", "5", "--format", "json"],
+        ),
+        p(
+            &["investors", "changes"],
+            &[
+                "investors",
+                "changes",
+                "0001067983",
+                "--top",
+                "5",
+                "--format",
+                "json",
+            ],
+        ),
+        p(&["dca"], &["dca", "--limit", "5", "--format", "json"]),
+        p(&["dca", "stats"], &["dca", "stats", "--format", "json"]),
+        p(
+            &["dca", "calc-date"],
+            &[
+                "dca",
+                "calc-date",
+                "AAPL.US",
+                "--frequency",
+                "monthly",
+                "--day-of-month",
+                "15",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["dca", "check"],
+            &["dca", "check", "AAPL.US", "TSLA.US", "--format", "json"],
+        ),
+        p(
+            &["short-positions"],
+            &[
+                "short-positions",
+                "AAPL.US",
+                "--limit",
+                "5",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["short-trades"],
+            &[
+                "short-trades",
+                "AAPL.US",
+                "--limit",
+                "5",
+                "--format",
+                "json",
+            ],
+        ),
+        p(
+            &["sharelist"],
+            &["sharelist", "--limit", "3", "--format", "json"],
+        ),
+        p(
+            &["sharelist", "popular"],
+            &["sharelist", "popular", "--limit", "3", "--format", "json"],
+        ),
+        p(&["bank-cards"], &["bank-cards", "--format", "json"]),
+        p(
+            &["withdrawals"],
+            &["withdrawals", "--limit", "3", "--format", "json"],
+        ),
+        p(
+            &["deposits"],
+            &["deposits", "--limit", "3", "--format", "json"],
+        ),
+        p(
+            &["ipo", "subscriptions"],
+            &["ipo", "subscriptions", "--format", "json"],
+        ),
+        p(
+            &["ipo", "wait-listing"],
+            &["ipo", "wait-listing", "--format", "json"],
+        ),
+        p(
+            &["ipo", "listed"],
+            &["ipo", "listed", "--limit", "5", "--format", "json"],
+        ),
+        p(
+            &["ipo", "calendar"],
+            &["ipo", "calendar", "--format", "json"],
+        ),
+        p(
+            &["ipo", "detail"],
+            &[
+                "ipo", "detail", "6810.HK", "--market", "HK", "--format", "json",
+            ],
+        ),
+        p(
+            &["ipo", "orders"],
+            &["ipo", "orders", "--limit", "5", "--format", "json"],
+        ),
+        p(
+            &["ipo", "profit-loss"],
+            &["ipo", "profit-loss", "--limit", "5", "--format", "json"],
+        ),
+        p(
+            &["ipo", "us-subscriptions"],
+            &["ipo", "us-subscriptions", "--format", "json"],
+        ),
+        p(
+            &["ipo", "us-wait-listing"],
+            &["ipo", "us-wait-listing", "--format", "json"],
+        ),
+        p(
+            &["ipo", "us-listed"],
+            &["ipo", "us-listed", "--limit", "5", "--format", "json"],
+        ),
+    ]
+}
+
+fn p(path: &'static [&'static str], args: &'static [&'static str]) -> Probe {
+    Probe { path, args }
+}
+
+fn run_schema(path: &[&str]) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_longbridge"))
+        .args(path)
+        .arg("--schema")
+        .output()
+        .unwrap_or_else(|e| panic!("run schema for {path:?}: {e}"));
+
+    assert!(
+        output.status.success(),
+        "schema command failed for `{}`: {}",
+        path.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "schema command did not return JSON for `{}`: {e}\nstdout:\n{}",
+            path.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+        )
+    })
+}
+
+fn run_json(args: &[&str]) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_longbridge"))
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("run longbridge {args:?}: {e}"));
+
+    assert!(
+        output.status.success(),
+        "live command failed `longbridge {}`:\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "live command did not return JSON `longbridge {}`: {e}\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn parse_schema_root(schema: &Value) -> Root {
+    if schema.get("anyOf").is_some() {
+        Root::Json
+    } else {
+        match schema.get("type").and_then(Value::as_str) {
+            Some("array") => Root::Array,
+            Some("object") => Root::Object,
+            _ => Root::Json,
+        }
+    }
+}
+
+fn parse_schema_keys(schema: &Value) -> BTreeSet<String> {
+    let mut keys = BTreeSet::new();
+    collect_schema_keys(schema, &mut keys);
+    keys
+}
+
+fn schema_for_key<'a>(schema: &'a Value, key: &str) -> Option<&'a Value> {
+    if let Some(field) = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .and_then(|properties| properties.get(key))
+    {
+        return Some(field);
+    }
+    if let Some(field) = schema
+        .get("items")
+        .and_then(|items| schema_for_key(items, key))
+    {
+        return Some(field);
+    }
+    schema
+        .get("anyOf")
+        .and_then(Value::as_array)
+        .and_then(|schemas| {
+            schemas
+                .iter()
+                .find_map(|schema| schema_for_key(schema, key))
+        })
+}
+
+fn schema_allows_value(schema: &Value, value: &Value) -> bool {
+    if let Some(any_of) = schema.get("anyOf").and_then(Value::as_array) {
+        return any_of
+            .iter()
+            .any(|schema| schema_allows_value(schema, value));
+    }
+
+    match schema.get("type") {
+        Some(Value::String(ty)) => json_type_matches(ty, value),
+        Some(Value::Array(types)) => types
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|ty| json_type_matches(ty, value)),
+        Some(_) => false,
+        None => true,
+    }
+}
+
+fn json_type_matches(ty: &str, value: &Value) -> bool {
+    match ty {
+        "array" => value.is_array(),
+        "boolean" => value.is_boolean(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "null" => value.is_null(),
+        "number" => value.is_number(),
+        "object" => value.is_object(),
+        "string" => value.is_string(),
+        _ => false,
+    }
+}
+
+fn collect_schema_keys(schema: &Value, keys: &mut BTreeSet<String>) {
+    if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
+        keys.extend(properties.keys().cloned());
+    }
+    if let Some(items) = schema.get("items") {
+        collect_schema_keys(items, keys);
+    }
+    if let Some(any_of) = schema.get("anyOf").and_then(Value::as_array) {
+        for schema in any_of {
+            collect_schema_keys(schema, keys);
+        }
+    }
+}
+
+fn assert_root_matches(root: Root, value: &Value, path: &[&str]) {
+    let ok = match root {
+        Root::Object => value.is_object(),
+        Root::Array => value.is_array(),
+        Root::Json => value.is_object() || value.is_array(),
+    };
+    assert!(
+        ok,
+        "schema root mismatch for `{}`: expected {root:?}, got {}",
+        path.join(" "),
+        value_type(value)
+    );
+}
+
+fn top_level_keys(value: &Value) -> BTreeSet<&str> {
+    match value {
+        Value::Object(map) => map.keys().map(String::as_str).collect(),
+        Value::Array(items) => items
+            .first()
+            .and_then(Value::as_object)
+            .map_or_else(BTreeSet::new, |map| {
+                map.keys().map(String::as_str).collect()
+            }),
+        _ => BTreeSet::new(),
+    }
+}
+
+fn top_level_entries(value: &Value) -> Vec<(&str, &Value)> {
+    match value {
+        Value::Object(map) => map
+            .iter()
+            .map(|(key, value)| (key.as_str(), value))
+            .collect(),
+        Value::Array(items) => {
+            items
+                .first()
+                .and_then(Value::as_object)
+                .map_or_else(Vec::new, |map| {
+                    map.iter()
+                        .map(|(key, value)| (key.as_str(), value))
+                        .collect()
+                })
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn value_type(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}


### PR DESCRIPTION
## Summary
- add global `--schema` handling before normal CLI startup and emit JSON Schema Draft 2020-12 for executable commands
- colocate schema providers with each command module so response schemas stay near command implementations
- add CLI contract tests, full command-tree schema coverage, and ignored live read-only JSON shape/type validation

## Test Plan
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets`
- full schema scan: 160 JSON Schema outputs, 7 group help outputs, 0 errors
- live read-only validation via `target/debug/longbridge` using the same probes from `tests/schema_live.rs`: 114/114 passed

Note: I left the local `Cargo.toml`/`Cargo.lock` path dependency changes unstaged because they are unrelated to this PR. A fresh `cargo test --test schema_live -- --ignored --nocapture` in this working tree is currently blocked by that local external dependency state under `../longport-openapi/rust`, so I validated the committed CLI binary behavior directly against the same live probe set.