### PR TITLE
cli: Migrate `quant run` to the v2 API with Navi support

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1415,11 +1415,13 @@ pub enum Commands {
 }
 
 #[derive(Subcommand)]
+// Backticks are rendered literally in `--help`, so PineScript stays bare here.
+#[allow(clippy::doc_markdown)]
 pub enum QuantCmd {
     /// Run a quant indicator script against historical K-line data on the server
     ///
     /// Executes the script server-side and returns the computed indicator/plot values as JSON.
-    /// Scripts default to Navi (.nv); pass --language pine for `PineScript`.
+    /// Scripts are written in Navi (.nv); pass --language pine for PineScript compatibility.
     ///
     /// Periods: 1m  5m  15m  30m  1h  day  week  month  year
     ///
@@ -1455,7 +1457,9 @@ pub enum QuantCmd {
         /// Must match the order of input.*() calls in the script.
         #[arg(long)]
         input: Option<String>,
-        /// Script language: navi or pine (default: navi)
+        // Backticks are rendered literally in `--help`, so PineScript stays bare here.
+        #[allow(clippy::doc_markdown)]
+        /// Script language: `navi` (default), or `pine` for PineScript compatibility
         #[arg(long, default_value = "navi")]
         language: String,
     },

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1326,7 +1326,7 @@ pub enum Commands {
     ///
     /// Subcommands: run
     /// Example: longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31 --script "..."
-    /// Example: cat script.pine | longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31
+    /// Example: cat script.nv | longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31
     Quant {
         #[command(subcommand)]
         cmd: QuantCmd,
@@ -1419,22 +1419,23 @@ pub enum QuantCmd {
     /// Run a quant indicator script against historical K-line data on the server
     ///
     /// Executes the script server-side and returns the computed indicator/plot values as JSON.
-    /// The script language is compatible with `PineScript` V6 syntax (minor exceptions may apply).
+    /// Scripts default to Navi (.nv); pass --language pine for `PineScript`.
     ///
     /// Periods: 1m  5m  15m  30m  1h  day  week  month  year
     ///
     /// Script source (--script takes priority over stdin):
     ///   --script TEXT   inline script text
-    ///   stdin           cat script.pine | longbridge quant run TSLA.US ...
+    ///   stdin           cat script.nv | longbridge quant run TSLA.US ...
     ///
     /// The optional --input flag accepts a JSON array matching the
     /// order of input.*() calls in the script, e.g. --input '[14,2.0]'
     ///
     /// Example: longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31 --script "..."
-    /// Example: cat script.pine | longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31
+    /// Example: cat script.nv | longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31
     /// Example: longbridge quant run 700.HK --period 1h --start 2024-01-01 --end 2024-06-30 --script "..." --input '[14]'
     /// Example: longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31 --script "..." --format json
     /// Example: longbridge quant run 700.HK --period 1m --start "2024-01-02 09:30" --end "2024-01-02 16:00" --script "..."
+    /// Example: cat script.pine | longbridge quant run TSLA.US --start 2024-01-01 --end 2024-12-31 --language pine
     Run {
         /// Symbol in <CODE>.<MARKET> format, e.g. TSLA.US 700.HK
         symbol: String,
@@ -1454,6 +1455,9 @@ pub enum QuantCmd {
         /// Must match the order of input.*() calls in the script.
         #[arg(long)]
         input: Option<String>,
+        /// Script language: navi or pine (default: navi)
+        #[arg(long, default_value = "navi")]
+        language: String,
     },
 }
 
@@ -3815,7 +3819,13 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
                 end,
                 script,
                 input,
-            } => run_script::cmd_run_script(symbol, &period, &start, &end, script, input, format, verbose).await,
+                language,
+            } => {
+                run_script::cmd_run_script(
+                    symbol, &period, &start, &end, script, input, &language, format, verbose,
+                )
+                .await
+            }
         },
 
         Commands::FinancialStatement { symbol, kind, report } => {

--- a/src/cli/quant_render.rs
+++ b/src/cli/quant_render.rs
@@ -70,17 +70,30 @@ fn extract_series(chart_json_raw: &Value) -> Vec<Series> {
         chart_json_raw.clone()
     };
 
-    let Some(Value::Object(graphs)) = chart_json.get("series_graphs") else {
-        return vec![];
+    // v2 returns `seriesGraphs` as an array; v1 returned `series_graphs` as an
+    // id-keyed object. Normalise both into a plot-ordered node list.
+    let nodes: Vec<&Value> = match (
+        chart_json.get("seriesGraphs"),
+        chart_json.get("series_graphs"),
+    ) {
+        (Some(Value::Array(list)), _) => list.iter().collect(),
+        (_, Some(Value::Object(graphs))) => {
+            let mut keys: Vec<u64> = graphs.keys().filter_map(|k| k.parse().ok()).collect();
+            keys.sort_unstable();
+            keys.into_iter()
+                .filter_map(|k| graphs.get(&k.to_string()))
+                .collect()
+        }
+        _ => return vec![],
     };
 
-    let mut keys: Vec<u64> = graphs.keys().filter_map(|k| k.parse().ok()).collect();
-    keys.sort_unstable();
-
-    keys.into_iter()
-        .filter_map(|k| {
-            let node = graphs.get(&k.to_string())?;
-            let plot = node.get("Plot").unwrap_or(node);
+    nodes
+        .into_iter()
+        .filter_map(|node| {
+            let plot = node
+                .get("plot")
+                .or_else(|| node.get("Plot"))
+                .unwrap_or(node);
             let title = plot
                 .get("title")
                 .and_then(Value::as_str)

--- a/src/cli/run_script.rs
+++ b/src/cli/run_script.rs
@@ -23,6 +23,15 @@ fn period_to_line_type(period: &str) -> Result<i32> {
     }
 }
 
+/// Map CLI language string to the numeric `language` expected by the API.
+/// Anything unrecognised falls back to Navi.
+fn language_to_code(language: &str) -> i32 {
+    match language {
+        "pine" => 1,
+        _ => 0,
+    }
+}
+
 /// Run a quant indicator script against historical K-line data on the server.
 pub async fn cmd_run_script(
     symbol: String,
@@ -31,11 +40,13 @@ pub async fn cmd_run_script(
     end: &str,
     script_arg: Option<String>,
     input: Option<String>,
+    language: &str,
     format: &OutputFormat,
     verbose: bool,
 ) -> Result<()> {
     let counter_id = symbol_to_counter_id(&symbol);
     let line_type = period_to_line_type(period)?;
+    let language = language_to_code(language);
 
     // Parse date strings to seconds-level Unix timestamps.
     let start_time = parse_datetime_start(start)?.unix_timestamp();
@@ -78,6 +89,7 @@ pub async fn cmd_run_script(
         "script": script,
         "inputs_json": input_json,
         "line_type": line_type,
+        "language": language,
         "exclude_chart": exclude_chart,
     });
 
@@ -87,7 +99,7 @@ pub async fn cmd_run_script(
         eprintln!("* start_time: {start_time}  end_time: {end_time}");
     }
 
-    let resp = http_post("/v1/quant/run_script", body, verbose).await?;
+    let resp = http_post("/v2/quant/run_script", body, verbose).await?;
     match format {
         OutputFormat::Json => print_json_value(&resp, format),
         OutputFormat::Pretty => quant_render::render_terminal(&resp),


### PR DESCRIPTION
The quant endpoint moved to `/v2/quant/run_script`, which added Navi as the script language.

## What changed

- **Endpoint**: `/v1/quant/run_script` → `/v2/quant/run_script`
- **New `--language` flag**: `navi` (default) or `pine`. Sent as the numeric `language` field the v2 API expects (`0` = Navi, `1` = Pine). Any unrecognised value falls back to Navi.
- **Chart rendering fix**: v2 renamed the chart payload — `series_graphs` (id-keyed object, `Plot` nodes) became `seriesGraphs` (array, `plot` nodes). Without this, `--format pretty` printed `No chart data in response.` for every script. Both shapes are accepted, so v1 payloads still render.

## Verified against the live API

| Scenario | Result |
| --- | --- |
| Navi script via stdin, no `--language` | ✅ table + sparkline render |
| Navi script, `700.HK` daily | ✅ |
| Navi `strategy()` script, `--format json` | ✅ strategy metadata, inputs, and backtest series returned |
| PineScript + `--language pine` | ✅ |
| `--language foo` → falls back to Navi | ✅ |

## Notes for reviewers

- The `language` field is an **int**, not a string — passing `"navi"` returns `code=13`.
- Script errors still come back as a bare `code=1` / `code=14` with no line number or compiler message, so authoring is best done against `navi lint` locally before hitting the API.
- Skill docs (`developers`, `longbridge-skills`) are updated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)