### PR TITLE
cli: Move `workspace` under `agent` and drop the A2A wording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,11 +261,12 @@ Example: `cli: Add statement export command`, `tui: Fix quit confirmation dialog
 When adding, removing, or modifying any CLI command (in `src/cli/`), always update all of the following in the same PR:
 
 1. **`README.md`** — the `<!-- COMMANDS_START -->` / `<!-- COMMANDS_END -->` block
-2. **`../developers/skills/longbridge/`** — all skill files are maintained in the `developers` repo; this repo no longer has its own `skills/` directory:
+2. **`../skills/skills/longbridge/`** — all skill files are maintained in the `skills` repo; this repo no longer has its own `skills/` directory:
    - `SKILL.md` — quick reference, if the command is common enough to mention
    - `references/cli/overview.md` — CLI overview (features, patterns, notable flags)
    - `references/python-sdk/` / `references/rust-sdk/` — corresponding SDK reference
 
 Skill files should stay high-level. Defer to the CLI's built-in `--help` for flag details — do not duplicate help text in skill files.
 
-If `../developers` is not available locally, the repository is https://github.com/longbridge/developers
+If `../skills` is not available locally, the repository is https://github.com/longbridge/skills
+(`../developers` used to hold a copy of these files; it was deleted as a stale duplicate.)

--- a/README.md
+++ b/README.md
@@ -303,14 +303,14 @@ longbridge sharelist popular [--count 10]                         # Get popular 
 ### AI Agents
 
 ```bash
-longbridge workspace list                                           # List AI workspaces
+longbridge agent workspaces                                         # List AI workspaces
 longbridge agent list [--workspace 33] [--name 选股]                # Discover chat-capable AI agents (--all includes workflow agents)
 longbridge agent chat chatbot "分析一下 TSLA"                       # `chatbot` (LongbridgeAI) is public — usable by any account
 longbridge agent chat chatbot "分析一下 TSLA"                       # Chat with an agent (SSE; --stream for live tokens)
 longbridge agent chat chatbot <CHAT_UID> <MSG_ID> "继续"            # Multi-turn follow-up
 longbridge agent continue chatbot <CHAT_UID> <MSG_ID> --answer "…"  # Resume an interrupted run
 longbridge agent continue chatbot <CHAT_UID> <MSG_ID> --answers-json '{…}'  # Resume with the raw answers payload
-longbridge agent --skill                                            # Print the A2A skill doc for AI harnesses
+longbridge agent --skill                                            # Print the agent skill doc for AI harnesses
 ```
 
 ### Trading

--- a/src/cli/agent/chat.rs
+++ b/src/cli/agent/chat.rs
@@ -408,7 +408,7 @@ pub(crate) fn ensure_interactive_supported_for(
     use crate::cli::AgentCmd;
     let interactive = match cmd {
         AgentCmd::Chat { interactive, .. } | AgentCmd::Continue { interactive, .. } => *interactive,
-        AgentCmd::List { .. } => false,
+        AgentCmd::List { .. } | AgentCmd::Workspaces => false,
     };
     ensure_interactive_supported(interactive, format)
 }
@@ -420,7 +420,7 @@ pub(crate) fn ensure_interactive_supported_for(
 /// `tool_call_id:question=answer` grammar — no separator can be confused for
 /// content, whatever the question contains.
 /// Every value echoed back by [`parse_answers_json`] is attacker-controlled:
-/// an A2A harness drives `--answers-json`, and its keys travel unmodified into
+/// an AI harness drives `--answers-json`, and its keys travel unmodified into
 /// stderr. Strip terminal control sequences and cap the length so a hostile
 /// payload cannot repaint the user's terminal through a validation error.
 fn sanitize_for_error(s: &str) -> String {
@@ -1574,7 +1574,7 @@ mod tests {
 
     // ── fix-round-5 regression tests ────────────────────────────────────────
 
-    /// Blocker 3 regression: `--answers-json` is written by the A2A harness,
+    /// Blocker 3 regression: `--answers-json` is written by an AI harness,
     /// so a malformed payload full of ANSI/OSC sequences must not reach stderr
     /// verbatim. Covers all three interpolation sites: the raw input, the
     /// decoded `tool_call_id` key, and the decoded question key.

--- a/src/cli/agent/events.rs
+++ b/src/cli/agent/events.rs
@@ -236,10 +236,12 @@ impl ChatAggregator {
                 self.outcome.references.clone_from(references);
                 self.outcome.further_questions.clone_from(further_questions);
             }
-            AgentEvent::ChatFinished { error_message } => {
-                if !error_message.is_empty() && self.outcome.error_message.is_empty() {
-                    self.outcome.error_message.clone_from(error_message);
-                }
+            // Never blank an existing message: a preceding event may already
+            // have carried the real cause while this one's field is empty.
+            AgentEvent::ChatFinished { error_message }
+                if !error_message.is_empty() && self.outcome.error_message.is_empty() =>
+            {
+                self.outcome.error_message.clone_from(error_message);
             }
             _ => {}
         }

--- a/src/cli/agent/mod.rs
+++ b/src/cli/agent/mod.rs
@@ -1,4 +1,4 @@
-//! AI agent commands (A2A): discovery, chat, interrupt continuation.
+//! AI agent commands: discovery, chat, interrupt continuation, workspaces.
 
 use std::collections::BTreeMap;
 
@@ -12,6 +12,7 @@ pub mod client;
 pub mod events;
 pub mod render;
 pub mod skills;
+pub mod workspace;
 
 /// Agent modes `agent chat` can drive. Anything else is hidden from
 /// `agent list` unless `--all` is passed.
@@ -360,6 +361,7 @@ pub async fn cmd_agent(
             )
             .await
         }
+        Some(AgentCmd::Workspaces) => workspace::cmd_workspaces(format, verbose).await,
     }
 }
 
@@ -480,6 +482,9 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<crate::cli::schema::Res
                 ),
             ],
         ),
+        Some("workspaces") => {
+            schema::object("AI workspaces for the current account", &["workspaces"])
+        }
         // Bare `longbridge agent` runs `agent list`, so `agent --schema`
         // must describe the list response instead of falling through to help.
         None | Some("list") => schema::object("AI agents across workspaces", &["agents"]),

--- a/src/cli/agent/skills.rs
+++ b/src/cli/agent/skills.rs
@@ -1,10 +1,10 @@
-//! Static A2A skill document served by `longbridge agent --skill`.
+//! Static skill document served by `longbridge agent --skill`.
 
 use indoc::indoc;
 
 pub fn skills_doc() -> &'static str {
     indoc! {r#"
-        # Longbridge A2A Agent Chat
+        # Longbridge AI Agent Chat
 
         Chat with Longbridge AI agents (investment research, stock analysis,
         screeners, custom workflow agents) from the command line. Designed for

--- a/src/cli/agent/workspace.rs
+++ b/src/cli/agent/workspace.rs
@@ -1,26 +1,13 @@
-//! AI workspace commands (list workspaces for the current account).
+//! `agent workspaces`: list the AI workspaces that hold the account's agents.
 
 use anyhow::Result;
 use serde_json::json;
 
-use super::agent::client::{AgentApi, LbAgentApi, WorkspaceInfo};
-use super::output::{fmt_unix_ts, print_json_value, print_table};
-use super::{OutputFormat, WorkspaceCmd};
+use super::client::{AgentApi, LbAgentApi, WorkspaceInfo};
+use crate::cli::output::{fmt_unix_ts, print_json_value, print_table};
+use crate::cli::OutputFormat;
 
-pub async fn cmd_workspace(
-    cmd: Option<WorkspaceCmd>,
-    format: &OutputFormat,
-    verbose: bool,
-) -> Result<()> {
-    match cmd {
-        // Bare `longbridge workspace`: show what the group offers rather than
-        // guessing a subcommand. See `exit_with_subcommand_help`.
-        None => crate::cli::exit_with_subcommand_help("workspace"),
-        Some(WorkspaceCmd::List) => cmd_list(format, verbose).await,
-    }
-}
-
-async fn cmd_list(format: &OutputFormat, verbose: bool) -> Result<()> {
+pub async fn cmd_workspaces(format: &OutputFormat, verbose: bool) -> Result<()> {
     let api = LbAgentApi { verbose };
     let workspaces = api.list_workspaces().await?;
     match format {
@@ -35,11 +22,11 @@ async fn cmd_list(format: &OutputFormat, verbose: bool) -> Result<()> {
     Ok(())
 }
 
-/// Build the pretty-table rows for `workspace list`. `id` and `name` are
+/// Build the pretty-table rows for `agent workspaces`. `id` and `name` are
 /// server-supplied and printed verbatim, so they are stripped of control
 /// characters first (JSON output stays raw — serde escapes it safely).
 fn workspace_rows(workspaces: &[WorkspaceInfo]) -> Vec<Vec<String>> {
-    use super::agent::render::strip_control_chars;
+    use super::render::strip_control_chars;
     workspaces
         .iter()
         .map(|w| {
@@ -51,18 +38,6 @@ fn workspace_rows(workspaces: &[WorkspaceInfo]) -> Vec<Vec<String>> {
             ]
         })
         .collect()
-}
-
-pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
-    use super::schema::object;
-
-    match path.join(" ").as_str() {
-        "workspace" | "workspace list" => Some(object(
-            "AI workspaces for the current account",
-            &["workspaces"],
-        )),
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,7 +29,6 @@ pub mod statement;
 pub mod topic;
 pub mod trade;
 pub mod watchlist;
-pub mod workspace;
 
 #[derive(ValueEnum, Clone, Default, Debug)]
 pub enum OutputFormat {
@@ -1431,30 +1430,20 @@ pub enum Commands {
     },
 
     // ── AI Agents ───────────────────────────────────────────────────────
-    /// AI workspaces: list workspaces for the current account
-    ///
-    /// Workspaces contain AI agents; use `longbridge agent list` to see them.
-    /// Returns: id, name, `created_at`, `updated_at`.
-    /// Example: longbridge workspace list
-    /// Example: longbridge workspace list --format json
-    Workspace {
-        #[command(subcommand)]
-        cmd: Option<WorkspaceCmd>,
-    },
-
-    /// AI agents: discover and chat with Longbridge AI agents (A2A)
+    /// AI agents: discover and chat with Longbridge AI agents
     ///
     /// Chat transport is SSE under the hood; agent runs can take 1-2 minutes.
     /// Returns (chat): `chat_uid`, `message_id`, status, answer (markdown), widgets,
     /// references, `further_questions`, `elapsed_time`.
     /// Example: longbridge agent list
+    /// Example: longbridge agent workspaces
     /// Example: longbridge agent chat chatbot "分析一下 TSLA 近一个月走势"
     /// Example: longbridge agent chat chatbot `ct_uid` 12345 "继续深入"
     /// Example: longbridge agent --skill
     Agent {
         #[command(subcommand)]
         cmd: Option<AgentCmd>,
-        /// Print the A2A skill document for AI harnesses and exit
+        /// Print the agent skill document for AI harnesses and exit
         // `--skills` is a silent alias kept for compatibility: the plural form
         // shipped first. Only `--skill` is advertised in `--help`.
         #[arg(long = "skill", alias = "skills")]
@@ -2338,14 +2327,6 @@ pub enum WatchlistCmd {
 }
 
 #[derive(Subcommand)]
-pub enum WorkspaceCmd {
-    /// List AI workspaces for the current account
-    ///
-    /// Example: longbridge workspace list
-    List,
-}
-
-#[derive(Subcommand)]
 // Backticks render literally in `--help`, so the mode names stay bare here.
 #[allow(clippy::doc_markdown)]
 pub enum AgentCmd {
@@ -2441,6 +2422,15 @@ pub enum AgentCmd {
         #[arg(long)]
         interactive: bool,
     },
+
+    /// List AI workspaces for the current account
+    ///
+    /// Workspaces hold the agents `longbridge agent list` enumerates.
+    /// Returns: id, name, `created_at`, `updated_at`.
+    /// Example: longbridge agent workspaces
+    /// Example: longbridge agent workspaces --format json
+    #[command(alias = "workspace")]
+    Workspaces,
 }
 
 #[derive(ValueEnum, Clone, Debug)]
@@ -4085,7 +4075,6 @@ IpoCmd::ProfitLoss { period, page, count } => {
             }
         },
 
-        Commands::Workspace { cmd } => workspace::cmd_workspace(cmd, format, verbose).await,
         Commands::Agent { cmd, skill } => agent::cmd_agent(cmd, skill, format, verbose).await,
 
         Commands::Auth { .. }
@@ -4906,25 +4895,31 @@ mod tests {
         }
     }
 
-    // ─── Workspace / Agent ────────────────────────────────────────────────────
+    // ─── Agent ────────────────────────────────────────────────────────────────
 
     #[test]
-    fn test_workspace_list() {
-        let cli = parse(&["longbridge", "workspace", "list"]).unwrap();
+    fn test_agent_workspaces() {
+        let cli = parse(&["longbridge", "agent", "workspaces"]).unwrap();
         assert!(matches!(
             cli.command,
-            Some(Commands::Workspace {
-                cmd: Some(WorkspaceCmd::List)
+            Some(Commands::Agent {
+                cmd: Some(AgentCmd::Workspaces),
+                ..
             })
         ));
     }
 
+    /// `workspace` was a top-level command before it moved under `agent`;
+    /// the singular alias keeps that spelling working.
     #[test]
-    fn test_workspace_bare_defaults_to_list() {
-        let cli = parse(&["longbridge", "workspace"]).unwrap();
+    fn test_agent_workspace_singular_alias() {
+        let cli = parse(&["longbridge", "agent", "workspace"]).unwrap();
         assert!(matches!(
             cli.command,
-            Some(Commands::Workspace { cmd: None })
+            Some(Commands::Agent {
+                cmd: Some(AgentCmd::Workspaces),
+                ..
+            })
         ));
     }
 
@@ -5180,18 +5175,12 @@ mod tests {
 
     #[test]
     fn bare_group_help_lists_every_subcommand() {
-        // Bare `agent` / `workspace` print this instead of running a command,
-        // so the text must actually name what the user can run next.
+        // Bare `agent` prints this instead of running a command, so the text
+        // must actually name what the user can run next.
         let agent = render_subcommand_help("agent").expect("agent is a subcommand");
-        for sub in ["list", "chat", "continue"] {
+        for sub in ["list", "chat", "continue", "workspaces"] {
             assert!(agent.contains(sub), "agent help must mention `{sub}`");
         }
-
-        let workspace = render_subcommand_help("workspace").expect("workspace is a subcommand");
-        assert!(
-            workspace.contains("list"),
-            "workspace help must mention `list`"
-        );
     }
 
     #[test]

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -5,8 +5,7 @@ use std::ffi::OsString;
 
 use super::{
     agent, asset, atm, auth, check, completion, dca, fundamental, init, insider_trades, investors,
-    ipo, news, quote, run_script, screener, sharelist, statement, topic, trade, watchlist,
-    workspace, Cli,
+    ipo, news, quote, run_script, screener, sharelist, statement, topic, trade, watchlist, Cli,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -337,7 +336,6 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<ResponseSchema> {
         "screener" => screener::schema_for_path(path),
         "bank-cards" | "withdrawals" | "deposits" => atm::schema_for_path(path),
         "ipo" => ipo::schema_for_path(path),
-        "workspace" => workspace::schema_for_path(path),
         "agent" => agent::schema_for_path(path),
         _ => None,
     }

--- a/src/cli/sec_edgar.rs
+++ b/src/cli/sec_edgar.rs
@@ -26,7 +26,7 @@ const SEC_UA: &str = concat!(
 const TICKER_MAP_URL: &str = "https://www.sec.gov/files/company_tickers_mf.json";
 
 // On-disk cache time-to-live for the ticker map.
-const TICKER_MAP_TTL: Duration = Duration::from_secs(7 * 24 * 3600);
+const TICKER_MAP_TTL: Duration = Duration::from_hours(7 * 24);
 
 /// A single portfolio holding parsed from an N-PORT filing.
 #[derive(Debug, Clone, Serialize)]
@@ -58,7 +58,7 @@ pub struct EtfHoldings {
 fn sec_client() -> reqwest::Client {
     reqwest::Client::builder()
         .user_agent(SEC_UA)
-        .timeout(Duration::from_secs(60))
+        .timeout(Duration::from_mins(1))
         .build()
         .expect("failed to build HTTP client")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,9 +186,6 @@ async fn main() {
         Some(cli::Commands::Agent { cmd: None, .. }) => {
             cli::exit_with_subcommand_help("agent");
         }
-        Some(cli::Commands::Workspace { cmd: None }) => {
-            cli::exit_with_subcommand_help("workspace");
-        }
         // `--interactive` needs a terminal to prompt on, so it cannot be
         // combined with machine-readable output. Rejecting it here keeps the
         // failure free of any token refresh or region request.

--- a/tests/schema_cli.rs
+++ b/tests/schema_cli.rs
@@ -104,7 +104,7 @@ fn root_schema_reports_no_response_schema() {
     );
 }
 
-// ── A2A command surface: behavior that only shows up in a real process ──────
+// ── Agent command surface: behavior that only shows up in a real process ──────
 //
 // These spawn the binary because the properties under test are process-level:
 // the exit status, which stream output lands on, and the fact that no auth or
@@ -131,7 +131,7 @@ fn run_logged_out(args: &[&str]) -> CliOutput {
 
 #[test]
 fn bare_command_groups_print_help_without_authenticating() {
-    for group in ["agent", "workspace"] {
+    for group in ["agent"] {
         let out = run_logged_out(&[group]);
 
         assert_eq!(

--- a/tests/schema_live.rs
+++ b/tests/schema_live.rs
@@ -57,11 +57,11 @@ fn read_only_probes() -> Vec<Probe> {
     vec![
         p(&["auth", "status"], &["auth", "status", "--format", "json"]),
         p(&["check"], &["check", "--format", "json"]),
-        p(
-            &["workspace", "list"],
-            &["workspace", "list", "--format", "json"],
-        ),
         p(&["agent", "list"], &["agent", "list", "--format", "json"]),
+        p(
+            &["agent", "workspaces"],
+            &["agent", "workspaces", "--format", "json"],
+        ),
         p(&["quote"], &["quote", "TSLA.US", "--format", "json"]),
         p(&["depth"], &["depth", "TSLA.US", "--format", "json"]),
         p(&["brokers"], &["brokers", "700.HK", "--format", "json"]),


### PR DESCRIPTION
## What changed

**`longbridge workspace list` → `longbridge agent workspaces`**

Workspaces exist only to hold agents, so a top-level command of their own bought nothing. `workspace` (singular) stays as an alias:

```
$ longbridge agent --help
Commands:
  list        List chat-capable AI agents (all workspaces by default)
  chat        Chat with an agent (first round or follow-up)
  continue    Answer an interrupted run's questions and resume it
  workspaces  List AI workspaces for the current account
```

Both `agent` and `workspace` shipped after v0.26.0, so no released command changes.

**"A2A" removed from all user-facing text**

The agent commands talk to Longbridge's own `/v1/ai/*` REST endpoints plus SSE. That is not the Agent2Agent protocol — there is no agent card at `/.well-known/agent-card.json`, no JSON-RPC 2.0, and none of `message/send` / `message/stream` / `tasks/get` / `tasks/cancel`. Calling it A2A told anyone familiar with the spec that they could point a standard A2A client at it, which is false.

Affected: the `agent` help text, `--skill`'s description and the document it prints, two doc comments in `chat.rs`, a test section header, and the README line.

`longbridge acp` keeps its protocol name — that command genuinely serves the Agent Client Protocol.

## Drive-by

- Fixes 3 pre-existing clippy failures from the Rust 1.97 lint set (`collapsible_match` in `agent/events.rs`, `duration_suboptimal_units` twice in `sec_edgar.rs`). Verified via `git stash` that they predate this branch.
- CLAUDE.md's docs-sync note now points at the `skills` repo; the copy under `developers` was a stale duplicate and has been deleted separately.

## Testing

`cargo fmt --check`, `cargo clippy` (0 errors), 383 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)