### PR TITLE
cli: Add US data-center login and routing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1433,7 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2620,7 +2620,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#d457196df4f941d5d30f2b64fd68e5c1b488354c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#d457196df4f941d5d30f2b64fd68e5c1b488354c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#d457196df4f941d5d30f2b64fd68e5c1b488354c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#d457196df4f941d5d30f2b64fd68e5c1b488354c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#d457196df4f941d5d30f2b64fd68e5c1b488354c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#d457196df4f941d5d30f2b64fd68e5c1b488354c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2794,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#d457196df4f941d5d30f2b64fd68e5c1b488354c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3091,7 +3091,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3687,7 +3687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3802,7 +3802,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4345,7 +4345,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5045,7 +5045,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6101,7 +6101,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1433,7 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2620,7 +2620,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2794,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#4e60df83ab4893415546bf6df1b20cb249cb9ef1"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3091,7 +3091,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3213,13 +3213,12 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
 dependencies = [
  "is-wsl",
  "libc",
- "pathdiff",
 ]
 
 [[package]]
@@ -3329,12 +3328,6 @@ checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -3687,7 +3680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3802,7 +3795,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4345,7 +4338,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5045,7 +5038,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6101,7 +6094,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1433,7 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2620,7 +2620,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#bc9d3badcd380097d1797d21a976d6064a8a3dac"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#bc9d3badcd380097d1797d21a976d6064a8a3dac"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#bc9d3badcd380097d1797d21a976d6064a8a3dac"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#bc9d3badcd380097d1797d21a976d6064a8a3dac"
 dependencies = [
  "dotenv",
  "futures-util",
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#bc9d3badcd380097d1797d21a976d6064a8a3dac"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#bc9d3badcd380097d1797d21a976d6064a8a3dac"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2794,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.3.2"
-source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#99321466ad051803de52896d66c19a1fb69b866c"
+source = "git+https://github.com/longbridge/openapi.git?branch=feat%2Fus-dc-region#bc9d3badcd380097d1797d21a976d6064a8a3dac"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3091,7 +3091,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3680,7 +3680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3795,7 +3795,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4338,7 +4338,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6094,7 +6094,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 dashmap = "6.1"
 dirs = "5.0"
 csv = "1"
-longbridge = { git = "https://github.com/longbridge/openapi.git", branch = "main" }
+longbridge = { git = "https://github.com/longbridge/openapi.git", branch = "feat/us-dc-region" }
 futures = "0.3.28"
 open = "5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "brotli"] }
@@ -114,4 +114,5 @@ needless_pass_by_value = "allow"
 pedantic = { level = "deny", priority = -1 }
 too_many_arguments = "allow"
 too_many_lines = "allow"
+
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,5 +114,3 @@ needless_pass_by_value = "allow"
 pedantic = { level = "deny", priority = -1 }
 too_many_arguments = "allow"
 too_many_lines = "allow"
-
-

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -338,27 +338,44 @@ pub fn open_browser(url: &str) -> bool {
 }
 
 /// Device Authorization Flow (RFC 8628).
-pub async fn device_login(verbose: bool, client_name: Option<String>) -> Result<()> {
-    use std::time::{Duration, Instant};
+/// Data centers polled for the device-login token. The `user_code` /
+/// `device_code` are created once on the default (AP) server, which syncs the
+/// device info to US, so the same `user_code` can be authorized on either DC's
+/// web page (the region is chosen during web login). We poll both DCs for the
+/// token; the one the user authorized on returns it, and the access token's
+/// `us_`/`ap_` prefix identifies the region.
+const DEVICE_LOGIN_REGIONS: [&str; 2] = ["ap", "us"];
 
-    let oauth_base = oauth_base_url();
-    let http_client = build_http_client()?;
-    let invite_code = read_invite_code();
+/// A pending device-authorization request. Created once on AP and synced to US
+/// server-side, so the single `device_code` is valid on both data centers.
+struct DeviceAuthorization {
+    device_code: String,
+    verification_uri_complete: String,
+    interval: u64,
+    expires_in: u64,
+}
 
-    let reg = get_or_register_client(&http_client, verbose, client_name).await?;
-    let client_id = reg.client_id.as_str();
-
+/// Create the device authorization by calling the default (AP) server. The
+/// server syncs the `device_code` / `user_code` to US so the same code can be
+/// authorized on either DC. No `x-dc-region` header — the default routes to AP.
+async fn request_device_authorize(
+    http_client: &reqwest::Client,
+    oauth_base: &str,
+    client_id: &str,
+    invite_code: Option<&str>,
+    verbose: bool,
+) -> Result<DeviceAuthorization> {
     let url = format!("{oauth_base}/device/authorize");
     if verbose {
         eprintln!("POST {url}");
     }
-    let mut device_auth_form: Vec<(&str, &str)> = vec![("client_id", client_id)];
-    if let Some(ref invite_code) = invite_code {
-        device_auth_form.push(("invite-code", invite_code.as_str()));
+    let mut form: Vec<(&str, &str)> = vec![("client_id", client_id)];
+    if let Some(invite_code) = invite_code {
+        form.push(("invite-code", invite_code));
     }
     let raw = http_client
         .post(&url)
-        .form(&device_auth_form)
+        .form(&form)
         .send()
         .await
         .context("Device authorization request failed")?;
@@ -369,31 +386,133 @@ pub async fn device_login(verbose: bool, client_name: Option<String>) -> Result<
         anyhow::bail!("Device authorization failed ({status}): {body}");
     }
 
-    let device_resp = raw
+    let resp = raw
         .json::<serde_json::Value>()
         .await
         .context("Failed to parse device authorization response")?;
-
-    let device_code = device_resp["device_code"]
+    let device_code = resp["device_code"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("No device_code in response"))?
         .to_owned();
-    let verification_url_base = device_resp["verification_uri_complete"]
+    let verification_uri_complete = resp["verification_uri_complete"]
         .as_str()
-        .unwrap_or_else(|| device_resp["verification_uri"].as_str().unwrap_or(""));
+        .or_else(|| resp["verification_uri"].as_str())
+        .unwrap_or_default()
+        .to_owned();
+    Ok(DeviceAuthorization {
+        device_code,
+        verification_uri_complete,
+        expires_in: resp["expires_in"].as_u64().unwrap_or(300),
+        interval: resp["interval"].as_u64().unwrap_or(5),
+    })
+}
+
+/// Poll `POST /token` on a single data center (selected via the `x-dc-region`
+/// header) for the shared `device_code` until it is authorized (returns the
+/// token), is rejected, or expires.
+async fn poll_device_token(
+    http_client: &reqwest::Client,
+    oauth_base: &str,
+    client_id: &str,
+    device_code: &str,
+    region: &'static str,
+    interval: u64,
+    expires_in: u64,
+    verbose: bool,
+) -> Result<longbridge::oauth::StoredToken> {
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    let url = format!("{oauth_base}/token");
+    let deadline = Instant::now() + Duration::from_secs(expires_in);
+    let poll_interval = Duration::from_secs(interval.max(1));
+
+    loop {
+        tokio::time::sleep(poll_interval).await;
+
+        if Instant::now() >= deadline {
+            anyhow::bail!("Device authorization timed out ({region})");
+        }
+
+        if verbose {
+            eprintln!("POST {url}  grant_type=device_code  x-dc-region={region}");
+        }
+        let raw = http_client
+            .post(&url)
+            .header(longbridge::DC_REGION_HEADER, region)
+            .form(&[
+                ("client_id", client_id),
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                ("device_code", device_code),
+            ])
+            .send()
+            .await
+            .with_context(|| format!("Token poll request failed ({region})"))?;
+
+        let status = raw.status();
+        if status.is_success() {
+            let token_resp = raw
+                .json::<serde_json::Value>()
+                .await
+                .with_context(|| format!("Failed to parse token response ({region})"))?;
+
+            let access_token = token_resp["access_token"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("No access_token in token response ({region})"))?;
+            let expires_in = token_resp["expires_in"].as_u64().unwrap_or(3600);
+            let refresh_token = token_resp["refresh_token"].as_str().map(str::to_owned);
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+
+            return Ok(longbridge::oauth::StoredToken {
+                client_id: client_id.to_string(),
+                access_token: access_token.to_string(),
+                refresh_token,
+                expires_at: now + expires_in,
+            });
+        }
+
+        let err_resp = raw.json::<serde_json::Value>().await.unwrap_or_default();
+        match err_resp["error"].as_str() {
+            Some("authorization_pending" | "slow_down") => {}
+            Some(other) => anyhow::bail!("Authorization failed ({region}): {other}"),
+            None => anyhow::bail!("Unexpected token poll response ({region})"),
+        }
+    }
+}
+
+pub async fn device_login(verbose: bool, client_name: Option<String>) -> Result<()> {
+    let oauth_base = oauth_base_url();
+    let http_client = build_http_client()?;
+    let invite_code = read_invite_code();
+
+    let reg = get_or_register_client(&http_client, verbose, client_name).await?;
+    let client_id = reg.client_id;
+
+    // Create the device authorization on the default (AP) server; it syncs the
+    // device info to US, so the same `user_code` can be authorized on either DC.
+    let auth = request_device_authorize(
+        &http_client,
+        &oauth_base,
+        &client_id,
+        invite_code.as_deref(),
+        verbose,
+    )
+    .await?;
+
+    // A single, region-neutral verification URL: the user picks their region by
+    // logging in on the web, and the synced `user_code` is valid there.
     let verification_url_owned;
     let verification_url = if let Some(ref invite_code) = invite_code {
         verification_url_owned =
-            append_query_param(verification_url_base, "invite-code", invite_code);
+            append_query_param(&auth.verification_uri_complete, "invite-code", invite_code);
         verification_url_owned.as_str()
     } else {
-        verification_url_base
+        auth.verification_uri_complete.as_str()
     };
-    let expires_in = device_resp["expires_in"].as_u64().unwrap_or(300);
-    let interval = device_resp["interval"].as_u64().unwrap_or(5);
 
     let opened = open_browser(verification_url);
-
     println!("Open the following URL in your browser to authorize:");
     println!();
     println!("{verification_url}");
@@ -404,71 +523,34 @@ pub async fn device_login(verbose: bool, client_name: Option<String>) -> Result<
         println!("Waiting for authorization...");
     }
 
-    let deadline = Instant::now() + Duration::from_secs(expires_in);
-    let poll_interval = Duration::from_secs(interval);
+    // The authorization lands on whichever data center the user logged in to, so
+    // poll both DCs in parallel for the shared `device_code`; the first to be
+    // authorized wins. The access token carries that DC's `us_`/`ap_` prefix, so
+    // subsequent API calls route back to the same data center automatically.
+    let polls = DEVICE_LOGIN_REGIONS.iter().map(|&region| {
+        Box::pin(poll_device_token(
+            &http_client,
+            &oauth_base,
+            &client_id,
+            &auth.device_code,
+            region,
+            auth.interval,
+            auth.expires_in,
+            verbose,
+        ))
+    });
+    let (token, _) = futures::future::select_ok(polls)
+        .await
+        .map_err(|e| anyhow::anyhow!("Device authorization failed: {e:#}"))?;
 
-    loop {
-        tokio::time::sleep(poll_interval).await;
+    crate::secure_storage::EncryptedFileTokenStorage
+        .save(&token)
+        .map_err(|e| anyhow::anyhow!("Failed to save token: {e}"))?;
 
-        if Instant::now() >= deadline {
-            anyhow::bail!("Device authorization timed out — please try again.");
-        }
-
-        let url = format!("{oauth_base}/token");
-        if verbose {
-            eprintln!("POST {url}  grant_type=device_code");
-        }
-        let raw = http_client
-            .post(&url)
-            .form(&[
-                ("client_id", client_id),
-                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
-                ("device_code", device_code.as_str()),
-            ])
-            .send()
-            .await
-            .context("Token poll request failed")?;
-
-        let status = raw.status();
-        if status.is_success() {
-            let token_resp = raw
-                .json::<serde_json::Value>()
-                .await
-                .context("Failed to parse token response")?;
-
-            let access_token = token_resp["access_token"]
-                .as_str()
-                .ok_or_else(|| anyhow::anyhow!("No access_token in token response"))?;
-            let expires_in = token_resp["expires_in"].as_u64().unwrap_or(3600);
-            let refresh_token = token_resp["refresh_token"].as_str().map(str::to_owned);
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
-
-            let token = longbridge::oauth::StoredToken {
-                client_id: client_id.to_string(),
-                access_token: access_token.to_string(),
-                refresh_token,
-                expires_at: now + expires_in,
-            };
-            crate::secure_storage::EncryptedFileTokenStorage
-                .save(&token)
-                .map_err(|e| anyhow::anyhow!("Failed to save token: {e}"))?;
-
-            // Registration was already persisted in get_or_register_client, so
-            // there is nothing more to store here.
-            println!("Successfully authenticated.");
-            return Ok(());
-        }
-
-        let err_resp = raw.json::<serde_json::Value>().await.unwrap_or_default();
-        match err_resp["error"].as_str() {
-            Some("authorization_pending" | "slow_down") => {}
-            Some(other) => anyhow::bail!("Authorization failed: {other}"),
-            None => anyhow::bail!("Unexpected token poll response"),
-        }
-    }
+    // Registration was already persisted in get_or_register_client, so there is
+    // nothing more to store here.
+    println!("Successfully authenticated.");
+    Ok(())
 }
 
 /// Refresh the access token in-place if it has expired.
@@ -749,9 +831,14 @@ pub async fn auth_code_exchange_login(code: &str) -> Result<()> {
     let mut last_rejection: Option<(reqwest::StatusCode, serde_json::Value)> = None;
     let saw_client_id = !attempts.is_empty();
     for (exchange_code, client_id) in &attempts {
-        tracing::debug!("Exchanging authorization code via {url}");
+        // The authorization code carries its data-center region as a prefix
+        // (`us_…` / `ap_…`); route the exchange to that DC via `x-dc-region` so
+        // a US-issued code is validated against the US server (default is AP).
+        let dc_region = longbridge::DcRegion::from_credential(exchange_code).as_str();
+        tracing::debug!("Exchanging authorization code via {url} (x-dc-region={dc_region})");
         let send_result = http_client
             .post(&url)
+            .header(longbridge::DC_REGION_HEADER, dc_region)
             .form(&[
                 ("grant_type", "authorization_code"),
                 ("code", exchange_code.as_str()),

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -417,6 +417,18 @@ pub async fn http_get(
     params: &[(&str, &str)],
     verbose: bool,
 ) -> Result<serde_json::Value> {
+    http_get_dc(path, params, None, verbose).await
+}
+
+/// [`http_get`], but restricting the request to a single data center via the
+/// SDK's `dc_restrict` API. Region-limited commands declare their region here; the
+/// SDK short-circuits a mismatched session with a unified error.
+pub async fn http_get_dc(
+    path: &str,
+    params: &[(&str, &str)],
+    dc_restrict: Option<longbridge::DcRegion>,
+    verbose: bool,
+) -> Result<serde_json::Value> {
     use longbridge::httpclient::Json;
     use reqwest::Method;
 
@@ -430,9 +442,11 @@ pub async fn http_get(
     }
     let client = crate::openapi::http_client();
     let params: Vec<(&str, &str)> = params.to_vec();
-    let resp = client
-        .request(Method::GET, path)
-        .query_params(params)
+    let mut builder = client.request(Method::GET, path).query_params(params);
+    if let Some(region) = dc_restrict {
+        builder = builder.dc_restrict(region);
+    }
+    let resp = builder
         .response::<Json<serde_json::Value>>()
         .send()
         .await
@@ -447,6 +461,17 @@ pub async fn http_post(
     body: serde_json::Value,
     verbose: bool,
 ) -> Result<serde_json::Value> {
+    http_post_dc(path, body, None, verbose).await
+}
+
+/// [`http_post`], but restricting the request to a single data center via the
+/// SDK's `dc_restrict` API.
+pub async fn http_post_dc(
+    path: &str,
+    body: serde_json::Value,
+    dc_restrict: Option<longbridge::DcRegion>,
+    verbose: bool,
+) -> Result<serde_json::Value> {
     use longbridge::httpclient::Json;
     use reqwest::Method;
 
@@ -458,9 +483,11 @@ pub async fn http_post(
         );
     }
     let client = crate::openapi::http_client();
-    let resp = client
-        .request(Method::POST, path)
-        .body(Json(body))
+    let mut builder = client.request(Method::POST, path).body(Json(body));
+    if let Some(region) = dc_restrict {
+        builder = builder.dc_restrict(region);
+    }
+    let resp = builder
         .response::<Json<serde_json::Value>>()
         .send()
         .await

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -54,6 +54,9 @@ struct TokenState {
     refresh_token_exp: Option<u64>,
     /// Unix timestamp of when the token file was last written (login time).
     logged_in_at: Option<u64>,
+    /// Data-center region (`us`/`ap`) derived from the access token prefix.
+    /// `None` when no token is stored or it cannot be decrypted.
+    dc_region: Option<&'static str>,
 }
 
 /// Decode a numeric field from a JWT payload without verifying the signature.
@@ -85,6 +88,7 @@ fn read_token_state() -> Result<TokenState> {
             access_token_exp: None,
             refresh_token_exp: None,
             logged_in_at: None,
+            dc_region: None,
         });
     }
 
@@ -99,8 +103,14 @@ fn read_token_state() -> Result<TokenState> {
             access_token_exp: None,
             refresh_token_exp: None,
             logged_in_at: None,
+            dc_region: None,
         });
     };
+
+    // Data-center region from the access token's `us_`/`ap_` prefix.
+    let dc_region = full["access_token"]
+        .as_str()
+        .map(|token| longbridge::DcRegion::from_credential(token).as_str());
 
     let expires_at = full["expires_at"].as_u64().unwrap_or(0);
     let refresh_token = full["refresh_token"].as_str().unwrap_or("");
@@ -129,6 +139,7 @@ fn read_token_state() -> Result<TokenState> {
             access_token_exp,
             refresh_token_exp,
             logged_in_at,
+            dc_region,
         });
     }
 
@@ -139,6 +150,7 @@ fn read_token_state() -> Result<TokenState> {
             access_token_exp,
             refresh_token_exp,
             logged_in_at,
+            dc_region,
         });
     }
 
@@ -155,6 +167,7 @@ fn read_token_state() -> Result<TokenState> {
             access_token_exp,
             refresh_token_exp,
             logged_in_at,
+            dc_region,
         })
     } else {
         Ok(TokenState {
@@ -166,6 +179,7 @@ fn read_token_state() -> Result<TokenState> {
             access_token_exp,
             refresh_token_exp,
             logged_in_at,
+            dc_region,
         })
     }
 }
@@ -349,6 +363,7 @@ pub async fn cmd_auth_status(format: &OutputFormat, market: &str) -> Result<()> 
                 "token": {
                     "status": token.status,
                     "logged_in_at": token.logged_in_at,
+                    "dc_region": token.dc_region,
                     "path": token_path.display().to_string(),
                 },
             });
@@ -416,6 +431,9 @@ pub async fn cmd_auth_status(format: &OutputFormat, market: &str) -> Result<()> 
                     W = W,
                     color = status_color,
                 );
+            }
+            if let Some(region) = token.dc_region {
+                println!("{:<W$} {}", "DC Region", region.to_uppercase(), W = W);
             }
             let local_offset = UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC);
             let fmt_exp = |ts: u64| -> String {

--- a/src/cli/dca.rs
+++ b/src/cli/dca.rs
@@ -1,13 +1,28 @@
 use anyhow::Result;
 
 use super::{
-    api::{http_get, http_post},
+    api::{http_get_dc, http_post_dc},
     output::{print_json_value, print_table},
     DcaCmd, DcaDayOfWeek, DcaFrequency, DcaReminderHours, OutputFormat,
 };
 
 use crate::utils::counter::{counter_id_to_symbol, symbol_to_counter_id};
 use crate::utils::datetime::format_timestamp;
+
+// Recurring investment (DCA) is served only by the AP data center. These
+// thin wrappers tag every request via the SDK's `dc_restrict` API so a US-region
+// session gets the SDK's unified error instead of a raw backend failure.
+async fn http_get(path: &str, params: &[(&str, &str)], verbose: bool) -> Result<serde_json::Value> {
+    http_get_dc(path, params, Some(longbridge::DcRegion::Ap), verbose).await
+}
+
+async fn http_post(
+    path: &str,
+    body: serde_json::Value,
+    verbose: bool,
+) -> Result<serde_json::Value> {
+    http_post_dc(path, body, Some(longbridge::DcRegion::Ap), verbose).await
+}
 
 pub async fn cmd_dca(
     cmd: Option<DcaCmd>,

--- a/src/cli/fundamental.rs
+++ b/src/cli/fundamental.rs
@@ -12,6 +12,19 @@ use crate::utils::number::format_financial_value;
 use crate::utils::text::strip_html;
 
 async fn http_get(path: &str, params: &[(&str, &str)], verbose: bool) -> Result<Value> {
+    http_get_dc(path, params, None, verbose).await
+}
+
+/// [`http_get`], but restricting the request to a single data center via the
+/// SDK's `dc_restrict` API. Region-limited fundamentals (e.g. AP-only operating
+/// reviews) declare their region here; the SDK returns a unified error when the
+/// session's region differs.
+async fn http_get_dc(
+    path: &str,
+    params: &[(&str, &str)],
+    dc_restrict: Option<longbridge::DcRegion>,
+    verbose: bool,
+) -> Result<Value> {
     if verbose {
         let qs = params
             .iter()
@@ -22,9 +35,11 @@ async fn http_get(path: &str, params: &[(&str, &str)], verbose: bool) -> Result<
     }
     let client = crate::openapi::http_client();
     let params: Vec<(&str, &str)> = params.to_vec();
-    let resp = client
-        .request(Method::GET, path)
-        .query_params(params)
+    let mut builder = client.request(Method::GET, path).query_params(params);
+    if let Some(region) = dc_restrict {
+        builder = builder.dc_restrict(region);
+    }
+    let resp = builder
         .response::<Json<Value>>()
         .send()
         .await
@@ -1922,7 +1937,13 @@ pub async fn cmd_operating(
         report_val = r.clone();
         params.push(("report", report_val.as_str()));
     }
-    let data = http_get("/v1/quote/operatings", &params, verbose).await?;
+    let data = http_get_dc(
+        "/v1/quote/operatings",
+        &params,
+        Some(longbridge::DcRegion::Ap),
+        verbose,
+    )
+    .await?;
     match format {
         OutputFormat::Json => print_json(&data),
         OutputFormat::Pretty => print_operating(&data),

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -8,7 +8,7 @@ use time::Date;
 use serde_json::Value;
 
 use super::{
-    api::{http_get, http_post, LbQuoteApi, QuoteApi},
+    api::{http_get, http_get_dc, http_post, LbQuoteApi, QuoteApi},
     output::{
         fmt_date, fmt_dec, fmt_decimal, fmt_decimal_div100, fmt_decimal_div252, parse_date,
         print_table,
@@ -2435,9 +2435,10 @@ pub async fn cmd_broker_holding_top(
     verbose: bool,
 ) -> Result<()> {
     let cid = symbol_to_counter_id(&symbol);
-    let data = http_get(
+    let data = http_get_dc(
         "/v1/quote/broker-holding",
         &[("counter_id", cid.as_str()), ("type", period)],
+        Some(longbridge::DcRegion::Ap),
         verbose,
     )
     .await?;
@@ -2480,9 +2481,10 @@ pub async fn cmd_broker_holding_detail(
     verbose: bool,
 ) -> Result<()> {
     let cid = symbol_to_counter_id(&symbol);
-    let data = http_get(
+    let data = http_get_dc(
         "/v1/quote/broker-holding/detail",
         &[("counter_id", cid.as_str())],
+        Some(longbridge::DcRegion::Ap),
         verbose,
     )
     .await?;
@@ -2534,9 +2536,10 @@ pub async fn cmd_broker_holding_daily(
     verbose: bool,
 ) -> Result<()> {
     let cid = symbol_to_counter_id(&symbol);
-    let data = http_get(
+    let data = http_get_dc(
         "/v1/quote/broker-holding/daily",
         &[("counter_id", cid.as_str()), ("parti_number", broker)],
+        Some(longbridge::DcRegion::Ap),
         verbose,
     )
     .await?;

--- a/src/region.rs
+++ b/src/region.rs
@@ -18,9 +18,10 @@ pub const QUOTE_WS_URL_CN: &str = "wss://openapi-quote.longbridge.cn/v2";
 pub const TRADE_WS_URL_CN: &str = "wss://openapi-trade.longbridge.cn/v2";
 pub const OPEN_URL_CN: &str = "https://open.longbridge.cn";
 
-// Test environment URLs (openapi.longbridge.xyz)
-pub const HTTP_URL_TEST: &str = "https://openapi.longbridge.xyz";
-pub const QUOTE_WS_URL_TEST: &str = "wss://openapi-quote.longbridge.xyz/v2";
+// Test environment URLs (openapi-global.longbridge.xyz). The HTTP host is the
+// `-global` gateway, which performs `x-dc-region` data-center routing.
+pub const HTTP_URL_TEST: &str = "https://openapi-global.longbridge.xyz";
+pub const QUOTE_WS_URL_TEST: &str = "wss://openapi-global-quote.longbridge.xyz/v2";
 pub const TRADE_WS_URL_TEST: &str = "wss://openapi-trade.longbridge.xyz/v2";
 
 /// Whether the staging environment is active (`LONGBRIDGE_ENV=staging`).


### PR DESCRIPTION
## What

Adds US data-center support across login and API routing.

- `auth login` (device flow) can authorize a US account: the device/user code is created once and polled on both data centers, and the resulting token routes back to the matching DC.
- `auth login --auth-code <CODE>` works for US-issued ConnectAI codes.
- `auth status` shows the active **DC Region** (`us`/`ap`) in both pretty and `--format json` output.
- All authenticated requests carry the `x-dc-region` header derived from the token's `us_`/`ap_` prefix, so US tokens reach the US data center.

## Notes

- Staging API host moved to the `-global` gateway (`openapi-global.longbridge.xyz`, quote WS `openapi-global-quote.longbridge.xyz`).
- Depends on **openapi#554** (`feat/us-dc-region`): the `longbridge` dependency points at that branch until it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)