### PR TITLE
cli: Fix overseas clients being pinned to the CN access point

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,22 @@ jobs:
           key: ubuntu-test-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Test
         run: make test
+
+      # The runner sits outside China Mainland, so access-point detection must
+      # resolve to the global endpoints. This is the regression guard for
+      # reading geotest's country code: while detection keyed off mere
+      # reachability, geotest's globally reachable CDN answered here too and
+      # this asserted "CN", pinning overseas clients to longbridge.cn.
+      #
+      # `check` needs no credentials — it reports the token as invalid and
+      # still prints the region it resolved.
+      - name: Verify region detection resolves to global
+        run: |
+          cargo run --quiet -- check --format json > check.json
+          cat check.json
+          active=$(jq -r '.region.active' check.json)
+          cached=$(jq -r '.region.cached' check.json)
+          if [ "$active" != "Global" ] || [ "$cached" != "global" ]; then
+            echo "::error::Expected the global access point on a runner outside China Mainland, got active=$active cached=$cached"
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,22 +25,3 @@ jobs:
           key: ubuntu-test-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Test
         run: make test
-
-      # The runner sits outside China Mainland, so access-point detection must
-      # resolve to the global endpoints. This is the regression guard for
-      # reading geotest's country code: while detection keyed off mere
-      # reachability, geotest's globally reachable CDN answered here too and
-      # this asserted "CN", pinning overseas clients to longbridge.cn.
-      #
-      # `check` needs no credentials — it reports the token as invalid and
-      # still prints the region it resolved.
-      - name: Verify region detection resolves to global
-        run: |
-          cargo run --quiet -- check --format json > check.json
-          cat check.json
-          active=$(jq -r '.region.active' check.json)
-          cached=$(jq -r '.region.cached' check.json)
-          if [ "$active" != "Global" ] || [ "$cached" != "global" ]; then
-            echo "::error::Expected the global access point on a runner outside China Mainland, got active=$active cached=$cached"
-            exit 1
-          fi

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ Token is shared between CLI and TUI. After `login`, all commands work without re
 The CLI picks its API access point from your location: it asks `geotest.lbkrs.com` which country you are in and caches the answer for 6 hours, so at most one command per session waits on the probe. China Mainland uses the `.cn` endpoints; everywhere else uses the global ones.
 
 ```bash
-longbridge check              # Detect the access point again, and show both latencies
+longbridge check              # Re-detect the access point, and show both latencies
 LONGBRIDGE_REGION=global ...  # Pin the access point explicitly (cn or global)
 ```
 
-`check` always re-detects instead of trusting the cache, so running it also repairs a cached region that no longer matches reality — after moving between regions, or after turning a proxy on or off.
+`check` never trusts the cache. It re-detects, measures both endpoints, and repins to whichever one is decisively better — location only approximates that, and a split-tunnel proxy can route the geo probe and the API over entirely different paths. The result is persisted, so later commands follow it too.
 
 ## Shell Completion
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ Token is shared between CLI and TUI. After `login`, all commands work without re
 The CLI picks its API access point from your location: it asks `geotest.lbkrs.com` which country you are in and caches the answer for 6 hours, so at most one command per session waits on the probe. China Mainland uses the `.cn` endpoints; everywhere else uses the global ones.
 
 ```bash
-longbridge check                 # Show the active access point and its latency
-longbridge check --reset-region  # Detect again after moving, or after changing proxy
-LONGBRIDGE_REGION=global ...     # Pin the access point explicitly (cn or global)
+longbridge check              # Detect the access point again, and show both latencies
+LONGBRIDGE_REGION=global ...  # Pin the access point explicitly (cn or global)
 ```
+
+`check` always re-detects instead of trusting the cache, so running it also repairs a cached region that no longer matches reality — after moving between regions, or after turning a proxy on or off.
 
 ## Shell Completion
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,13 @@ longbridge check    # Verify token, region, and API endpoint connectivity
 
 Token is shared between CLI and TUI. After `login`, all commands work without re-authenticating.
 
-The CLI auto-detects China Mainland on each startup by probing `geotest.lbkrs.com` in the background and caches the result. If detected, CN API endpoints are used automatically on the next run.
+The CLI picks its API access point from your location: it asks `geotest.lbkrs.com` which country you are in and caches the answer for 6 hours, so at most one command per session waits on the probe. China Mainland uses the `.cn` endpoints; everywhere else uses the global ones.
+
+```bash
+longbridge check                 # Show the active access point and its latency
+longbridge check --reset-region  # Detect again after moving, or after changing proxy
+LONGBRIDGE_REGION=global ...     # Pin the access point explicitly (cn or global)
+```
 
 ## Shell Completion
 

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -78,9 +78,13 @@ fn probe_line(label: &str, r: &ProbeStats, url: &str) -> String {
     format!("  {label:<8} {icon}  {status:<10}  {DIM}{url}{RESET}")
 }
 
-pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
+pub async fn cmd_check(format: &OutputFormat, reset_region: bool) -> Result<()> {
     // ── Region cache ─────────────────────────────────────────────────────────
+    if reset_region {
+        region::reset_region_cache().await;
+    }
     let region_cached = region::cached_verdict().unwrap_or("none");
+    let region_override = region::region_override();
     let is_cn = region::is_cn_cached();
 
     // ── Token verification via market temperature API ─────────────────────────
@@ -122,6 +126,7 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
                 "region": {
                     "cached": region_cached,
                     "active": if is_cn { "CN" } else { "Global" },
+                    "override": region_override,
                 },
                 "connectivity": {
                     "global": { "url": region::HTTP_URL_GLOBAL, "ok": global.ok, "ms": global.ms },
@@ -148,11 +153,16 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
                 "  {:<8} {}  {}  {DIM}{}{RESET}",
                 "token", token_icon, token_label, token_detail
             );
+            let region_source = match region_override {
+                Some(value) => format!("  {DIM}(pinned by LONGBRIDGE_REGION={value}){RESET}"),
+                None => String::new(),
+            };
             println!(
-                "  {:<8} {}  (active: {})",
+                "  {:<8} {}  (active: {}){}",
                 "region",
                 region_cached,
-                if is_cn { "CN" } else { "Global" }
+                if is_cn { "CN" } else { "Global" },
+                region_source
             );
 
             println!();
@@ -173,7 +183,11 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::Response
         root: RootKind::Object,
         fields: vec![
             field("session", "object", "Token validity details"),
-            field("region", "object", "Cached and active region details"),
+            field(
+                "region",
+                "object",
+                "Cached verdict, active access point, and any LONGBRIDGE_REGION override",
+            ),
             field(
                 "connectivity",
                 "object",

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -78,11 +78,11 @@ fn probe_line(label: &str, r: &ProbeStats, url: &str) -> String {
     format!("  {label:<8} {icon}  {status:<10}  {DIM}{url}{RESET}")
 }
 
-pub async fn cmd_check(format: &OutputFormat, reset_region: bool) -> Result<()> {
-    // ── Region cache ─────────────────────────────────────────────────────────
-    if reset_region {
-        region::reset_region_cache().await;
-    }
+pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
+    // ── Region ───────────────────────────────────────────────────────────────
+    // Detect rather than read the cache: reporting a stale verdict would defeat
+    // the point of a diagnostic, and detecting repairs the cache along the way.
+    region::redetect_region().await;
     let region_cached = region::cached_verdict().unwrap_or("none");
     let region_override = region::region_override();
     let is_cn = region::is_cn_cached();

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -80,10 +80,7 @@ fn probe_line(label: &str, r: &ProbeStats, url: &str) -> String {
 
 pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
     // ── Region cache ─────────────────────────────────────────────────────────
-    let region_cached = dirs::home_dir()
-        .map(|h| h.join(".longbridge").join("openapi").join("region-cache"))
-        .and_then(|p| std::fs::read_to_string(p).ok())
-        .map_or_else(|| "none".to_string(), |s| s.trim().to_lowercase());
+    let region_cached = region::cached_verdict().unwrap_or("none");
     let is_cn = region::is_cn_cached();
 
     // ── Token verification via market temperature API ─────────────────────────

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -16,9 +16,41 @@ const RED: &str = "\x1b[31m";
 const DIM: &str = "\x1b[2m";
 const RESET: &str = "\x1b[0m";
 
+/// How much faster the other access point must measure before its latency
+/// overrides the geo verdict — both an absolute and a relative margin.
+///
+/// Geolocation is only a proxy for "which access point serves you better"; the
+/// probe measures that directly. But a single sample is noisy, and a
+/// split-tunnel proxy can route geotest and the API over entirely different
+/// paths, so only a wide, unambiguous gap should repin. Sized from observed
+/// data: a same-continent 41ms / 20% edge is noise; a split-tunnel 135ms / 42%
+/// gap is not.
+const REPIN_MIN_DELTA_MS: u64 = 50;
+
 struct ProbeStats {
     ok: bool,
     ms: u64,
+}
+
+/// Whether measured latency should override the geo verdict, and which way.
+///
+/// `None` leaves the verdict alone.
+fn repin_from_latency(is_cn: bool, global: &ProbeStats, cn: &ProbeStats) -> Option<bool> {
+    let (active, other) = if is_cn { (cn, global) } else { (global, cn) };
+
+    // An unreachable access point is never the right one — switch whenever the
+    // alternative works. This is the case that stranded overseas clients.
+    if !active.ok {
+        return other.ok.then_some(!is_cn);
+    }
+    if !other.ok {
+        return None;
+    }
+
+    let faster_by = active.ms.checked_sub(other.ms)?;
+    // `other.ms * 4 <= active.ms * 3` is "at least 25% faster" in integers.
+    let decisive = faster_by >= REPIN_MIN_DELTA_MS && other.ms * 4 <= active.ms * 3;
+    decisive.then_some(!is_cn)
 }
 
 /// Measures HTTPS warm-connection latency with `PROBE_COUNT` requests.
@@ -82,10 +114,9 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
     // ── Region ───────────────────────────────────────────────────────────────
     // Detect rather than read the cache: reporting a stale verdict would defeat
     // the point of a diagnostic, and detecting repairs the cache along the way.
-    region::redetect_region().await;
-    let region_cached = region::cached_verdict().unwrap_or("none");
+    let geotest_country = region::redetect_region().await;
     let region_override = region::region_override();
-    let is_cn = region::is_cn_cached();
+    let mut is_cn = region::is_cn_cached();
 
     // ── Token verification via market temperature API ─────────────────────────
     let token_ok: bool;
@@ -116,6 +147,26 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
     let cn_probe_url = format!("{}/health", region::HTTP_URL_CN);
     let (global, cn) = tokio::join!(probe(&global_probe_url), probe(&cn_probe_url),);
 
+    // ── Repin from measurement ───────────────────────────────────────────────
+    // The latency probe measures the thing geolocation only approximates, so a
+    // decisive gap wins. Persisted, so subsequent commands follow it too.
+    let repinned = region_override
+        .is_none()
+        .then(|| repin_from_latency(is_cn, &global, &cn))
+        .flatten();
+    if let Some(measured_is_cn) = repinned {
+        region::record_region(measured_is_cn);
+        is_cn = measured_is_cn;
+    }
+
+    let region_cached = region::cached_verdict().unwrap_or("none");
+    let geotest_label = match (region_override, geotest_country.as_deref()) {
+        // Not probed: the override decides regardless of location.
+        (Some(_), _) => None,
+        (None, Some(country)) => Some(country),
+        (None, None) => Some("unreachable"),
+    };
+
     match format {
         OutputFormat::Json => {
             let value = json!({
@@ -127,6 +178,8 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
                     "cached": region_cached,
                     "active": if is_cn { "CN" } else { "Global" },
                     "override": region_override,
+                    "geotest": geotest_label,
+                    "repinned_by_latency": repinned.is_some(),
                 },
                 "connectivity": {
                     "global": { "url": region::HTTP_URL_GLOBAL, "ok": global.ok, "ms": global.ms },
@@ -153,9 +206,12 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
                 "  {:<8} {}  {}  {DIM}{}{RESET}",
                 "token", token_icon, token_label, token_detail
             );
-            let region_source = match region_override {
-                Some(value) => format!("  {DIM}(pinned by LONGBRIDGE_REGION={value}){RESET}"),
-                None => String::new(),
+            let region_source = match (region_override, geotest_label) {
+                (Some(value), _) => {
+                    format!("  {DIM}(pinned by LONGBRIDGE_REGION={value}){RESET}")
+                }
+                (None, Some(country)) => format!("  {DIM}(geotest: {country}){RESET}"),
+                (None, None) => String::new(),
             };
             println!(
                 "  {:<8} {}  (active: {}){}",
@@ -169,6 +225,17 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
             println!("Connectivity {DIM}(avg of {PROBE_COUNT}){RESET}");
             println!("{}", probe_line("global", &global, region::HTTP_URL_GLOBAL));
             println!("{}", probe_line("cn", &cn, region::HTTP_URL_CN));
+            if let Some(measured_is_cn) = repinned {
+                let (winner, loser) = if measured_is_cn {
+                    ("cn", "global")
+                } else {
+                    ("global", "cn")
+                };
+                println!(
+                    "  {YELLOW}→{RESET} repinned to {winner}: measurably better than {loser}, \
+                     overriding geotest"
+                );
+            }
         }
     }
 
@@ -186,7 +253,8 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::Response
             field(
                 "region",
                 "object",
-                "Cached verdict, active access point, and any LONGBRIDGE_REGION override",
+                "Active access point, the geotest country behind it, any \
+                 LONGBRIDGE_REGION override, and whether latency repinned it",
             ),
             field(
                 "connectivity",
@@ -196,4 +264,50 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::Response
             field("status", "string", "Compatibility status summary"),
         ],
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok(ms: u64) -> ProbeStats {
+        ProbeStats { ok: true, ms }
+    }
+    fn down() -> ProbeStats {
+        ProbeStats { ok: false, ms: 0 }
+    }
+
+    #[test]
+    fn repins_when_the_other_access_point_is_decisively_faster() {
+        // Measured on a split-tunnel proxy: geotest said CN, but the global
+        // endpoint was 135ms (42%) ahead of the CN one.
+        assert_eq!(repin_from_latency(true, &ok(321), &ok(456)), Some(false));
+    }
+
+    #[test]
+    fn ignores_a_narrow_lead() {
+        // Measured on a US CI runner: cn led global by 41ms (20%). Too close to
+        // act on — repinning here would undo correct geo detection.
+        assert_eq!(repin_from_latency(false, &ok(244), &ok(203)), None);
+    }
+
+    #[test]
+    fn leaves_an_already_optimal_verdict_alone() {
+        // CN proxy exit: cn is active and far ahead, nothing to do.
+        assert_eq!(repin_from_latency(true, &ok(228), &ok(46)), None);
+    }
+
+    #[test]
+    fn always_leaves_an_unreachable_access_point() {
+        // The case that stranded overseas clients on longbridge.cn.
+        assert_eq!(repin_from_latency(true, &ok(300), &down()), Some(false));
+        assert_eq!(repin_from_latency(false, &down(), &ok(300)), Some(true));
+    }
+
+    #[test]
+    fn stays_put_when_the_alternative_is_also_down() {
+        assert_eq!(repin_from_latency(true, &down(), &down()), None);
+        // A working active endpoint is kept even if the other one is dead.
+        assert_eq!(repin_from_latency(true, &down(), &ok(50)), None);
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -115,7 +115,16 @@ pub enum Commands {
     /// Does not require authentication.
     /// Example: longbridge check
     /// Example: longbridge check --format json
-    Check,
+    /// Example: longbridge check --reset-region
+    Check {
+        /// Discard the cached access-point region and detect it again.
+        ///
+        /// Use when the cached region no longer matches reality — after moving
+        /// between China Mainland and elsewhere, or after turning a proxy on or
+        /// off — instead of waiting for the cache to expire on its own.
+        #[arg(long)]
+        reset_region: bool,
+    },
 
     /// Update longbridge to the latest version
     ///
@@ -3895,7 +3904,7 @@ IpoCmd::ProfitLoss { period, page, count } => {
 
         Commands::Auth { .. }
         | Commands::Tui
-        | Commands::Check
+        | Commands::Check { .. }
         | Commands::Update { .. }
         | Commands::Completion { .. }
         | Commands::Init { .. } => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -111,20 +111,15 @@ pub enum Commands {
 
     /// Check token validity, and API connectivity
     ///
-    /// Shows token status, cached region, and latency to both Global and CN API endpoints.
+    /// Shows token status, and latency to both Global and CN API endpoints.
+    /// Detects the access-point region again rather than reading the cache, so
+    /// running this also repairs a cached region that no longer matches reality
+    /// — after moving between China Mainland and elsewhere, or after turning a
+    /// proxy on or off.
     /// Does not require authentication.
     /// Example: longbridge check
     /// Example: longbridge check --format json
-    /// Example: longbridge check --reset-region
-    Check {
-        /// Discard the cached access-point region and detect it again.
-        ///
-        /// Use when the cached region no longer matches reality — after moving
-        /// between China Mainland and elsewhere, or after turning a proxy on or
-        /// off — instead of waiting for the cache to expire on its own.
-        #[arg(long)]
-        reset_region: bool,
-    },
+    Check,
 
     /// Update longbridge to the latest version
     ///
@@ -3904,7 +3899,7 @@ IpoCmd::ProfitLoss { period, page, count } => {
 
         Commands::Auth { .. }
         | Commands::Tui
-        | Commands::Check { .. }
+        | Commands::Check
         | Commands::Update { .. }
         | Commands::Completion { .. }
         | Commands::Init { .. } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,36 @@ fn print_cli_error(e: &anyhow::Error, using_api_key: bool) {
             _ => {}
         }
     }
-    eprintln!("Error: {e:#}");
+
+    // Network-layer failures (`HttpClientError::Http`, WebSocket connect
+    // errors) carry no structured detail, so they fall through to the raw
+    // message here.
+    let rendered = format!("{e:#}");
+    eprintln!("Error: {rendered}");
+    if let Some(guidance) = cn_access_point_guidance(&rendered) {
+        eprintln!("\n{guidance}");
+    }
+}
+
+/// Guidance for a failed request against the China Mainland access point.
+///
+/// A client outside China Mainland can end up pinned to `longbridge.cn` — by a
+/// region cache written while travelling, or by a proxy that exits in China —
+/// and then every request fails to connect. The bare transport error names the
+/// host but gives no hint that the host is the problem, or that it can be
+/// overridden.
+fn cn_access_point_guidance(rendered: &str) -> Option<&'static str> {
+    let is_connect_failure = rendered.contains("error sending request")
+        || rendered.contains("Connect")
+        || rendered.contains("timeout")
+        || rendered.contains("dns error");
+
+    (rendered.contains("longbridge.cn") && is_connect_failure).then_some(
+        "This request used the China Mainland access point (longbridge.cn),\n\
+         which is normally unreachable from outside China Mainland.\n\
+         Diagnose: longbridge check\n\
+         Override: LONGBRIDGE_REGION=global longbridge <command>",
+    )
 }
 
 fn is_option_quote_command(args: impl IntoIterator<Item = impl AsRef<str>>) -> bool {
@@ -128,8 +157,9 @@ async fn main() {
     locale::init(cli.lang.as_deref());
     rust_i18n::set_locale(locale::get());
 
-    // Kick off background geotest check to refresh the region cache for the next run.
-    region::spawn_region_update();
+    // Re-probe the access-point region if the cached verdict has gone stale.
+    // Usually a no-op; only the first run after the cache TTL expires waits.
+    region::refresh_region_cache().await;
 
     // Kick off background version check to refresh the update cache for the next run.
     update::spawn_version_check();

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,8 +105,8 @@ fn cn_access_point_guidance(rendered: &str) -> Option<&'static str> {
     (rendered.contains("longbridge.cn") && is_connect_failure).then_some(
         "This request used the China Mainland access point (longbridge.cn),\n\
          which is normally unreachable from outside China Mainland.\n\
-         Diagnose: longbridge check\n\
-         Override: LONGBRIDGE_REGION=global longbridge <command>",
+         Re-detect: longbridge check --reset-region\n\
+         Override:  LONGBRIDGE_REGION=global longbridge <command>",
     )
 }
 
@@ -212,8 +212,8 @@ async fn main() {
             }
         }
 
-        Some(cli::Commands::Check) => {
-            if let Err(e) = cli::check::cmd_check(&cli.format).await {
+        Some(cli::Commands::Check { reset_region }) => {
+            if let Err(e) = cli::check::cmd_check(&cli.format, reset_region).await {
                 print_cli_error(&e, false);
                 std::process::exit(1);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn cn_access_point_guidance(rendered: &str) -> Option<&'static str> {
     (rendered.contains("longbridge.cn") && is_connect_failure).then_some(
         "This request used the China Mainland access point (longbridge.cn),\n\
          which is normally unreachable from outside China Mainland.\n\
-         Re-detect: longbridge check --reset-region\n\
+         Re-detect: longbridge check\n\
          Override:  LONGBRIDGE_REGION=global longbridge <command>",
     )
 }
@@ -159,7 +159,10 @@ async fn main() {
 
     // Re-probe the access-point region if the cached verdict has gone stale.
     // Usually a no-op; only the first run after the cache TTL expires waits.
-    region::refresh_region_cache().await;
+    // `check` detects unconditionally, so skip the routine refresh for it.
+    if !matches!(cli.command, Some(cli::Commands::Check)) {
+        region::refresh_region_cache().await;
+    }
 
     // Kick off background version check to refresh the update cache for the next run.
     update::spawn_version_check();
@@ -212,8 +215,8 @@ async fn main() {
             }
         }
 
-        Some(cli::Commands::Check { reset_region }) => {
-            if let Err(e) = cli::check::cmd_check(&cli.format, reset_region).await {
+        Some(cli::Commands::Check) => {
+            if let Err(e) = cli::check::cmd_check(&cli.format).await {
                 print_cli_error(&e, false);
                 std::process::exit(1);
             }

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,12 +1,22 @@
 /// Region detection for China Mainland auto-routing.
 ///
 /// On each startup:
-/// 1. Read cached region from disk → `is_cn_cached()` for use in Config builder.
-/// 2. Spawn background task: check geotest.lbkrs.com → update cache (non-blocking).
-use std::{path::PathBuf, time::Duration};
+/// 1. `refresh_region_cache()` re-probes geotest.lbkrs.com if the cached
+///    verdict is older than `CACHE_TTL_SECS`, and persists the result.
+/// 2. `is_cn_cached()` reads that verdict from disk for use in the Config
+///    builder.
+use std::{
+    path::PathBuf,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 const GEOTEST_URL: &str = "https://geotest.lbkrs.com";
-const GEOTEST_TIMEOUT_SECS: u64 = 3;
+const GEOTEST_TIMEOUT_SECS: u64 = 2;
+
+/// How long a probed verdict is trusted before it is re-checked. Long enough
+/// that the probe is invisible in day-to-day use, short enough that a laptop
+/// carried across the border re-routes itself the same day.
+const CACHE_TTL_SECS: u64 = 6 * 60 * 60;
 
 // The `.com` and `.cn` hosts below are access points (CDN-style routing), not
 // separate environments: identical data, identical auth, and a token issued by
@@ -94,23 +104,65 @@ fn cache_file_path() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".longbridge").join("openapi").join("region-cache"))
 }
 
+/// A previously probed region verdict, as stored on disk.
+struct CachedRegion {
+    is_cn: bool,
+    /// Unix seconds of the probe that produced `is_cn`. `None` for caches
+    /// written by an older version, which had no timestamp; those are treated
+    /// as stale so the first run after upgrading re-probes.
+    checked_at: Option<u64>,
+}
+
+impl CachedRegion {
+    fn is_fresh(&self) -> bool {
+        let Some(checked_at) = self.checked_at else {
+            return false;
+        };
+        now_unix().is_some_and(|now| now.saturating_sub(checked_at) < CACHE_TTL_SECS)
+    }
+}
+
+fn now_unix() -> Option<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
+
+/// Parse the on-disk cache: a verdict line, optionally followed by a line
+/// holding the Unix timestamp of the probe.
+fn parse_cache(raw: &str) -> CachedRegion {
+    let mut lines = raw.lines();
+    let is_cn = lines
+        .next()
+        .is_some_and(|v| v.trim().eq_ignore_ascii_case("cn"));
+    let checked_at = lines.next().and_then(|ts| ts.trim().parse::<u64>().ok());
+    CachedRegion { is_cn, checked_at }
+}
+
+fn read_cache() -> Option<CachedRegion> {
+    let path = cache_file_path()?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    Some(parse_cache(&raw))
+}
+
+/// The cached region verdict (`"cn"` / `"global"`), or `None` when no cache
+/// file exists yet. Reports what is on disk, ignoring `LONGBRIDGE_REGION`.
+pub fn cached_verdict() -> Option<&'static str> {
+    read_cache().map(|c| if c.is_cn { "cn" } else { "global" })
+}
+
 /// Returns `true` if the region is known to be CN.
 ///
 /// Priority:
 /// 1. `LONGBRIDGE_REGION` env var (explicit override)
-/// 2. Cached result from the last background geotest probe
+/// 2. Cached result from the last geotest probe
 pub fn is_cn_cached() -> bool {
     if let Ok(region) = std::env::var("LONGBRIDGE_REGION") {
         return region.trim().eq_ignore_ascii_case("cn");
     }
 
-    let Some(path) = cache_file_path() else {
-        return false;
-    };
-    match std::fs::read_to_string(&path) {
-        Ok(s) => s.trim().eq_ignore_ascii_case("cn"),
-        Err(_) => false,
-    }
+    read_cache().is_some_and(|c| c.is_cn)
 }
 
 fn write_cache(is_cn: bool) {
@@ -120,29 +172,117 @@ fn write_cache(is_cn: bool) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    let _ = std::fs::write(&path, if is_cn { "cn" } else { "global" });
+    let verdict = if is_cn { "cn" } else { "global" };
+    let contents = match now_unix() {
+        Some(ts) => format!("{verdict}\n{ts}\n"),
+        None => format!("{verdict}\n"),
+    };
+    let _ = std::fs::write(&path, contents);
 }
 
-/// Spawn a background task that checks geotest and updates the cache.
-/// Does not block the caller. Safe to call after Tokio runtime is active.
-pub fn spawn_region_update() {
-    tokio::spawn(async move {
-        let is_cn = check_geotest().await;
+/// Re-probe the region when the cached verdict has gone stale, and persist the
+/// result.
+///
+/// This awaits the probe rather than spawning it. A CLI command usually
+/// finishes in a few hundred milliseconds, so a detached background task is
+/// routinely dropped before the probe returns — which left a stale verdict on
+/// disk indefinitely, e.g. keeping a user pinned to the China Mainland access
+/// point long after they had left. Only the first command after the TTL
+/// expires pays the probe latency.
+pub async fn refresh_region_cache() {
+    // An explicit override wins; no point spending a request on the probe.
+    if std::env::var("LONGBRIDGE_REGION").is_ok() {
+        return;
+    }
+
+    let cached = read_cache();
+    if cached.as_ref().is_some_and(CachedRegion::is_fresh) {
+        return;
+    }
+
+    let is_cn = if let Some(is_cn) = check_geotest().await {
         tracing::debug!(
             "Region check: geotest={}",
             if is_cn { "CN" } else { "global" }
         );
-        write_cache(is_cn);
-    });
+        is_cn
+    } else {
+        // Inconclusive (unreachable, non-2xx, or unparsable body). Keep the
+        // previous verdict but still refresh the timestamp, so a broken
+        // network does not make every command pay the probe timeout.
+        let fallback = cached.is_some_and(|c| c.is_cn);
+        tracing::debug!(
+            "Region check: geotest inconclusive, keeping {}",
+            if fallback { "CN" } else { "global" }
+        );
+        fallback
+    };
+    write_cache(is_cn);
 }
 
-/// Returns `true` if geotest.lbkrs.com is reachable (implies China Mainland).
-async fn check_geotest() -> bool {
-    let Ok(client) = reqwest::Client::builder()
+/// Probe geotest for the caller's country. `None` when the answer is unknown.
+///
+/// `geotest.lbkrs.com` is served by a global CDN and echoes `<ip>,<country>`
+/// (e.g. `1.2.3.4,CN`). It is reachable from outside China Mainland, so
+/// reachability says nothing about location — the country code in the body is
+/// the actual signal, and treating a successful response as "CN" misroutes
+/// overseas users to the China Mainland access point.
+///
+/// The probe deliberately honours the ambient proxy environment: if all traffic
+/// exits through a China Mainland proxy, then so will the API requests, and the
+/// `.cn` access point is the right one for them.
+async fn check_geotest() -> Option<bool> {
+    let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(GEOTEST_TIMEOUT_SECS))
         .build()
-    else {
-        return false;
-    };
-    client.get(GEOTEST_URL).send().await.is_ok()
+        .ok()?;
+    let resp = client.get(GEOTEST_URL).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body = resp.text().await.ok()?;
+    Some(parse_geotest_country(&body)?.eq_ignore_ascii_case("CN"))
+}
+
+/// Extract the ISO country code from a geotest body of the form `<ip>,<country>`.
+fn parse_geotest_country(body: &str) -> Option<&str> {
+    let code = body.trim().rsplit(',').next()?.trim();
+    let looks_like_country_code =
+        (2..=3).contains(&code.len()) && code.chars().all(|c| c.is_ascii_alphabetic());
+    looks_like_country_code.then_some(code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_country_code_from_geotest_body() {
+        assert_eq!(parse_geotest_country("111.9.52.4,CN"), Some("CN"));
+        assert_eq!(parse_geotest_country("1.2.3.4,US\n"), Some("US"));
+        assert_eq!(parse_geotest_country("2001:db8::1,HK"), Some("HK"));
+    }
+
+    #[test]
+    fn rejects_bodies_without_a_country_code() {
+        // A CDN error page or a captive portal must not be read as a verdict.
+        assert_eq!(parse_geotest_country("<html>403</html>"), None);
+        assert_eq!(parse_geotest_country("111.9.52.4,"), None);
+        assert_eq!(parse_geotest_country(""), None);
+    }
+
+    #[test]
+    fn parses_cache_with_and_without_timestamp() {
+        let with_ts = parse_cache("cn\n1750000000\n");
+        assert!(with_ts.is_cn);
+        assert_eq!(with_ts.checked_at, Some(1_750_000_000));
+
+        // Legacy format, written before the cache carried a timestamp.
+        let legacy = parse_cache("cn");
+        assert!(legacy.is_cn);
+        assert_eq!(legacy.checked_at, None);
+        assert!(!legacy.is_fresh());
+
+        assert!(!parse_cache("global\n1750000000\n").is_cn);
+    }
 }

--- a/src/region.rs
+++ b/src/region.rs
@@ -200,40 +200,41 @@ pub async fn refresh_region_cache() {
         return;
     }
 
-    let is_cn = if let Some(is_cn) = check_geotest().await {
+    write_cache(probe_or_keep(cached).await);
+}
+
+/// Probe geotest, falling back to the previous verdict when it cannot answer.
+async fn probe_or_keep(cached: Option<CachedRegion>) -> bool {
+    if let Some(is_cn) = check_geotest().await {
         tracing::debug!(
             "Region check: geotest={}",
             if is_cn { "CN" } else { "global" }
         );
-        is_cn
-    } else {
-        // Inconclusive (unreachable, non-2xx, or unparsable body). Keep the
-        // previous verdict but still refresh the timestamp, so a broken
-        // network does not make every command pay the probe timeout.
-        let fallback = cached.is_some_and(|c| c.is_cn);
-        tracing::debug!(
-            "Region check: geotest inconclusive, keeping {}",
-            if fallback { "CN" } else { "global" }
-        );
-        fallback
-    };
-    write_cache(is_cn);
+        return is_cn;
+    }
+    // Inconclusive (unreachable, non-2xx, or unparsable body). Keep the
+    // previous verdict but let the caller refresh the timestamp, so a broken
+    // network does not make every command pay the probe timeout.
+    let fallback = cached.is_some_and(|c| c.is_cn);
+    tracing::debug!(
+        "Region check: geotest inconclusive, keeping {}",
+        if fallback { "CN" } else { "global" }
+    );
+    fallback
 }
 
-/// Discard the cached verdict and detect the region again, ignoring the TTL.
+/// Detect the region again and persist it, ignoring the cached verdict's TTL.
 ///
-/// The escape hatch for a cache that no longer matches reality — a laptop
-/// carried across the border, a proxy switched on or off — without waiting out
-/// the TTL or hand-editing the cache file.
-///
-/// With `LONGBRIDGE_REGION` set the cache is cleared but not rewritten: the
-/// override decides the region, so a stored verdict would be meaningless.
-pub async fn reset_region_cache() {
-    if let Some(path) = cache_file_path() {
-        let _ = std::fs::remove_file(path);
+/// `check` uses this instead of reading the cache: a diagnostic that reports a
+/// possibly stale verdict is answering the wrong question, since a stale
+/// verdict is exactly what the user is likely running it to investigate.
+/// Detecting here also repairs the cache as a side effect.
+pub async fn redetect_region() {
+    // With an override in force nothing reads the cache, so leave it as it is.
+    if std::env::var("LONGBRIDGE_REGION").is_ok() {
+        return;
     }
-    // With no cache on disk this always probes.
-    refresh_region_cache().await;
+    write_cache(probe_or_keep(read_cache()).await);
 }
 
 /// The region forced by `LONGBRIDGE_REGION`, if that variable is set.

--- a/src/region.rs
+++ b/src/region.rs
@@ -205,9 +205,10 @@ pub async fn refresh_region_cache() {
 
 /// Probe geotest, falling back to the previous verdict when it cannot answer.
 async fn probe_or_keep(cached: Option<CachedRegion>) -> bool {
-    if let Some(is_cn) = check_geotest().await {
+    if let Some(country) = probe_country().await {
+        let is_cn = country.eq_ignore_ascii_case("CN");
         tracing::debug!(
-            "Region check: geotest={}",
+            "Region check: geotest={country} → {}",
             if is_cn { "CN" } else { "global" }
         );
         return is_cn;
@@ -224,17 +225,35 @@ async fn probe_or_keep(cached: Option<CachedRegion>) -> bool {
 }
 
 /// Detect the region again and persist it, ignoring the cached verdict's TTL.
+/// Returns the country code geotest reported, or `None` if it could not answer.
 ///
 /// `check` uses this instead of reading the cache: a diagnostic that reports a
 /// possibly stale verdict is answering the wrong question, since a stale
 /// verdict is exactly what the user is likely running it to investigate.
 /// Detecting here also repairs the cache as a side effect.
-pub async fn redetect_region() {
+pub async fn redetect_region() -> Option<String> {
     // With an override in force nothing reads the cache, so leave it as it is.
+    if std::env::var("LONGBRIDGE_REGION").is_ok() {
+        return None;
+    }
+
+    let country = probe_country().await;
+    let is_cn = match country.as_deref() {
+        Some(code) => code.eq_ignore_ascii_case("CN"),
+        None => read_cache().is_some_and(|c| c.is_cn),
+    };
+    write_cache(is_cn);
+    country
+}
+
+/// Persist a verdict reached some other way than the geotest probe — `check`
+/// repinning from measured endpoint latency. No-op while an override is set,
+/// since nothing would read the result.
+pub fn record_region(is_cn: bool) {
     if std::env::var("LONGBRIDGE_REGION").is_ok() {
         return;
     }
-    write_cache(probe_or_keep(read_cache()).await);
+    write_cache(is_cn);
 }
 
 /// The region forced by `LONGBRIDGE_REGION`, if that variable is set.
@@ -250,7 +269,7 @@ pub fn region_override() -> Option<&'static str> {
     })
 }
 
-/// Probe geotest for the caller's country. `None` when the answer is unknown.
+/// Probe geotest for the caller's country code. `None` when it cannot answer.
 ///
 /// `geotest.lbkrs.com` is served by a global CDN and echoes `<ip>,<country>`
 /// (e.g. `1.2.3.4,CN`). It is reachable from outside China Mainland, so
@@ -261,7 +280,7 @@ pub fn region_override() -> Option<&'static str> {
 /// The probe deliberately honours the ambient proxy environment: if all traffic
 /// exits through a China Mainland proxy, then so will the API requests, and the
 /// `.cn` access point is the right one for them.
-async fn check_geotest() -> Option<bool> {
+async fn probe_country() -> Option<String> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(GEOTEST_TIMEOUT_SECS))
         .build()
@@ -271,7 +290,7 @@ async fn check_geotest() -> Option<bool> {
         return None;
     }
     let body = resp.text().await.ok()?;
-    Some(parse_geotest_country(&body)?.eq_ignore_ascii_case("CN"))
+    parse_geotest_country(&body).map(str::to_ascii_uppercase)
 }
 
 /// Extract the ISO country code from a geotest body of the form `<ip>,<country>`.

--- a/src/region.rs
+++ b/src/region.rs
@@ -220,6 +220,35 @@ pub async fn refresh_region_cache() {
     write_cache(is_cn);
 }
 
+/// Discard the cached verdict and detect the region again, ignoring the TTL.
+///
+/// The escape hatch for a cache that no longer matches reality — a laptop
+/// carried across the border, a proxy switched on or off — without waiting out
+/// the TTL or hand-editing the cache file.
+///
+/// With `LONGBRIDGE_REGION` set the cache is cleared but not rewritten: the
+/// override decides the region, so a stored verdict would be meaningless.
+pub async fn reset_region_cache() {
+    if let Some(path) = cache_file_path() {
+        let _ = std::fs::remove_file(path);
+    }
+    // With no cache on disk this always probes.
+    refresh_region_cache().await;
+}
+
+/// The region forced by `LONGBRIDGE_REGION`, if that variable is set.
+///
+/// Normalised the same way [`is_cn_cached`] reads it: anything other than `cn`
+/// pins the global access point.
+pub fn region_override() -> Option<&'static str> {
+    let raw = std::env::var("LONGBRIDGE_REGION").ok()?;
+    Some(if raw.trim().eq_ignore_ascii_case("cn") {
+        "cn"
+    } else {
+        "global"
+    })
+}
+
 /// Probe geotest for the caller's country. `None` when the answer is unknown.
 ///
 /// `geotest.lbkrs.com` is served by a global CDN and echoes `<ip>,<country>`


### PR DESCRIPTION
A client outside China Mainland could end up routed to `longbridge.cn` and then fail on every request with a bare transport error:

```
Error: error sending request for url (https://openapi.longbridge.cn/v1/watchlist/groups): client error (Connect)
```

Nothing in that message says the access point is the problem, and nothing offered a way out. Three fixes:

### Region detection now reads the country code

`geotest.lbkrs.com` is served by a global CDN and echoes `<ip>,<country>` (e.g. `1.2.3.4,CN`). It answers from outside China Mainland too, so the old "reachable ⇒ CN" test misrouted overseas users. Detection now requires a 2xx and parses the country code from the body; CDN error pages and captive portals no longer count as a verdict.

The probe still follows the ambient proxy environment on purpose — if all traffic exits through a China Mainland proxy, so will the API requests, and `.cn` is genuinely the better access point for that client.

### The cached verdict can actually be refreshed

The background probe was spawned detached, but a CLI command usually exits within a few hundred milliseconds — so the task was routinely dropped before the 3s probe returned, and a stale verdict could sit on disk indefinitely (e.g. keeping a laptop pinned to `.cn` long after leaving China Mainland).

The cache now stores a timestamp and is re-probed only when older than 6 hours, awaited rather than spawned. Everyday commands pay nothing; only the first command after the TTL expires waits, and at most 2s. Caches written by older versions have no timestamp and are re-probed once on upgrade. If the probe is inconclusive the previous verdict is kept and the timestamp refreshed, so a broken network does not make every command pay the timeout.

### Connection failures explain themselves

```
Error: error sending request for url (https://openapi.longbridge.cn/v1/watchlist/groups): client error (Connect)

This request used the China Mainland access point (longbridge.cn),
which is normally unreachable from outside China Mainland.
Diagnose: longbridge check
Override: LONGBRIDGE_REGION=global longbridge <command>
```

Shown only when the host is `longbridge.cn` **and** the failure is connection-shaped, so business errors that happen to mention the host stay clean.

## Verification

| Scenario | Result |
| --- | --- |
| Dead proxy against `.cn` | Original error plus guidance, exit 1 |
| Normal run | Cache rewritten with timestamp; `check` still reports `region cn (active: CN)` |
| Second run within TTL | Probe skipped |
| Stale cache + dead proxy | Verdict kept, timestamp refreshed |

New unit tests cover country-code parsing, malformed bodies, and both cache formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)