### PR TITLE
cli: Always reach the US data center via the global endpoint

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -246,6 +246,27 @@ fn oauth_base_url() -> String {
     format!("{}/oauth2", crate::region::http_url())
 }
 
+/// Return the OAuth base URL for an explicit data-center region (`"us"` / `"ap"`).
+///
+/// The US data center is only reachable through the global (`.com`) access
+/// point: `.cn` has no route to it and rejects US requests outright (an
+/// authorization code comes back as `invalid_grant: code not found`) no matter
+/// what `x-dc-region` says — the header selects the DC, it cannot create a
+/// route to one. Region-aware selection still applies to AP, since `.com` may
+/// be unreachable from China Mainland networks.
+fn oauth_base_url_for_region(dc_region: longbridge::DcRegion) -> String {
+    if !crate::region::is_test_env() && dc_region == longbridge::DcRegion::Us {
+        return format!("{}/oauth2", crate::region::HTTP_URL_GLOBAL);
+    }
+    oauth_base_url()
+}
+
+/// Return the OAuth base URL to use for a credential carrying a data-center
+/// prefix (`us_…` / `ap_…`), such as an authorization code or a refresh token.
+fn oauth_base_url_for(credential: &str) -> String {
+    oauth_base_url_for_region(longbridge::DcRegion::from_credential(credential))
+}
+
 /// `/connect` reverse-authorization page URL for the current region.
 fn connect_url() -> String {
     format!("{}/connect", crate::region::open_url())
@@ -347,7 +368,8 @@ pub fn open_browser(url: &str) -> bool {
 /// web page (the region is chosen during web login). We poll both DCs for the
 /// token; the one the user authorized on returns it, and the access token's
 /// `us_`/`ap_` prefix identifies the region.
-const DEVICE_LOGIN_REGIONS: [&str; 2] = ["ap", "us"];
+const DEVICE_LOGIN_REGIONS: [longbridge::DcRegion; 2] =
+    [longbridge::DcRegion::Ap, longbridge::DcRegion::Us];
 
 /// A pending device-authorization request. Created once on AP and synced to US
 /// server-side, so the single `device_code` is valid on both data centers.
@@ -427,13 +449,16 @@ async fn poll_device_token(
     oauth_base: &str,
     client_id: &str,
     device_code: &str,
-    region: &'static str,
+    region: longbridge::DcRegion,
     shared_interval_ms: Arc<AtomicU64>,
     expires_in: u64,
     initial_delay: bool,
     verbose: bool,
 ) -> Result<longbridge::oauth::StoredToken> {
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    // Shadow with the header/display form used throughout this function.
+    let region = region.as_str();
 
     let url = format!("{oauth_base}/token");
     let deadline = Instant::now() + Duration::from_secs(expires_in);
@@ -571,14 +596,23 @@ pub async fn device_login(verbose: bool, client_name: Option<String>) -> Result<
     //
     // The AP poller starts immediately; the US poller waits one interval before its
     // first poll to give the AP→US device-code replication time to complete.
+    //
+    // Each poller talks to its own DC's access point: the US data center is only
+    // reachable via `.com`, so on a CN region the US poller must not inherit the
+    // `.cn` base the device authorization was created on — it would poll a node
+    // with no route to the DC the user may have authorized on.
     let shared_interval_ms = Arc::new(AtomicU64::new(auth.interval.max(1) * 1000));
+    let region_bases: Vec<String> = DEVICE_LOGIN_REGIONS
+        .iter()
+        .map(|&r| oauth_base_url_for_region(r))
+        .collect();
     let mut polls: futures::stream::FuturesUnordered<_> = DEVICE_LOGIN_REGIONS
         .iter()
         .enumerate()
         .map(|(i, &region)| {
             Box::pin(poll_device_token(
                 &http_client,
-                &oauth_base,
+                &region_bases[i],
                 &client_id,
                 &auth.device_code,
                 region,
@@ -669,12 +703,18 @@ pub async fn refresh_if_expired() -> Result<()> {
         .build()
         .context("Failed to build HTTP client for token refresh")?;
 
-    let url = format!("{}/token", oauth_base_url());
-    tracing::debug!("Refreshing expired access token via {url}");
+    // The refresh token carries the same `us_…` / `ap_…` data-center prefix as
+    // the authorization code it came from: a US token can only be refreshed at
+    // `.com`, routed with `x-dc-region`. The prefix is part of the credential
+    // the server stores — send it verbatim.
+    let dc_region = longbridge::DcRegion::from_credential(&refresh_token).as_str();
+    let url = format!("{}/token", oauth_base_url_for(&refresh_token));
+    tracing::debug!("Refreshing expired access token via {url} (x-dc-region={dc_region})");
 
     let dynamic_client_id = effective_client_id();
     let resp = http_client
         .post(&url)
+        .header(longbridge::DC_REGION_HEADER, dc_region)
         .form(&[
             ("grant_type", "refresh_token"),
             ("refresh_token", refresh_token.as_str()),
@@ -891,7 +931,6 @@ pub async fn auth_code_exchange_login(code: &str) -> Result<()> {
         }
     }
 
-    let url = format!("{}/token", oauth_base_url());
     let http_client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(15))
         .build()
@@ -904,9 +943,11 @@ pub async fn auth_code_exchange_login(code: &str) -> Result<()> {
     let saw_client_id = !attempts.is_empty();
     for (exchange_code, client_id) in &attempts {
         // The authorization code carries its data-center region as a prefix
-        // (`us_…` / `ap_…`); route the exchange to that DC via `x-dc-region` so
-        // a US-issued code is validated against the US server (default is AP).
+        // (`us_…` / `ap_…`). It selects both the access point (a `us_` code is
+        // only known to `.com`) and the `x-dc-region` routing header. The
+        // prefix is part of the stored code — send it verbatim, do not strip it.
         let dc_region = longbridge::DcRegion::from_credential(exchange_code).as_str();
+        let url = format!("{}/token", oauth_base_url_for(exchange_code));
         tracing::debug!("Exchanging authorization code via {url} (x-dc-region={dc_region})");
         let send_result = http_client
             .post(&url)


### PR DESCRIPTION
## 问题

US 数据中心只能经全球（`.com`）接入点访问。`.cn` 接入点没有通往它的链路，会直接拒绝 US 请求——授权码返回 `invalid_grant: code not found`——且 `x-dc-region` 头救不了：该头只能**选择**数据中心，无法**创造**一条通往它的路由。

但携带 `us_` 前缀凭证的 OAuth 请求此前仍按缓存的 region 决定 host，因此在 CN region 下，所有 US 账户的登录与刷新都会失败：

| 路径 | 问题 |
|---|---|
| `auth login --auth-code <CODE>` | US 授权码被发往 `.cn`，报 `code not found`，而错误提示会误导为「码已过期或被使用过」 |
| Token 刷新 | US refresh token 被发往 `.cn`，且请求**完全没有** `x-dc-region` 头 |
| Device flow | 两个 poller 共用一个 base URL，CN region 下 US poller 轮询的节点没有通往 US DC 的路由 |

## 改动

按**数据中心**而非缓存 region 选择接入点。新增 `oauth_base_url_for_region(DcRegion)`，US → `.com`，AP → 跟随 region（`.com` 在中国大陆网络可能不可达），`LONGBRIDGE_ENV=staging` 仍然最高优先级。

**Device flow 的双轮询保留不变**——登录完全可能落在 AP。两个 poller、select 逻辑、`shared_interval_ms`、AP 先起 / US 延迟一个 interval 的时序全部原样，**只有各自访问的接入点变了，AP 路径逐字节未变**。事实上改之前 CN 网络下的 US poller 永远等不到 token，双轮询已退化成单轮询，这个改动才让它真正是"两边都轮询"。

## `us_` 前缀不能剥离

对这些 OAuth grant 而言，`us_` 前缀是服务端存储的凭证的组成部分，必须原样发送——这与业务 API 的 `Authorization: Bearer` 头相反（那里必须 strip）。

对线上服务器实测确认，同一个授权码：

| host | redirect_uri | code | 结果 |
|---|---|---|---|
| `.cn` | `.cn` | 带 `us_` | 400 code not found ← 修复前的行为 |
| `.cn` | `.com` | 带 `us_` | 400 code not found |
| `.cn` | `.com` | 裸 | 400 code not found |
| `.com` | `.com` | **裸** | 400 code not found |
| `.com` | `.com` | **带 `us_`** | **200 ✅** |

## 验证

- `auth-code` 交换路径已实测：debug 日志确认请求从 `https://openapi.longbridge.cn/oauth2/token` 切到 `https://openapi.longbridge.com/oauth2/token`（`x-dc-region=us`），且上表 E 组在真实服务器上换回了 token。
- **刷新与 device flow 两条路径未做端到端实测**，改动依据是与 `auth-code` 相同的路由规则和同样带 `us_` 前缀的凭证。
- 业务 API 端点（`openapi::context`）本就已正确处理（`is_cn_cached() && !token_dc_is_us(...)`），未改动。

## 已知遗留

`connect_url()` 仍跟随 region，所以 CN region 下的错误提示会把用户引向 `https://open.longbridge.cn/connect`——而 `.cn` 连接页无法授权 US 账户。交换失败时其实已经能从 code 解析出 DC，可据此给出正确站点。不在本 PR 范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)