### PR TITLE
tui: Polish visuals — rounded borders, weight hierarchy, distribution bar

### DIFF
--- a/src/tui/systems/orders.rs
+++ b/src/tui/systems/orders.rs
@@ -932,6 +932,7 @@ fn make_orders_table<'a>(
     let border_style = styles::border();
     let mut block = Block::default()
         .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(border_style)
         .title(title);
     if let Some(hints) = bottom_hints {
@@ -1245,6 +1246,7 @@ pub fn render_order_entry_popup(frame: &mut Frame, rect: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(side_style)
         .title(Line::from(vec![
             Span::raw(format!(" {} — ", t!("Trade.PlaceOrder"))),
@@ -1434,6 +1436,7 @@ pub fn render_cancel_order_popup(frame: &mut Frame, rect: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(styles::border())
         .title(format!(" {} ", t!("CancelOrder.Title")));
 
@@ -1488,6 +1491,7 @@ pub fn render_replace_order_popup(frame: &mut Frame, rect: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(styles::border())
         .title(format!(" {} ", t!("ReplaceOrder.Title")))
         .title_bottom(
@@ -1618,6 +1622,7 @@ pub fn render_date_filter_popup(frame: &mut Frame, rect: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(styles::border())
         .title(format!(" {} ", t!("Orders.DateFilterTitle")))
         .title_bottom(

--- a/src/tui/systems/portfolio.rs
+++ b/src/tui/systems/portfolio.rs
@@ -131,11 +131,13 @@ pub fn render_portfolio(
                 .borders(Borders::ALL)
                 .border_type(ratatui::widgets::BorderType::Rounded)
                 .border_style(styles::border())
-                .title(format!(
-                    " {} ({}) ─── Refresh [r] ",
-                    t!("Portfolio.Title"),
-                    overview.currency
-                ))
+                .title(Line::from(vec![
+                    Span::styled(
+                        format!(" {} ({}) ", t!("Portfolio.Title"), overview.currency),
+                        styles::title(),
+                    ),
+                    Span::styled("─── Refresh [r] ", styles::dark_gray()),
+                ]))
                 .title_bottom(
                     Line::from(Span::styled(
                         format!(" {} ", t!("Portfolio.QuoteDisclaimer")),

--- a/src/tui/systems/portfolio.rs
+++ b/src/tui/systems/portfolio.rs
@@ -100,6 +100,7 @@ pub fn render_portfolio(
                     .block(
                         Block::default()
                             .borders(Borders::ALL)
+                            .border_type(ratatui::widgets::BorderType::Rounded)
                             .border_style(styles::border()),
                     ),
                 content_rect,
@@ -128,6 +129,7 @@ pub fn render_portfolio(
         {
             let overview_block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(ratatui::widgets::BorderType::Rounded)
                 .border_style(styles::border())
                 .title(format!(
                     " {} ({}) ─── Refresh [r] ",
@@ -158,7 +160,7 @@ pub fn render_portfolio(
 
             // Split inner area: 3-column overview + 1 distribution row
             let inner_vertical = Layout::default()
-                .constraints([Constraint::Min(3), Constraint::Length(1)])
+                .constraints([Constraint::Min(3), Constraint::Length(2)])
                 .direction(Direction::Vertical)
                 .split(inner_area);
 
@@ -200,14 +202,28 @@ pub fn render_portfolio(
             let middle_items = vec![
                 ListItem::new(Line::from(vec![
                     Span::styled(format!("{}: ", t!("Portfolio.P/L")), styles::label()),
-                    Span::styled(format!("{:+.2}", overview.total_pl), pl_style),
+                    Span::styled(
+                        format!(
+                            "{}{:+.2}",
+                            styles::trend_arrow(overview.total_pl.cmp(&Decimal::ZERO)),
+                            overview.total_pl
+                        ),
+                        pl_style,
+                    ),
                 ])),
                 ListItem::new(Line::from(vec![
                     Span::styled(
                         format!("{}: ", t!("Portfolio.Intraday P/L")),
                         styles::label(),
                     ),
-                    Span::styled(format!("{:+.2}", overview.total_today_pl), today_pl_style),
+                    Span::styled(
+                        format!(
+                            "{}{:+.2}",
+                            styles::trend_arrow(overview.total_today_pl.cmp(&Decimal::ZERO)),
+                            overview.total_today_pl
+                        ),
+                        today_pl_style,
+                    ),
                 ])),
                 ListItem::new(Line::from(vec![
                     Span::styled(
@@ -281,21 +297,41 @@ pub fn render_portfolio(
                 entries.push(("Cash".to_string(), overview.total_cash, None));
                 entries.sort_by_key(|b| std::cmp::Reverse(b.1));
 
-                let mut spans: Vec<Span> = Vec::new();
+                // Two rows: a stacked proportion bar, then the legend below it.
+                let dist_rows = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Length(1), Constraint::Length(1)])
+                    .split(inner_vertical[1]);
+
+                // Row 0: one colored block segment per entry, widths
+                // proportional to value and summing to the row width.
+                let values: Vec<Decimal> = entries.iter().map(|(_, v, _)| *v).collect();
+                let seg_total: Decimal = values.iter().copied().sum();
+                let widths = distribution_segments(&values, seg_total, dist_rows[0].width);
+                let bar_spans: Vec<Span> = entries
+                    .iter()
+                    .zip(widths)
+                    .filter(|(_, w)| *w > 0)
+                    .map(|((_, _, market_opt), w)| {
+                        let color = (*market_opt).map_or(Color::Green, styles::market_color);
+                        Span::styled("█".repeat(w as usize), Style::default().fg(color))
+                    })
+                    .collect();
+                frame.render_widget(Paragraph::new(Line::from(bar_spans)), dist_rows[0]);
+
+                // Row 1: legend — colored dot + label + percent.
+                let mut legend: Vec<Span> = Vec::new();
                 for (label, value, market_opt) in &entries {
                     let pct = value / total * Decimal::ONE_HUNDRED;
-                    let dot_style = if let Some(m) = market_opt {
-                        styles::market(*m)
-                    } else {
-                        Style::default().fg(Color::Green)
-                    };
-                    spans.push(Span::styled("● ", dot_style));
-                    spans.push(Span::styled(
+                    let dot_style =
+                        market_opt.map_or(Style::default().fg(Color::Green), styles::market);
+                    legend.push(Span::styled("● ", dot_style));
+                    legend.push(Span::styled(
                         format!("{label} {pct:.1}%  "),
                         styles::label(),
                     ));
                 }
-                frame.render_widget(Paragraph::new(Line::from(spans)), inner_vertical[1]);
+                frame.render_widget(Paragraph::new(Line::from(legend)), dist_rows[1]);
             }
         }
 
@@ -303,6 +339,7 @@ pub fn render_portfolio(
         {
             let holdings_block = Block::default()
                 .borders(Borders::ALL)
+                .border_type(ratatui::widgets::BorderType::Rounded)
                 .border_style(styles::border())
                 .title(format!(" {} ", t!("Holding.Holding")))
                 .title_bottom(
@@ -510,6 +547,63 @@ pub struct View {
     pub overview: Overview,
     pub market_portfolio: HashMap<Market, MarketPortfolio>,
     pub cash_balance: CashBalance,
+}
+
+/// Split `values` into integer column widths proportional to each value,
+/// summing exactly to `width` (largest-remainder apportionment). Used to draw
+/// the asset-distribution bar without rounding drift.
+#[allow(clippy::cast_sign_loss)] // ratios are clamped non-negative before flooring
+fn distribution_segments(values: &[Decimal], total: Decimal, width: u16) -> Vec<u16> {
+    use rust_decimal::prelude::ToPrimitive;
+    if width == 0 || total <= Decimal::ZERO {
+        return vec![0; values.len()];
+    }
+    let w = f64::from(width);
+    let total_f = total.to_f64().unwrap_or(1.0);
+    let raw: Vec<f64> = values
+        .iter()
+        .map(|v| v.to_f64().unwrap_or(0.0).max(0.0) / total_f * w)
+        .collect();
+    let mut out: Vec<u16> = raw.iter().map(|r| r.floor() as u16).collect();
+    let assigned: u16 = out.iter().copied().sum();
+    let mut remainder = width.saturating_sub(assigned);
+    let mut order: Vec<usize> = (0..raw.len()).collect();
+    order.sort_by(|&a, &b| {
+        (raw[b] - raw[b].floor())
+            .partial_cmp(&(raw[a] - raw[a].floor()))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    for i in order {
+        if remainder == 0 {
+            break;
+        }
+        out[i] += 1;
+        remainder -= 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::distribution_segments;
+    use rust_decimal::Decimal;
+
+    #[test]
+    fn distribution_segments_sum_to_width() {
+        let values = [Decimal::from(50), Decimal::from(30), Decimal::from(20)];
+        let segs = distribution_segments(&values, Decimal::from(100), 10);
+        assert_eq!(segs.iter().copied().sum::<u16>(), 10);
+        assert_eq!(segs, vec![5, 3, 2]);
+    }
+
+    #[test]
+    fn distribution_segments_handles_zero_total() {
+        let values = [Decimal::ZERO, Decimal::ZERO];
+        assert_eq!(
+            distribution_segments(&values, Decimal::ZERO, 10),
+            vec![0, 0]
+        );
+    }
 }
 
 pub async fn fetch_holdings() -> anyhow::Result<Vec<Counter>> {

--- a/src/tui/systems/stock_detail.rs
+++ b/src/tui/systems/stock_detail.rs
@@ -249,6 +249,7 @@ pub(crate) fn stock_detail(
     let detail_container = Block::default()
         .title(Line::from(titles))
         .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(styles::border());
 
     // draw border

--- a/src/tui/systems/stock_news.rs
+++ b/src/tui/systems/stock_news.rs
@@ -306,6 +306,7 @@ fn render_news_list(frame: &mut Frame, rect: Rect, compact: bool) {
     let block = Block::default()
         .title(format!(" {title_str} "))
         .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(styles::border());
     frame.render_widget(block, rect);
 
@@ -395,6 +396,7 @@ pub fn render_news_detail_view(frame: &mut Frame, rect: Rect) {
     let block = Block::default()
         .title(format!(" {detail_title} "))
         .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(styles::border());
     frame.render_widget(block, chunks[1]);
 

--- a/src/tui/systems/watchlist.rs
+++ b/src/tui/systems/watchlist.rs
@@ -151,6 +151,7 @@ pub fn watch(frame: &mut Frame, rect: Rect, full_mode: bool) {
 
     let background = Block::default()
         .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(styles::border())
         .title(format!(" {} ─── {}[g] ", t!("Watchlist"), group_name))
         .title_bottom(
@@ -211,6 +212,7 @@ fn banner(frame: &mut Frame, rect: Rect) {
     frame.render_widget(
         Block::default()
             .borders(Borders::ALL)
+            .border_type(ratatui::widgets::BorderType::Rounded)
             .border_style(styles::border()),
         rect,
     );

--- a/src/tui/systems/watchlist.rs
+++ b/src/tui/systems/watchlist.rs
@@ -153,7 +153,10 @@ pub fn watch(frame: &mut Frame, rect: Rect, full_mode: bool) {
         .borders(Borders::ALL)
         .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(styles::border())
-        .title(format!(" {} ─── {}[g] ", t!("Watchlist"), group_name))
+        .title(Line::from(vec![
+            Span::styled(format!(" {} ", t!("Watchlist")), styles::title()),
+            Span::styled(format!("─── {group_name}[g] "), styles::dark_gray()),
+        ]))
         .title_bottom(
             Line::from(vec![
                 Span::styled(format!(" {} ", t!("Trade.BuyKey")), styles::dark_gray()),

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -1,6 +1,8 @@
 pub mod assets;
 mod content;
 pub mod rect;
+#[cfg(test)]
+mod snapshot;
 pub mod styles;
 pub mod text;
 

--- a/src/tui/ui/snapshot.rs
+++ b/src/tui/ui/snapshot.rs
@@ -1,0 +1,127 @@
+//! Headless UI snapshot exporter (dev-only, test-gated).
+//!
+//! Renders view components into an in-memory `TestBackend` buffer (no terminal,
+//! no auth, no network) and exports the buffer to a self-contained HTML file
+//! that approximates a dark terminal. This lets visuals be inspected/iterated
+//! without a live TUI: run `cargo test ui_snapshot -- --nocapture`, then open
+//! (or screenshot) the generated files under `target/ui-snapshots/`.
+
+#![cfg(test)]
+
+use ratatui::buffer::Buffer;
+use ratatui::style::{Color, Modifier};
+
+const PAGE_BG: &str = "#0d0d0d";
+const PAGE_FG: &str = "#c8ccd4";
+
+/// Map a ratatui color to a CSS color for a typical dark terminal.
+/// Returns `None` for `Reset` (caller substitutes the default fg/bg).
+fn css_color(c: Color) -> Option<String> {
+    let s = match c {
+        Color::Reset => return None,
+        Color::Black => "#0c0c0c",
+        Color::Red => "#c05a5a",
+        Color::Green => "#5fae7f",
+        Color::Yellow => "#c8a35a",
+        Color::Blue => "#5a8ac8",
+        Color::Magenta => "#a05aa0",
+        Color::Cyan => "#5aa0a0",
+        Color::Gray => "#a6acb8",
+        Color::DarkGray => "#585c66",
+        Color::LightRed => "#f06c7a",
+        Color::LightGreen => "#7bd88f",
+        Color::LightYellow => "#e6c07b",
+        Color::LightBlue => "#7aa2f7",
+        Color::LightMagenta => "#c792ea",
+        Color::LightCyan => "#7fdbca",
+        Color::White => "#e6e6e6",
+        Color::Rgb(r, g, b) => return Some(format!("#{r:02x}{g:02x}{b:02x}")),
+        Color::Indexed(_) => "#a6acb8",
+    };
+    Some(s.to_string())
+}
+
+fn esc(sym: &str) -> String {
+    sym.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+}
+
+/// Serialize a rendered buffer to a standalone HTML page.
+fn buffer_to_html(buf: &Buffer, title: &str) -> String {
+    let area = buf.area();
+    let mut body = String::new();
+    for y in 0..area.height {
+        for x in 0..area.width {
+            let cell = buf.cell((area.x + x, area.y + y)).expect("cell in bounds");
+            let sym = cell.symbol();
+            // Skip wide-glyph continuation cells (empty symbol) so CJK keeps
+            // its natural 2-column width in a monospace font.
+            if sym.is_empty() {
+                continue;
+            }
+            let st = cell.style();
+            let mut fg = st.fg.and_then(css_color);
+            let mut bg = st.bg.and_then(css_color);
+            if st.add_modifier.contains(Modifier::REVERSED) {
+                std::mem::swap(&mut fg, &mut bg);
+                fg = Some(fg.unwrap_or_else(|| PAGE_BG.to_string()));
+                bg = Some(bg.unwrap_or_else(|| PAGE_FG.to_string()));
+            }
+            let mut style = String::new();
+            if let Some(fg) = fg {
+                style.push_str(&format!("color:{fg};"));
+            }
+            if let Some(bg) = bg {
+                style.push_str(&format!("background:{bg};"));
+            }
+            if st.add_modifier.contains(Modifier::BOLD) {
+                style.push_str("font-weight:700;");
+            }
+            if st.add_modifier.contains(Modifier::DIM) {
+                style.push_str("opacity:.6;");
+            }
+            body.push_str(&format!("<span style=\"{style}\">{}</span>", esc(sym)));
+        }
+        body.push('\n');
+    }
+    format!(
+        "<!doctype html><meta charset=\"utf-8\"><title>{title}</title>\
+<style>body{{margin:0;background:{PAGE_BG};}}\
+pre{{margin:0;padding:16px;color:{PAGE_FG};background:{PAGE_BG};\
+font:15px/1.2 'Menlo','DejaVu Sans Mono','Consolas',monospace;\
+white-space:pre;display:inline-block;letter-spacing:0;}}</style>\
+<pre>{body}</pre>"
+    )
+}
+
+fn out_dir() -> std::path::PathBuf {
+    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/ui-snapshots");
+    std::fs::create_dir_all(&dir).expect("create snapshot dir");
+    dir
+}
+
+/// Render a view via a `TestBackend` of the given size and write it to
+/// `target/ui-snapshots/<name>.html`.
+fn snapshot<F>(name: &str, width: u16, height: u16, draw: F)
+where
+    F: FnOnce(&mut ratatui::Frame),
+{
+    let backend = ratatui::backend::TestBackend::new(width, height);
+    let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+    terminal.draw(|f| draw(f)).expect("draw");
+    let buf = terminal.backend().buffer().clone();
+    let html = buffer_to_html(&buf, name);
+    let path = out_dir().join(format!("{name}.html"));
+    std::fs::write(&path, html).expect("write snapshot");
+    println!("ui-snapshot: {}", path.display());
+}
+
+#[test]
+fn ui_snapshot_export() {
+    rust_i18n::set_locale("en");
+
+    // Navbar (top bar) on the Orders screen — proves the pipeline end-to-end
+    // with no fixtures (reads only global keymap + default account channel).
+    snapshot("navbar", 150, 1, |f| {
+        crate::tui::views::navbar::render(f, f.area(), crate::tui::app::AppState::Orders);
+    });
+}

--- a/src/tui/ui/styles.rs
+++ b/src/tui/ui/styles.rs
@@ -11,7 +11,10 @@ use crate::utils::Sign;
 
 #[inline]
 pub fn header() -> Style {
-    Style::default().fg(Color::Gray)
+    // Bold table headers to lift them off the data rows below.
+    Style::default()
+        .fg(Color::Gray)
+        .add_modifier(Modifier::BOLD)
 }
 
 #[inline]
@@ -49,6 +52,13 @@ pub fn keyboard() -> Style {
     text()
 }
 
+/// Style for the `[key]` part of a shortcut hint — brighter + bold so the key
+/// stands out from its dimmed description (Grok-style hint hierarchy).
+#[inline]
+pub fn hint_key() -> Style {
+    gray().add_modifier(Modifier::BOLD)
+}
+
 #[inline]
 pub fn popup() -> Style {
     text()
@@ -56,7 +66,8 @@ pub fn popup() -> Style {
 
 #[inline]
 pub fn title() -> Style {
-    text()
+    // Bold titles give panels/modals a clear visual anchor.
+    text().add_modifier(Modifier::BOLD)
 }
 
 #[inline]
@@ -70,15 +81,19 @@ pub fn active_border() -> Style {
 }
 
 #[inline]
-pub fn market(m: Market) -> Style {
+pub fn market_color(m: Market) -> Color {
     use crate::data::Market as M;
-    let color = match m {
+    match m {
         M::US => Color::Blue,
         M::HK => Color::Magenta,
         M::CN => Color::Red,
         M::SG => Color::Cyan,
-    };
-    Style::default().fg(color)
+    }
+}
+
+#[inline]
+pub fn market(m: Market) -> Style {
+    Style::default().fg(market_color(m))
 }
 
 #[inline]
@@ -87,6 +102,17 @@ pub fn up(val: Ordering) -> Style {
         Ordering::Less => bull_bear().1,
         Ordering::Equal => Style::default().fg(Color::Reset),
         Ordering::Greater => bull_bear().0,
+    }
+}
+
+/// Direction glyph for a value's sign — a quick up/down cue, independent of the
+/// red/green color convention (▲ = up, ▼ = down, empty = flat).
+#[inline]
+pub fn trend_arrow(val: Ordering) -> &'static str {
+    match val {
+        Ordering::Greater => "▲ ",
+        Ordering::Less => "▼ ",
+        Ordering::Equal => "",
     }
 }
 
@@ -232,4 +258,17 @@ pub fn offline() -> Style {
 
 pub fn bmp() -> Style {
     Style::default().fg(Color::Yellow)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::trend_arrow;
+    use std::cmp::Ordering;
+
+    #[test]
+    fn trend_arrow_directions() {
+        assert_eq!(trend_arrow(Ordering::Greater), "▲ ");
+        assert_eq!(trend_arrow(Ordering::Less), "▼ ");
+        assert_eq!(trend_arrow(Ordering::Equal), "");
+    }
 }

--- a/src/tui/views/help.rs
+++ b/src/tui/views/help.rs
@@ -26,6 +26,7 @@ pub fn render(frame: &mut Frame, rect: Rect) {
     let paragraph = Paragraph::new(spans).style(styles::popup()).block(
         Block::default()
             .borders(Borders::ALL)
+            .border_type(ratatui::widgets::BorderType::Rounded)
             .border_style(styles::border())
             .padding(Padding::horizontal(2))
             .title(Span::styled(t!("Help"), styles::title())),

--- a/src/tui/views/navbar.rs
+++ b/src/tui/views/navbar.rs
@@ -53,7 +53,15 @@ pub fn render(frame: &mut Frame, rect: Rect, state: AppState) {
         if i > 0 {
             spans.push(Span::styled(" ", dark_gray_style));
         }
-        spans.push(Span::styled(t!(action.label).to_string(), dark_gray_style));
+        // Split "Name [key]" into a dim label + a bold key.
+        let label = t!(action.label).to_string();
+        if let Some(open) = label.rfind('[') {
+            let (name, key) = label.split_at(open);
+            spans.push(Span::styled(name.to_string(), dark_gray_style));
+            spans.push(Span::styled(key.to_string(), styles::hint_key()));
+        } else {
+            spans.push(Span::styled(label, dark_gray_style));
+        }
     }
     let user_info = Paragraph::new(Line::from(spans)).alignment(Alignment::Right);
 

--- a/src/tui/views/popup.rs
+++ b/src/tui/views/popup.rs
@@ -56,6 +56,7 @@ fn switch_account(frame: &mut Frame, rect: Rect, account: &mut LocalSearch<crate
     let paragraph = Paragraph::new(input.value()).block(
         Block::default()
             .borders(Borders::ALL)
+            .border_type(ratatui::widgets::BorderType::Rounded)
             .border_style(styles::border())
             .title(t!("SwitchAccount.title")),
     );
@@ -86,6 +87,7 @@ fn switch_account(frame: &mut Frame, rect: Rect, account: &mut LocalSearch<crate
         .block(
             Block::default()
                 .borders(Borders::all())
+                .border_type(ratatui::widgets::BorderType::Rounded)
                 .border_style(styles::border()),
         )
         .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
@@ -115,6 +117,7 @@ fn switch_currency(
     let paragraph = Paragraph::new(input.value()).block(
         Block::default()
             .borders(Borders::ALL)
+            .border_type(ratatui::widgets::BorderType::Rounded)
             .border_style(styles::border())
             .title(t!("SwitchCurrency.title")),
     );
@@ -145,6 +148,7 @@ fn switch_currency(
         .block(
             Block::default()
                 .borders(Borders::all())
+                .border_type(ratatui::widgets::BorderType::Rounded)
                 .border_style(styles::border()),
         )
         .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
@@ -174,6 +178,7 @@ fn switch_watchlist(
     let paragraph = Paragraph::new(input.value()).block(
         Block::default()
             .borders(Borders::ALL)
+            .border_type(ratatui::widgets::BorderType::Rounded)
             .border_style(styles::border())
             .title(t!("SwitchWatchlist.title")),
     );
@@ -204,6 +209,7 @@ fn switch_watchlist(
         .block(
             Block::default()
                 .borders(Borders::all())
+                .border_type(ratatui::widgets::BorderType::Rounded)
                 .border_style(styles::border()),
         )
         .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
@@ -222,6 +228,7 @@ fn searching(frame: &mut Frame, rect: Rect, search: &mut Search<openapi::search:
     let paragraph = Paragraph::new(input.value()).block(
         Block::default()
             .borders(Borders::ALL)
+            .border_type(ratatui::widgets::BorderType::Rounded)
             .border_style(styles::border())
             .title(t!("SearchStock.title")),
     );
@@ -257,6 +264,7 @@ fn search_watchlist(frame: &mut Frame, rect: Rect, search: &mut LocalSearch<Coun
     let paragraph = Paragraph::new(input.value()).block(
         Block::default()
             .borders(Borders::ALL)
+            .border_type(ratatui::widgets::BorderType::Rounded)
             .border_style(border_style)
             .title(title),
     );
@@ -289,6 +297,7 @@ fn search_watchlist(frame: &mut Frame, rect: Rect, search: &mut LocalSearch<Coun
         .block(
             Block::default()
                 .borders(Borders::all())
+                .border_type(ratatui::widgets::BorderType::Rounded)
                 .border_style(styles::border()),
         )
         .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))

--- a/src/tui/views/settings.rs
+++ b/src/tui/views/settings.rs
@@ -59,6 +59,7 @@ pub fn render(frame: &mut Frame, rect: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(styles::border())
         .title(Span::styled(t!("settings.title"), styles::title()));
     frame.render_widget(Clear, area);

--- a/src/tui/widgets/log_panel.rs
+++ b/src/tui/widgets/log_panel.rs
@@ -114,6 +114,7 @@ impl LogPanel {
             .title(" Debug Log [`] ")
             .bg(Color::Black)
             .borders(Borders::ALL)
+            .border_type(ratatui::widgets::BorderType::Rounded)
             .border_style(Style::default().fg(Color::Yellow))
             .style(Style::default().bg(Color::Black));
 


### PR DESCRIPTION
Structural visual polish, all using **terminal-native colors** (follows the terminal's own light/dark palette — no custom theme introduced, per the requirement to just follow the terminal).

## What changed
- **Rounded borders** on every panel and modal (was square `Borders::ALL`).
- **Weight hierarchy** — panel/modal titles and table headers are now bold; navbar shortcut hints split into a dim label + a bold `[key]`.
- **Asset-distribution bar** (Portfolio) — the market breakdown row became a stacked proportion bar (colored `█` segments sized by holdings share, each in its market's terminal color) with a legend row below.
- **Trend arrows** — P/L values show ▲/▼ (direction independent of the red/green convention).

## Notes
- No RGB theme / no light-dark setting: colors intentionally follow the terminal so it matches whatever palette the user's terminal uses.
- 3 unit tests added (distribution segment apportionment ×2, trend arrow directions); `cargo clippy` clean; `cargo build` OK.
- Stacked on `feat/tui-keymap-settings` (PR #272) so this diff shows only the visual commit. Visual result should be eyeballed with `cargo run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)