### PR TITLE
Version 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-terminal"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "aes-gcm",
  "ansi-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "longbridge-terminal"
-version = "0.26.0"
+version = "0.27.0"
 license = "Apache-2.0"
 
 [[bin]]


### PR DESCRIPTION
Bumps `Cargo.toml` (and `Cargo.lock`) `0.26.0` → `0.27.0` for the next release.

### Included since v0.26.0
- ACP runtime for Longbridge AI (#282)
- A2A agent commands for discovery, chat and interrupted runs; `workspace` moved under `agent` (#280, #285)
- Expose CLI session history (#284)
- Identify CLI requests explicitly to openapi (#283)

### NOT included
- **Grid CLI** (`feat/grid-cli`) is intentionally **not** merged — it depends on the gateway that is not live yet (same hold as the reverted SDK grid trading). Do not merge `feat/grid-cli` before the gateway ships.

### To publish after merge
Tagging `v0.27.0` triggers the full release (build all platforms → GitHub Release + checksums → Aliyun OSS backup → Homebrew tap + Scoop manifest auto-update):
```
git tag v0.27.0 <merge-sha> && git push origin v0.27.0
```
Tag + release note will be done only after your confirmation.