### PR TITLE
chore: Document which access point can serve each data center

### DIFF
--- a/src/region.rs
+++ b/src/region.rs
@@ -24,6 +24,27 @@ const GEOTEST_TIMEOUT_SECS: u64 = 3;
 //   - Access point (`.cn` / `.com`) — this module, network routing.
 //   - Data center (`ap` / `us`)     — the `x-dc-region` header, selects the
 //     account's data center and determines which US-only APIs are available.
+//
+// The two are not freely combinable. A credential's prefix (`us_…` / `ap_…`,
+// see `longbridge::DcRegion::from_credential`) fixes which access points can
+// serve it:
+//
+//   | Data center | `.com`                             | `.cn` |
+//   |-------------|------------------------------------|-------|
+//   | `us`        | yes — the only usable access point | no    |
+//   | `ap`        | yes                                | yes   |
+//
+// `.cn` has no path to the US data center. This is a hard constraint, not a
+// latency preference: a US token sent to `.cn` still authenticates, and basic
+// calls such as `static_info` succeed, but every market-data request comes back
+// `301604 no quote access` because `.cn` cannot source US-account quotes. The
+// error reads like a missing permission and is not one.
+//
+// So a US-data-center token must be pinned to the global endpoints regardless
+// of where the client sits — see the `token_dc_is_us` guard in
+// `openapi::init_contexts`, which keeps US tokens off the CN branch even when
+// the cached geotest says China Mainland. AP tokens take the nearer access
+// point, since both serve them.
 
 // Global endpoint URLs
 pub const HTTP_URL_GLOBAL: &str = "https://openapi.longbridge.com";


### PR DESCRIPTION
## 背景

排查「US 账户通过 MCP 拿不到行情」时绕了很久：`quote` / `candlesticks` 全部报 `301604 no quote access`，看起来像账户没开通行情权限，但同一个 token 用 CLI 就完全正常。

真因是访问点选错了 —— US 数据中心的 token 被送到了 `.cn` 节点。CLI 本来就有 `token_dc_is_us` 守卫挡着，所以没事；但这条规则只体现在代码分支里，没有写下来。

## 内容

在 `src/region.rs` 已有的「access point 与 data center 是两个概念」那段后面，补上二者的可达关系：

| Data center | `.com` | `.cn` |
|---|---|---|
| `us` | 唯一可用 | ✗ |
| `ap` | ✓ | ✓ |

同时记下这个失败为什么难认：US token 打 `.cn` 不会 401，WS 照常握手、`static_info` 照常返回，只有行情请求报 `301604`，报错长得像权限缺失。

纯文档，无行为变更。

## 相关

longbridge-mcp#98 修的是 MCP server 缺少同款 pin 逻辑，两边文档措辞保持一致。