### PR TITLE
cli: Add `longbridge serve` JSON-RPC endpoint for third-party clients

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,19 @@ Requirements:
 RUST_LOG=debug cargo run
 ```
 
+## Convention Over Configuration
+
+**Never introduce a new environment variable, CLI flag, or config option without the user's explicit approval.** This holds even when the option looks obviously useful, is opt-in, or defaults to today's behavior.
+
+This project follows convention over configuration: choose the behavior that is right and implement only that. A knob is a permanent widening of the contract — it has to be named, documented, tested, and kept working, and every later change has to keep working across all of its states.
+
+When a change seems to call for a switch:
+
+1. Pick the behavior that is correct for the common case, implement only it, and say in the PR why that default is the right one.
+2. If two behaviors are genuinely both required, stop and ask before adding the option — do not add it and let review decide.
+
+Environment variables are the strictest case: they do not appear in `--help`, cannot be discovered from the CLI surface, and produce configuration only its author knows about. Do not add one.
+
 ## Code Style
 
 ### Clippy Rules

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,14 @@ strum = { version = "0.26", features = ["derive"] }
 tempfile = "3"
 termimad = "0.30"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
-tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.33.0", features = [
+    "io-std",
+    "io-util",
+    "macros",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 tokio-stream = "0.1"
 tracing = "0.1.40"
 tracing-appender = { version = "0.2.4" }

--- a/README.md
+++ b/README.md
@@ -543,9 +543,11 @@ on, so a client needs only a JSON parser and a line splitter, no protocol librar
 → {"jsonrpc":"2.0","id":1,"method":"quote.quote","params":{"symbols":["700.HK"]}}
 ← {"jsonrpc":"2.0","id":1,"result":[{"symbol":"700.HK","last_done":"445.600", ...}]}
 → {"jsonrpc":"2.0","id":2,"method":"quote.subscribe","params":{"symbols":["700.HK"]}}
-← {"jsonrpc":"2.0","id":2,"result":{"subscribed":[{"symbol":"700.HK","fields":["quote"]}]}}
+← {"jsonrpc":"2.0","id":2,"result":{"subscribed":[{"symbol":"700.HK","fields":["quote"]}],"quotes":[…]}}
 ← {"jsonrpc":"2.0","method":"quote.updated","params":{"symbol":"700.HK","last_done":"446.000", ...}}
 ```
+
+One request per line: batches (a JSON array) are not accepted, as in LSP and MCP.
 
 ### Raw payloads, on purpose
 
@@ -564,7 +566,7 @@ whole command surface without a parallel implementation:
 | `quote.*` | Every `QuoteApi` call — `quote.quote`, `quote.depth`, `quote.candlesticks`, `quote.watchlist`, `quote.option_chain_info_by_date`, … |
 | `trade.*` | Every `TradeApi` call — `trade.stock_positions`, `trade.account_balance`, `trade.today_orders`, `trade.submit_order`, … |
 | `api.get` / `api.post` | Raw passthrough to any REST endpoint, e.g. `{"path":"/v1/quote/dividends","query":{"symbol":"AAPL.US"}}`. This is how the fundamentals, screener, IPO and news commands reach their data. |
-| `quote.subscribe` / `quote.unsubscribe` | Live feed; `fields` is any of `quote`, `depth`, `brokers`, `trades` (default `quote`). No one-shot CLI equivalent. |
+| `quote.subscribe` / `quote.unsubscribe` | Live feed; `fields` is any of `quote`, `depth`, `brokers`, `trades` (default `quote`). `subscribe` also returns a `quotes` snapshot to paint the first screen from. No one-shot CLI equivalent. |
 | `initialize` / `shutdown` | Session control. `initialize` returns the full method list, so clients discover the surface rather than hard-coding it. |
 
 `longbridge serve -h` prints the protocol, the full method list and a worked exchange —
@@ -573,6 +575,9 @@ there. Params and results follow the Longbridge OpenAPI shapes for the same call
 a method up under its own name at <https://open.longbridge.com/docs> for its fields.
 
 Server notifications: `quote.updated`, `quote.depth`, `quote.brokers`, `quote.trades`.
+`quote.updated` is a tick rather than a full quote, and a push that raced ahead of
+`subscribe`'s snapshot can still be the older of the two, so keep whichever `timestamp` is
+newer.
 
 A test asserts every `QuoteApi`/`TradeApi` method is reachable over RPC, so adding one
 without exposing it fails the build — `serve` cannot drift behind the CLI.
@@ -583,8 +588,11 @@ positions and FX rates) are deliberately not methods: a client composes them fro
 our arithmetic.
 
 Requests are answered concurrently — a slow `trade.stock_positions` never stalls the quote
-feed — so responses may arrive out of order; correlate them by `id`. The process exits when
-stdin closes, so it cannot outlive the client that spawned it.
+feed — so responses may arrive out of order; correlate them by `id`. Up to 8 run upstream
+at once and the rest queue, so a burst is paced rather than dropped. An error code says
+whether a retry can help: `-32602` names the parameter at fault and will fail the same way
+again, `-32000` came from Longbridge and may not. The process exits when stdin closes, so
+it cannot outlive the client that spawned it.
 
 ## Output Format
 

--- a/README.md
+++ b/README.md
@@ -567,6 +567,11 @@ whole command surface without a parallel implementation:
 | `quote.subscribe` / `quote.unsubscribe` | Live feed; `fields` is any of `quote`, `depth`, `brokers`, `trades` (default `quote`). No one-shot CLI equivalent. |
 | `initialize` / `shutdown` | Session control. `initialize` returns the full method list, so clients discover the surface rather than hard-coding it. |
 
+`longbridge serve -h` prints the protocol, the full method list and a worked exchange —
+generated from the routing tables, so the help cannot advertise a method that is not
+there. Params and results follow the Longbridge OpenAPI shapes for the same call, so look
+a method up under its own name at <https://open.longbridge.com/docs> for its fields.
+
 Server notifications: `quote.updated`, `quote.depth`, `quote.brokers`, `quote.trades`.
 
 A test asserts every `QuoteApi`/`TradeApi` method is reachable over RPC, so adding one

--- a/README.md
+++ b/README.md
@@ -412,6 +412,12 @@ longbridge screener search --market HK --filter filter_marketcap:100:1000 --filt
 longbridge screener indicators                                # List all available filter indicators with IDs, keys, and default value ranges
 ```
 
+### Embedding in Another App
+
+```bash
+longbridge serve                                              # JSON-RPC 2.0 API endpoint on stdin/stdout, with live quote push
+```
+
 <!-- COMMANDS_END -->
 
 ### Symbol Format
@@ -518,6 +524,62 @@ Zed can register it as a custom external agent:
   }
 }
 ```
+
+## Embedding in another app
+
+Third-party clients — desktop widgets, bar plugins, dashboards — can drive the CLI as a
+long-lived data source instead of polling one-shot commands:
+
+```bash
+longbridge serve
+```
+
+The process authenticates and opens the market WebSocket once, then speaks
+newline-delimited [JSON-RPC 2.0](https://www.jsonrpc.org/specification) on stdin/stdout —
+one compact JSON object per line. That is the same base protocol LSP, MCP and ACP build
+on, so a client needs only a JSON parser and a line splitter, no protocol library.
+
+```jsonc
+→ {"jsonrpc":"2.0","id":1,"method":"quote.quote","params":{"symbols":["700.HK"]}}
+← {"jsonrpc":"2.0","id":1,"result":[{"symbol":"700.HK","last_done":"445.600", ...}]}
+→ {"jsonrpc":"2.0","id":2,"method":"quote.subscribe","params":{"symbols":["700.HK"]}}
+← {"jsonrpc":"2.0","id":2,"result":{"subscribed":[{"symbol":"700.HK","fields":["quote"]}]}}
+← {"jsonrpc":"2.0","method":"quote.updated","params":{"symbol":"700.HK","last_done":"446.000", ...}}
+```
+
+### Raw payloads, on purpose
+
+`serve` returns the **raw Longbridge OpenAPI payloads** — not the JSON the CLI prints.
+The CLI's `--format json` reshapes data for AI consumption and is free to change with it;
+`serve` is an API contract for other people's software, so it tracks the upstream shapes
+instead.
+
+### Method surface
+
+`serve` sits below the CLI commands, at the API seam all of them share, so it covers the
+whole command surface without a parallel implementation:
+
+| Namespace | Covers |
+| --- | --- |
+| `quote.*` | Every `QuoteApi` call — `quote.quote`, `quote.depth`, `quote.candlesticks`, `quote.watchlist`, `quote.option_chain_info_by_date`, … |
+| `trade.*` | Every `TradeApi` call — `trade.stock_positions`, `trade.account_balance`, `trade.today_orders`, `trade.submit_order`, … |
+| `api.get` / `api.post` | Raw passthrough to any REST endpoint, e.g. `{"path":"/v1/quote/dividends","query":{"symbol":"AAPL.US"}}`. This is how the fundamentals, screener, IPO and news commands reach their data. |
+| `quote.subscribe` / `quote.unsubscribe` | Live feed; `fields` is any of `quote`, `depth`, `brokers`, `trades` (default `quote`). No one-shot CLI equivalent. |
+| `initialize` / `shutdown` | Session control. `initialize` returns the full method list, so clients discover the surface rather than hard-coding it. |
+
+Server notifications: `quote.updated`, `quote.depth`, `quote.brokers`, `quote.trades`.
+
+A test asserts every `QuoteApi`/`TradeApi` method is reachable over RPC, so adding one
+without exposing it fails the build — `serve` cannot drift behind the CLI.
+
+Derived views the CLI computes locally (`portfolio`, for instance, which merges balances,
+positions and FX rates) are deliberately not methods: a client composes them from
+`trade.account_balance`, `trade.stock_positions` and `quote.quote` rather than depending on
+our arithmetic.
+
+Requests are answered concurrently — a slow `trade.stock_positions` never stalls the quote
+feed — so responses may arrive out of order; correlate them by `id`. The process exits when
+stdin closes, so it cannot outlive the client that spawned it.
 
 ## Output Format
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -188,6 +188,11 @@ pub enum Commands {
     ///
     /// Example: longbridge serve
     /// Example: echo '{"jsonrpc":"2.0","id":1,"method":"quote.watchlist"}' | longbridge serve
+    // The protocol and method list are appended to the help rather than kept
+    // as a separate `--list-methods` flag: this is the reference someone reads
+    // while writing a client, and `-h` is where they will look for it.
+    // `after_help` (not `after_long_help`) so the short form carries it too.
+    #[command(after_help = crate::cli::serve::method_reference())]
     Serve,
 
     /// Chat with Longbridge AI in a full-screen TUI

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,6 +24,7 @@ pub mod schema;
 pub mod screener;
 pub mod search;
 pub mod sec_edgar;
+pub mod serve;
 pub mod sharelist;
 pub mod statement;
 pub mod topic;
@@ -157,6 +158,37 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: Option<AcpCmd>,
     },
+
+    /// Serve the Longbridge API over JSON-RPC on stdin/stdout, with live quote push
+    ///
+    /// A stable, long-lived data source for third-party clients — desktop
+    /// widgets, bar plugins, dashboards. The process authenticates and opens
+    /// the market WebSocket once, then answers newline-delimited JSON-RPC 2.0
+    /// requests and pushes real-time updates as server notifications. Clients
+    /// need only a JSON parser and a line splitter, no protocol library.
+    ///
+    /// Results are the raw Longbridge `OpenAPI` payloads, NOT the reshaped
+    /// `--format json` output the CLI prints: that output is tuned for AI
+    /// consumption and may change, whereas this is an API contract.
+    ///
+    /// Method surface (call `initialize` for the full list):
+    ///   `quote.*` — every `QuoteApi` call, e.g. `quote.quote`,
+    ///               `quote.candlesticks`, `quote.watchlist`
+    ///   `trade.*` — every `TradeApi` call, e.g. `trade.stock_positions`,
+    ///               `trade.account_balance`, `trade.submit_order`
+    ///   `api.get` / `api.post` — raw passthrough to any REST endpoint, which
+    ///               is how the fundamentals, screener, IPO and news commands
+    ///               reach their data
+    ///   `quote.subscribe` / `quote.unsubscribe` — live feed, no CLI equivalent
+    ///
+    /// Notifications: `quote.updated`, `quote.depth`, `quote.brokers`,
+    /// `quote.trades`.
+    ///
+    /// Exits when stdin closes, so it cannot outlive the client that spawned it.
+    ///
+    /// Example: longbridge serve
+    /// Example: echo '{"jsonrpc":"2.0","id":1,"method":"quote.watchlist"}' | longbridge serve
+    Serve,
 
     /// Chat with Longbridge AI in a full-screen TUI
     ///
@@ -4166,6 +4198,7 @@ IpoCmd::ProfitLoss { period, page, count } => {
         Commands::Auth { .. }
         | Commands::Acp { .. }
         | Commands::Ai { .. }
+        | Commands::Serve
         | Commands::Tui
         | Commands::Check
         | Commands::Update { .. }

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -29,7 +29,7 @@ fn locale_name<'a>(en: &'a str, zh: &'a str) -> &'a str {
     }
 }
 
-fn parse_period(s: &str) -> Result<Period> {
+pub fn parse_period(s: &str) -> Result<Period> {
     match s {
         "1m" | "minute" => Ok(Period::OneMinute),
         "5m" => Ok(Period::FiveMinute),
@@ -44,7 +44,7 @@ fn parse_period(s: &str) -> Result<Period> {
     }
 }
 
-fn parse_adjust(s: &str) -> Result<AdjustType> {
+pub fn parse_adjust(s: &str) -> Result<AdjustType> {
     match s {
         "none" | "no_adjust" => Ok(AdjustType::NoAdjust),
         "forward" | "forward_adjust" => Ok(AdjustType::ForwardAdjust),
@@ -82,6 +82,30 @@ fn change_pct(last: rust_decimal::Decimal, prev_close: rust_decimal::Decimal) ->
 fn change_val(last: rust_decimal::Decimal, prev_close: rust_decimal::Decimal) -> String {
     let val = last - prev_close;
     format!("{val:+}")
+}
+
+/// Render one real-time quote as the JSON object that `quote --format json`
+/// emits.
+fn quote_to_json(q: &longbridge::quote::SecurityQuote) -> serde_json::Value {
+    serde_json::json!({
+        "symbol": q.symbol,
+        "last": q.last_done.to_string(),
+        "change_value": (q.last_done - q.prev_close).to_string(),
+        "change_percentage": if q.prev_close.is_zero() { None } else {
+            let pct = (q.last_done - q.prev_close) / q.prev_close * rust_decimal::Decimal::ONE_HUNDRED;
+            Some(pct.round_dp(2).to_string())
+        },
+        "prev_close": q.prev_close.to_string(),
+        "open": q.open.to_string(),
+        "high": q.high.to_string(),
+        "low": q.low.to_string(),
+        "volume": q.volume,
+        "turnover": q.turnover.to_string(),
+        "status": format!("{:?}", q.trade_status),
+        "post_market": q.post_market_quote.as_ref().filter(|p| pre_post_has_data(p)).map(pre_post_quote_to_json),
+        "overnight": q.overnight_quote.as_ref().filter(|p| pre_post_has_data(p)).map(pre_post_quote_to_json),
+        "pre_market": q.pre_market_quote.as_ref().filter(|p| pre_post_has_data(p)).map(pre_post_quote_to_json),
+    })
 }
 
 fn pre_post_quote_to_json(q: &PrePostQuote) -> serde_json::Value {
@@ -175,7 +199,7 @@ fn calc_index_column(key: &str) -> Option<(&'static str, CalcIndexExtractor)> {
     }
 }
 
-fn parse_calc_indexes(indexes: &[String]) -> Vec<CalcIndex> {
+pub fn parse_calc_indexes(indexes: &[String]) -> Vec<CalcIndex> {
     indexes
         .iter()
         .filter_map(|s| match s.as_str() {
@@ -224,7 +248,7 @@ fn parse_calc_indexes(indexes: &[String]) -> Vec<CalcIndex> {
         .collect()
 }
 
-fn parse_market(s: &str) -> Result<longbridge::Market> {
+pub fn parse_market(s: &str) -> Result<longbridge::Market> {
     match s.to_uppercase().as_str() {
         "HK" => Ok(longbridge::Market::HK),
         "US" => Ok(longbridge::Market::US),
@@ -249,30 +273,7 @@ pub async fn cmd_quote(symbols: Vec<String>, format: &OutputFormat) -> Result<()
 
     match format {
         OutputFormat::Json => {
-            let records: Vec<serde_json::Value> = quotes
-                .iter()
-                .map(|q| {
-                    serde_json::json!({
-                        "symbol": q.symbol,
-                        "last": q.last_done.to_string(),
-                        "change_value": (q.last_done - q.prev_close).to_string(),
-                        "change_percentage": if q.prev_close.is_zero() { None } else {
-                            let pct = (q.last_done - q.prev_close) / q.prev_close * rust_decimal::Decimal::ONE_HUNDRED;
-                            Some(pct.round_dp(2).to_string())
-                        },
-                        "prev_close": q.prev_close.to_string(),
-                        "open": q.open.to_string(),
-                        "high": q.high.to_string(),
-                        "low": q.low.to_string(),
-                        "volume": q.volume,
-                        "turnover": q.turnover.to_string(),
-                        "status": format!("{:?}", q.trade_status),
-                        "post_market": q.post_market_quote.as_ref().filter(|p| pre_post_has_data(p)).map(pre_post_quote_to_json),
-                        "overnight": q.overnight_quote.as_ref().filter(|p| pre_post_has_data(p)).map(pre_post_quote_to_json),
-                        "pre_market": q.pre_market_quote.as_ref().filter(|p| pre_post_has_data(p)).map(pre_post_quote_to_json),
-                    })
-                })
-                .collect();
+            let records: Vec<serde_json::Value> = quotes.iter().map(quote_to_json).collect();
             println!("{}", serde_json::to_string_pretty(&records)?);
         }
         OutputFormat::Pretty => {

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -293,6 +293,13 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<ResponseSchema> {
             _ => None,
         },
         "ai" => (path == ["ai"]).then(|| text("Interactive Longbridge AI chat TUI")),
+        "serve" => (path == ["serve"]).then(|| {
+            text(
+                "JSON-RPC 2.0 session over stdio (NDJSON). Results are raw \
+                 Longbridge OpenAPI payloads, not the reshaped `--format json` \
+                 output; call `initialize` for the method list",
+            )
+        }),
         "quote" | "depth" | "brokers" | "trades" | "intraday" | "kline" | "static"
         | "calc-index" | "capital" | "market-temp" | "trading" | "security-list"
         | "participants" | "subscriptions" | "option" | "warrant" | "constituent"
@@ -531,7 +538,7 @@ mod tests {
                 let paths = real_leaf_paths(&root);
                 assert_eq!(
                     paths.len(),
-                    150,
+                    151,
                     "real command count changed; review schema coverage"
                 );
 

--- a/src/cli/serve/methods.rs
+++ b/src/cli/serve/methods.rs
@@ -31,7 +31,7 @@ use anyhow::{bail, Result};
 use longbridge::quote::{PushEvent, PushEventDetail, SubFlags};
 use serde_json::{json, Value};
 
-use super::params::Params;
+use super::params::{bail_param, param_err, Params};
 use super::protocol::{Message, PROTOCOL_VERSION};
 use crate::cli::api::{QuoteApi, TradeApi};
 
@@ -143,12 +143,6 @@ pub fn is_known(method: &str) -> bool {
             .is_some_and(|n| TRADE_METHODS.contains(&n))
 }
 
-/// The `initialize` method list, so a client discovers the surface in-band
-/// rather than hard-coding it.
-fn method_catalog() -> Vec<String> {
-    all_methods()
-}
-
 /// Run one method. Errors surface as JSON-RPC errors and never end the
 /// session: one bad symbol must not take down a client's live feed.
 pub async fn call(method: &str, params: Option<Value>) -> Result<Value> {
@@ -156,13 +150,15 @@ pub async fn call(method: &str, params: Option<Value>) -> Result<Value> {
 
     match method {
         // ── Session ──────────────────────────────────────────────────────
+        // Reports the surface rather than negotiating it: a client may call
+        // any method without calling this first.
         "initialize" => Ok(json!({
             "protocolVersion": PROTOCOL_VERSION,
             "serverInfo": { "name": "longbridge", "version": env!("CARGO_PKG_VERSION") },
             "capabilities": {
                 "subscribe": ["quote", "depth", "brokers", "trades"],
             },
-            "methods": method_catalog(),
+            "methods": all_methods(),
         })),
         // Handled by the run loop; listed so `is_known` accepts it.
         "shutdown" => Ok(Value::Null),
@@ -193,12 +189,29 @@ pub async fn call(method: &str, params: Option<Value>) -> Result<Value> {
         "quote.subscribe" => {
             let symbols = p.strs("symbols")?;
             let flags = parse_fields(p)?;
-            // Subscribing starts the feed; it does not replay the current
-            // value. Clients paint the initial screen with `quote.quote`,
-            // which they call anyway to render the list.
             let ctx = crate::openapi::quote_cmd();
             ctx.subscribe(&symbols, flags).await?;
-            active_subscriptions(ctx).await
+
+            // The feed itself does not replay the current value, so the result
+            // carries a snapshot to paint the first screen with. Taken *after*
+            // subscribing, which is the ordering that loses nothing: every
+            // change from here on is guaranteed to arrive as a push. A push
+            // that raced ahead of the snapshot can still be the older of the
+            // two, so a client keeps whichever `timestamp` is newer — the same
+            // rule it needs for out-of-order responses anyway.
+            let mut result = active_subscriptions(ctx).await?;
+            match quote_api().quote(symbols).await {
+                Ok(quotes) => {
+                    result["quotes"] = serde_json::to_value(quotes)?;
+                }
+                // The subscription is live either way, and reporting it as a
+                // failure would leave the client believing otherwise while
+                // pushes arrive. Omitting the field says the snapshot is the
+                // part that did not happen; a client falls back to
+                // `quote.quote`.
+                Err(e) => tracing::warn!("quote.subscribe: snapshot failed: {e}"),
+            }
+            Ok(result)
         }
         "quote.unsubscribe" => {
             let symbols = p.strs("symbols")?;
@@ -430,7 +443,7 @@ fn parse_side(s: &str) -> Result<longbridge::trade::OrderSide> {
     match s.to_lowercase().as_str() {
         "buy" => Ok(longbridge::trade::OrderSide::Buy),
         "sell" => Ok(longbridge::trade::OrderSide::Sell),
-        other => bail!("`side` must be buy or sell, got `{other}`"),
+        other => bail_param!("`side` must be buy or sell, got `{other}`"),
     }
 }
 
@@ -439,7 +452,7 @@ fn parse_side(s: &str) -> Result<longbridge::trade::OrderSide> {
 fn decimal(raw: &str, field: &str) -> Result<rust_decimal::Decimal> {
     use std::str::FromStr;
     rust_decimal::Decimal::from_str(raw)
-        .map_err(|_| anyhow::anyhow!("`{field}` must be a decimal string, got `{raw}`"))
+        .map_err(|_| param_err(format!("`{field}` must be a decimal string, got `{raw}`")))
 }
 
 fn update_group_request(p: Params<'_>) -> Result<longbridge::quote::RequestUpdateWatchlistGroup> {
@@ -448,7 +461,7 @@ fn update_group_request(p: Params<'_>) -> Result<longbridge::quote::RequestUpdat
         None | Some("add") => SecuritiesUpdateMode::Add,
         Some("remove") => SecuritiesUpdateMode::Remove,
         Some("replace") => SecuritiesUpdateMode::Replace,
-        Some(other) => bail!("`mode` must be add, remove or replace, got `{other}`"),
+        Some(other) => bail_param!("`mode` must be add, remove or replace, got `{other}`"),
     };
     let securities = p.strs_opt("securities")?;
     Ok(longbridge::quote::RequestUpdateWatchlistGroup {
@@ -471,9 +484,9 @@ fn parse_fields(p: Params<'_>) -> Result<SubFlags> {
             "depth" => SubFlags::DEPTH,
             "brokers" => SubFlags::BROKER,
             "trades" => SubFlags::TRADE,
-            other => {
-                bail!("`fields`: unknown field `{other}`; expected quote, depth, brokers or trades")
-            }
+            other => bail_param!(
+                "`fields`: unknown field `{other}`; expected quote, depth, brokers or trades"
+            ),
         };
     }
     Ok(flags)

--- a/src/cli/serve/methods.rs
+++ b/src/cli/serve/methods.rs
@@ -55,6 +55,58 @@ const EXTRA_METHODS: &[&str] = &[
     "quote.unsubscribe",
 ];
 
+/// The `QuoteApi` methods exposed, in trait declaration order.
+const QUOTE_METHODS: &[&str] = &[
+    "quote",
+    "depth",
+    "brokers",
+    "trades",
+    "intraday",
+    "candlesticks",
+    "history_candlesticks_by_date",
+    "history_candlesticks_by_offset",
+    "static_info",
+    "us_crypto_overview",
+    "calc_indexes",
+    "capital_flow",
+    "capital_distribution",
+    "market_temperature",
+    "history_market_temperature",
+    "trading_session",
+    "trading_days",
+    "security_list",
+    "participants",
+    "subscriptions",
+    "option_quote",
+    "option_chain_expiry_date_list",
+    "option_chain_info_by_date",
+    "warrant_quote",
+    "warrant_list",
+    "warrant_issuers",
+    "watchlist",
+    "create_watchlist_group",
+    "delete_watchlist_group",
+    "update_watchlist_group",
+];
+
+/// The `TradeApi` methods exposed, in trait declaration order.
+const TRADE_METHODS: &[&str] = &[
+    "today_orders",
+    "history_orders",
+    "order_detail",
+    "today_executions",
+    "history_executions",
+    "submit_order",
+    "cancel_order",
+    "replace_order",
+    "account_balance",
+    "cash_flow",
+    "stock_positions",
+    "fund_positions",
+    "margin_ratio",
+    "estimate_max_purchase_quantity",
+];
+
 fn quote_api() -> crate::cli::api::LbQuoteApi {
     crate::cli::api::LbQuoteApi::new(crate::openapi::quote_cmd())
 }
@@ -68,86 +120,33 @@ fn ok<T: serde::Serialize>(value: T) -> Result<Value> {
     Ok(serde_json::to_value(value)?)
 }
 
-pub fn is_known(method: &str) -> bool {
-    EXTRA_METHODS.contains(&method)
-        || quote_method_names().contains(&method.trim_start_matches(QUOTE_PREFIX))
-            && method.starts_with(QUOTE_PREFIX)
-        || trade_method_names().contains(&method.trim_start_matches(TRADE_PREFIX))
-            && method.starts_with(TRADE_PREFIX)
-}
-
-/// The `QuoteApi` methods exposed, in trait declaration order.
-fn quote_method_names() -> &'static [&'static str] {
-    &[
-        "quote",
-        "depth",
-        "brokers",
-        "trades",
-        "intraday",
-        "candlesticks",
-        "history_candlesticks_by_date",
-        "history_candlesticks_by_offset",
-        "static_info",
-        "us_crypto_overview",
-        "calc_indexes",
-        "capital_flow",
-        "capital_distribution",
-        "market_temperature",
-        "history_market_temperature",
-        "trading_session",
-        "trading_days",
-        "security_list",
-        "participants",
-        "subscriptions",
-        "option_quote",
-        "option_chain_expiry_date_list",
-        "option_chain_info_by_date",
-        "warrant_quote",
-        "warrant_list",
-        "warrant_issuers",
-        "watchlist",
-        "create_watchlist_group",
-        "delete_watchlist_group",
-        "update_watchlist_group",
-    ]
-}
-
-/// The `TradeApi` methods exposed, in trait declaration order.
-fn trade_method_names() -> &'static [&'static str] {
-    &[
-        "today_orders",
-        "history_orders",
-        "order_detail",
-        "today_executions",
-        "history_executions",
-        "submit_order",
-        "cancel_order",
-        "replace_order",
-        "account_balance",
-        "cash_flow",
-        "stock_positions",
-        "fund_positions",
-        "margin_ratio",
-        "estimate_max_purchase_quantity",
-    ]
-}
-
-/// A method list for `initialize`, so a client can discover the surface
-/// without out-of-band documentation.
-fn method_catalog() -> Vec<String> {
+/// Every method name with its namespace applied, sorted.
+///
+/// Derived from the same tables [`is_known`] routes on, so the list printed by
+/// `serve -h` and returned by `initialize` cannot describe a surface the
+/// dispatcher does not have.
+pub fn all_methods() -> Vec<String> {
     let mut all: Vec<String> = EXTRA_METHODS.iter().map(|m| (*m).to_string()).collect();
-    all.extend(
-        quote_method_names()
-            .iter()
-            .map(|m| format!("{QUOTE_PREFIX}{m}")),
-    );
-    all.extend(
-        trade_method_names()
-            .iter()
-            .map(|m| format!("{TRADE_PREFIX}{m}")),
-    );
+    all.extend(QUOTE_METHODS.iter().map(|m| format!("{QUOTE_PREFIX}{m}")));
+    all.extend(TRADE_METHODS.iter().map(|m| format!("{TRADE_PREFIX}{m}")));
     all.sort();
     all
+}
+
+pub fn is_known(method: &str) -> bool {
+    EXTRA_METHODS.contains(&method)
+        || method
+            .strip_prefix(QUOTE_PREFIX)
+            .is_some_and(|n| QUOTE_METHODS.contains(&n))
+        || method
+            .strip_prefix(TRADE_PREFIX)
+            .is_some_and(|n| TRADE_METHODS.contains(&n))
+}
+
+/// The `initialize` method list, so a client discovers the surface in-band
+/// rather than hard-coding it.
+fn method_catalog() -> Vec<String> {
+    all_methods()
 }
 
 /// Run one method. Errors surface as JSON-RPC errors and never end the
@@ -587,8 +586,8 @@ mod tests {
     #[test]
     fn serve_exposes_every_api_trait_method() {
         for (trait_name, prefix, exposed) in [
-            ("QuoteApi", QUOTE_PREFIX, quote_method_names()),
-            ("TradeApi", TRADE_PREFIX, trade_method_names()),
+            ("QuoteApi", QUOTE_PREFIX, QUOTE_METHODS),
+            ("TradeApi", TRADE_PREFIX, TRADE_METHODS),
         ] {
             let declared = trait_methods(trait_name);
             assert!(
@@ -619,7 +618,7 @@ mod tests {
 
     #[test]
     fn every_advertised_method_is_routable() {
-        let catalog = method_catalog();
+        let catalog = all_methods();
         for method in &catalog {
             assert!(is_known(method), "{method} advertised but not routable");
         }

--- a/src/cli/serve/methods.rs
+++ b/src/cli/serve/methods.rs
@@ -1,0 +1,714 @@
+//! RPC methods for `longbridge serve`.
+//!
+//! # Where this layer sits
+//!
+//! Deliberately *below* the CLI commands, at the API client seam they all share:
+//!
+//! ```text
+//!   CLI commands (151, AI-facing JSON, free to change)
+//!         │
+//!         ├── QuoteApi / TradeApi traits ──┐
+//!         └── http_get / http_post ────────┤
+//!                                          ▼
+//!                            serve (raw upstream payloads)
+//! ```
+//!
+//! Two consequences, both deliberate:
+//!
+//! 1. **Stable shapes.** A `result` here is `serde_json::to_value` of the SDK
+//!    response type, or the untouched REST body — the Longbridge `OpenAPI`
+//!    contract. The CLI's `--format json` reshapes data for AI consumption and
+//!    is free to change; third-party clients must not be coupled to that.
+//!
+//! 2. **No parallel dev track.** Every CLI command reaches the network through
+//!    one of these two seams, so `serve` covers all of them without per-command
+//!    work. REST-backed commands need nothing at all — `api.get`/`api.post`
+//!    already reach any endpoint. SDK-backed commands are covered by the trait
+//!    mirror below, and [`tests::serve_exposes_every_api_trait_method`] fails
+//!    the build if a trait method is ever added without one.
+
+use anyhow::{bail, Result};
+use longbridge::quote::{PushEvent, PushEventDetail, SubFlags};
+use serde_json::{json, Value};
+
+use super::params::Params;
+use super::protocol::{Message, PROTOCOL_VERSION};
+use crate::cli::api::{QuoteApi, TradeApi};
+
+/// Namespace prefixes: `quote.<QuoteApi method>`, `trade.<TradeApi method>`.
+///
+/// Named after the API trait methods rather than the CLI command spellings on
+/// purpose — CLI names may be tuned for AI ergonomics, the API seam is the
+/// stable thing, and the mechanical mapping is what lets the coverage test
+/// enforce itself.
+const QUOTE_PREFIX: &str = "quote.";
+const TRADE_PREFIX: &str = "trade.";
+
+/// Methods that are not a trait mirror: session control, the REST passthrough,
+/// and the live subscription that has no one-shot CLI equivalent.
+const EXTRA_METHODS: &[&str] = &[
+    "initialize",
+    "shutdown",
+    "api.get",
+    "api.post",
+    "quote.subscribe",
+    "quote.unsubscribe",
+];
+
+fn quote_api() -> crate::cli::api::LbQuoteApi {
+    crate::cli::api::LbQuoteApi::new(crate::openapi::quote_cmd())
+}
+
+fn trade_api() -> crate::cli::api::LbTradeApi {
+    crate::cli::api::LbTradeApi::new(crate::openapi::trade())
+}
+
+/// Wrap an SDK response as a JSON-RPC result.
+fn ok<T: serde::Serialize>(value: T) -> Result<Value> {
+    Ok(serde_json::to_value(value)?)
+}
+
+pub fn is_known(method: &str) -> bool {
+    EXTRA_METHODS.contains(&method)
+        || quote_method_names().contains(&method.trim_start_matches(QUOTE_PREFIX))
+            && method.starts_with(QUOTE_PREFIX)
+        || trade_method_names().contains(&method.trim_start_matches(TRADE_PREFIX))
+            && method.starts_with(TRADE_PREFIX)
+}
+
+/// The `QuoteApi` methods exposed, in trait declaration order.
+fn quote_method_names() -> &'static [&'static str] {
+    &[
+        "quote",
+        "depth",
+        "brokers",
+        "trades",
+        "intraday",
+        "candlesticks",
+        "history_candlesticks_by_date",
+        "history_candlesticks_by_offset",
+        "static_info",
+        "us_crypto_overview",
+        "calc_indexes",
+        "capital_flow",
+        "capital_distribution",
+        "market_temperature",
+        "history_market_temperature",
+        "trading_session",
+        "trading_days",
+        "security_list",
+        "participants",
+        "subscriptions",
+        "option_quote",
+        "option_chain_expiry_date_list",
+        "option_chain_info_by_date",
+        "warrant_quote",
+        "warrant_list",
+        "warrant_issuers",
+        "watchlist",
+        "create_watchlist_group",
+        "delete_watchlist_group",
+        "update_watchlist_group",
+    ]
+}
+
+/// The `TradeApi` methods exposed, in trait declaration order.
+fn trade_method_names() -> &'static [&'static str] {
+    &[
+        "today_orders",
+        "history_orders",
+        "order_detail",
+        "today_executions",
+        "history_executions",
+        "submit_order",
+        "cancel_order",
+        "replace_order",
+        "account_balance",
+        "cash_flow",
+        "stock_positions",
+        "fund_positions",
+        "margin_ratio",
+        "estimate_max_purchase_quantity",
+    ]
+}
+
+/// A method list for `initialize`, so a client can discover the surface
+/// without out-of-band documentation.
+fn method_catalog() -> Vec<String> {
+    let mut all: Vec<String> = EXTRA_METHODS.iter().map(|m| (*m).to_string()).collect();
+    all.extend(
+        quote_method_names()
+            .iter()
+            .map(|m| format!("{QUOTE_PREFIX}{m}")),
+    );
+    all.extend(
+        trade_method_names()
+            .iter()
+            .map(|m| format!("{TRADE_PREFIX}{m}")),
+    );
+    all.sort();
+    all
+}
+
+/// Run one method. Errors surface as JSON-RPC errors and never end the
+/// session: one bad symbol must not take down a client's live feed.
+pub async fn call(method: &str, params: Option<Value>) -> Result<Value> {
+    let p = Params(params.as_ref());
+
+    match method {
+        // ── Session ──────────────────────────────────────────────────────
+        "initialize" => Ok(json!({
+            "protocolVersion": PROTOCOL_VERSION,
+            "serverInfo": { "name": "longbridge", "version": env!("CARGO_PKG_VERSION") },
+            "capabilities": {
+                "subscribe": ["quote", "depth", "brokers", "trades"],
+            },
+            "methods": method_catalog(),
+        })),
+        // Handled by the run loop; listed so `is_known` accepts it.
+        "shutdown" => Ok(Value::Null),
+
+        // ── Raw REST passthrough ─────────────────────────────────────────
+        // Covers every endpoint the CLI reaches over HTTP, including ones
+        // added later, and returns the response body untouched.
+        "api.get" => {
+            let path = p.str("path")?;
+            let query = p.query("query")?;
+            let pairs: Vec<(&str, &str)> = query
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            crate::cli::api::http_get(&path, &pairs, false).await
+        }
+        "api.post" => {
+            let path = p.str("path")?;
+            let body = params
+                .as_ref()
+                .and_then(|v| v.get("body"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            crate::cli::api::http_post(&path, body, false).await
+        }
+
+        // ── Live subscription (no one-shot CLI equivalent) ───────────────
+        "quote.subscribe" => {
+            let symbols = p.strs("symbols")?;
+            let flags = parse_fields(p)?;
+            // Subscribing starts the feed; it does not replay the current
+            // value. Clients paint the initial screen with `quote.quote`,
+            // which they call anyway to render the list.
+            let ctx = crate::openapi::quote_cmd();
+            ctx.subscribe(&symbols, flags).await?;
+            active_subscriptions(ctx).await
+        }
+        "quote.unsubscribe" => {
+            let symbols = p.strs("symbols")?;
+            // Drop every field: a client unsubscribing a symbol wants it gone,
+            // not downgraded to whatever it did not happen to name.
+            let ctx = crate::openapi::quote_cmd();
+            ctx.unsubscribe(&symbols, SubFlags::all()).await?;
+            active_subscriptions(ctx).await
+        }
+
+        _ => {
+            if let Some(name) = method.strip_prefix(QUOTE_PREFIX) {
+                call_quote(name, p).await
+            } else if let Some(name) = method.strip_prefix(TRADE_PREFIX) {
+                call_trade(name, p).await
+            } else {
+                bail!("unknown method `{method}`")
+            }
+        }
+    }
+}
+
+async fn call_quote(name: &str, p: Params<'_>) -> Result<Value> {
+    let api = quote_api();
+    match name {
+        "quote" => ok(api.quote(p.strs("symbols")?).await?),
+        "depth" => ok(api.depth(p.str("symbol")?).await?),
+        "brokers" => ok(api.brokers(p.str("symbol")?).await?),
+        "trades" => ok(api
+            .trades(p.str("symbol")?, p.usize_or("count", 20)?)
+            .await?),
+        "intraday" => ok(api.intraday(p.str("symbol")?).await?),
+        "candlesticks" => ok(api
+            .candlesticks(
+                p.str("symbol")?,
+                p.period("period")?,
+                p.usize_or("count", 100)?,
+                p.adjust("adjust")?,
+            )
+            .await?),
+        "history_candlesticks_by_date" => ok(api
+            .history_candlesticks_by_date(
+                p.str("symbol")?,
+                p.period("period")?,
+                p.adjust("adjust")?,
+                p.date_opt("start")?,
+                p.date_opt("end")?,
+            )
+            .await?),
+        "history_candlesticks_by_offset" => ok(api
+            .history_candlesticks_by_offset(
+                p.str("symbol")?,
+                p.period("period")?,
+                p.adjust("adjust")?,
+                p.usize_or("count", 100)?,
+            )
+            .await?),
+        "static_info" => ok(api.static_info(p.strs("symbols")?).await?),
+        "us_crypto_overview" => api.us_crypto_overview(p.str("symbol")?).await,
+        "calc_indexes" => {
+            let indexes = crate::cli::quote::parse_calc_indexes(&p.strs("indexes")?);
+            ok(api.calc_indexes(p.strs("symbols")?, indexes).await?)
+        }
+        "capital_flow" => ok(api.capital_flow(p.str("symbol")?).await?),
+        "capital_distribution" => ok(api.capital_distribution(p.str("symbol")?).await?),
+        "market_temperature" => ok(api.market_temperature(p.market("market")?).await?),
+        "history_market_temperature" => ok(api
+            .history_market_temperature(p.market("market")?, p.date("start")?, p.date("end")?)
+            .await?),
+        "trading_session" => ok(api.trading_session().await?),
+        "trading_days" => ok(api
+            .trading_days(p.market("market")?, p.date("start")?, p.date("end")?)
+            .await?),
+        "security_list" => ok(api.security_list(p.market("market")?).await?),
+        "participants" => ok(api.participants().await?),
+        // `Subscription` is one of the few SDK types without `Serialize`, so
+        // its fields are mirrored by hand under their SDK names.
+        "subscriptions" => ok(api
+            .subscriptions()
+            .await?
+            .iter()
+            .map(|s| {
+                json!({
+                    "symbol": s.symbol,
+                    "sub_types": flags_to_names(s.sub_types),
+                    "candlesticks": s.candlesticks.iter().map(|p| format!("{p:?}")).collect::<Vec<_>>(),
+                })
+            })
+            .collect::<Vec<_>>()),
+        "option_quote" => ok(api.option_quote(p.strs("symbols")?).await?),
+        "option_chain_expiry_date_list" => {
+            ok(api.option_chain_expiry_date_list(p.str("symbol")?).await?)
+        }
+        "option_chain_info_by_date" => ok(api
+            .option_chain_info_by_date(p.str("symbol")?, p.date("expiry_date")?)
+            .await?),
+        "warrant_quote" => ok(api.warrant_quote(p.strs("symbols")?).await?),
+        "warrant_list" => ok(api.warrant_list(p.str("symbol")?).await?),
+        "warrant_issuers" => ok(api.warrant_issuers().await?),
+        "watchlist" => ok(api.watchlist().await?),
+        "create_watchlist_group" => ok(json!({
+            "id": api.create_watchlist_group(p.str("name")?).await?,
+        })),
+        "delete_watchlist_group" => {
+            api.delete_watchlist_group(p.i64("id")?).await?;
+            Ok(Value::Null)
+        }
+        "update_watchlist_group" => {
+            api.update_watchlist_group(update_group_request(p)?).await?;
+            Ok(Value::Null)
+        }
+        other => bail!("unknown method `{QUOTE_PREFIX}{other}`"),
+    }
+}
+
+async fn call_trade(name: &str, p: Params<'_>) -> Result<Value> {
+    use longbridge::trade::{
+        EstimateMaxPurchaseQuantityOptions, GetCashFlowOptions, GetHistoryExecutionsOptions,
+        GetHistoryOrdersOptions, GetTodayExecutionsOptions, GetTodayOrdersOptions,
+        ReplaceOrderOptions, SubmitOrderOptions,
+    };
+    let api = trade_api();
+    match name {
+        "today_orders" => {
+            let mut opts = GetTodayOrdersOptions::new();
+            if let Some(s) = p.str_opt("symbol")? {
+                opts = opts.symbol(s);
+            }
+            ok(api.today_orders(opts).await?)
+        }
+        "history_orders" => {
+            let mut opts = GetHistoryOrdersOptions::new();
+            if let Some(s) = p.str_opt("symbol")? {
+                opts = opts.symbol(s);
+            }
+            if let Some(s) = p.str_opt("start")? {
+                opts = opts.start_at(crate::cli::output::parse_datetime_start(&s)?);
+            }
+            if let Some(e) = p.str_opt("end")? {
+                opts = opts.end_at(crate::cli::output::parse_datetime_end(&e)?);
+            }
+            ok(api.history_orders(opts).await?)
+        }
+        "order_detail" => ok(api.order_detail(p.str("order_id")?).await?),
+        "today_executions" => {
+            let mut opts = GetTodayExecutionsOptions::new();
+            if let Some(s) = p.str_opt("symbol")? {
+                opts = opts.symbol(s);
+            }
+            ok(api.today_executions(opts).await?)
+        }
+        "history_executions" => {
+            let mut opts = GetHistoryExecutionsOptions::new();
+            if let Some(s) = p.str_opt("symbol")? {
+                opts = opts.symbol(s);
+            }
+            if let Some(s) = p.str_opt("start")? {
+                opts = opts.start_at(crate::cli::output::parse_datetime_start(&s)?);
+            }
+            if let Some(e) = p.str_opt("end")? {
+                opts = opts.end_at(crate::cli::output::parse_datetime_end(&e)?);
+            }
+            ok(api.history_executions(opts).await?)
+        }
+        "submit_order" => {
+            let mut opts = SubmitOrderOptions::new(
+                p.str("symbol")?,
+                crate::cli::trade::parse_order_type(&p.str("order_type")?)?,
+                parse_side(&p.str("side")?)?,
+                decimal(&p.str("quantity")?, "quantity")?,
+                crate::cli::trade::parse_tif(&p.str("time_in_force")?)?,
+            );
+            if let Some(v) = p.str_opt("price")? {
+                opts = opts.submitted_price(decimal(&v, "price")?);
+            }
+            if let Some(v) = p.str_opt("trigger_price")? {
+                opts = opts.trigger_price(decimal(&v, "trigger_price")?);
+            }
+            if let Some(v) = p.str_opt("outside_rth")? {
+                opts = opts.outside_rth(crate::cli::trade::parse_outside_rth(&v)?);
+            }
+            if let Some(v) = p.str_opt("remark")? {
+                opts = opts.remark(v);
+            }
+            ok(api.submit_order(opts).await?)
+        }
+        "cancel_order" => {
+            api.cancel_order(p.str("order_id")?).await?;
+            Ok(Value::Null)
+        }
+        "replace_order" => {
+            let mut opts = ReplaceOrderOptions::new(
+                p.str("order_id")?,
+                decimal(&p.str("quantity")?, "quantity")?,
+            );
+            if let Some(v) = p.str_opt("price")? {
+                opts = opts.price(decimal(&v, "price")?);
+            }
+            api.replace_order(opts).await?;
+            Ok(Value::Null)
+        }
+        "account_balance" => ok(api.account_balance(p.str_opt("currency")?).await?),
+        "cash_flow" => {
+            let opts = GetCashFlowOptions::new(
+                crate::cli::output::parse_datetime_start(&p.str("start")?)?,
+                crate::cli::output::parse_datetime_end(&p.str("end")?)?,
+            );
+            ok(api.cash_flow(opts).await?)
+        }
+        "stock_positions" => ok(api.stock_positions().await?),
+        "fund_positions" => ok(api.fund_positions().await?),
+        "margin_ratio" => ok(api.margin_ratio(p.str("symbol")?).await?),
+        "estimate_max_purchase_quantity" => {
+            let mut opts = EstimateMaxPurchaseQuantityOptions::new(
+                p.str("symbol")?,
+                crate::cli::trade::parse_order_type(&p.str("order_type")?)?,
+                parse_side(&p.str("side")?)?,
+            );
+            if let Some(v) = p.str_opt("price")? {
+                opts = opts.price(decimal(&v, "price")?);
+            }
+            ok(api.estimate_max_purchase_quantity(opts).await?)
+        }
+        other => bail!("unknown method `{TRADE_PREFIX}{other}`"),
+    }
+}
+
+fn parse_side(s: &str) -> Result<longbridge::trade::OrderSide> {
+    match s.to_lowercase().as_str() {
+        "buy" => Ok(longbridge::trade::OrderSide::Buy),
+        "sell" => Ok(longbridge::trade::OrderSide::Sell),
+        other => bail!("`side` must be buy or sell, got `{other}`"),
+    }
+}
+
+/// Decimals cross the wire as strings so a client cannot lose precision to a
+/// JSON float on the way to an order.
+fn decimal(raw: &str, field: &str) -> Result<rust_decimal::Decimal> {
+    use std::str::FromStr;
+    rust_decimal::Decimal::from_str(raw)
+        .map_err(|_| anyhow::anyhow!("`{field}` must be a decimal string, got `{raw}`"))
+}
+
+fn update_group_request(p: Params<'_>) -> Result<longbridge::quote::RequestUpdateWatchlistGroup> {
+    use longbridge::quote::SecuritiesUpdateMode;
+    let mode = match p.str_opt("mode")?.as_deref() {
+        None | Some("add") => SecuritiesUpdateMode::Add,
+        Some("remove") => SecuritiesUpdateMode::Remove,
+        Some("replace") => SecuritiesUpdateMode::Replace,
+        Some(other) => bail!("`mode` must be add, remove or replace, got `{other}`"),
+    };
+    let securities = p.strs_opt("securities")?;
+    Ok(longbridge::quote::RequestUpdateWatchlistGroup {
+        id: p.i64("id")?,
+        name: p.str_opt("name")?,
+        securities: (!securities.is_empty()).then_some(securities),
+        mode,
+    })
+}
+
+fn parse_fields(p: Params<'_>) -> Result<SubFlags> {
+    let names = p.strs_opt("fields")?;
+    if names.is_empty() {
+        return Ok(SubFlags::QUOTE);
+    }
+    let mut flags = SubFlags::empty();
+    for name in &names {
+        flags |= match name.as_str() {
+            "quote" => SubFlags::QUOTE,
+            "depth" => SubFlags::DEPTH,
+            "brokers" => SubFlags::BROKER,
+            "trades" => SubFlags::TRADE,
+            other => {
+                bail!("`fields`: unknown field `{other}`; expected quote, depth, brokers or trades")
+            }
+        };
+    }
+    Ok(flags)
+}
+
+async fn active_subscriptions(ctx: &longbridge::quote::QuoteContext) -> Result<Value> {
+    // The SDK keeps a symbol in the list with an empty flag set after its last
+    // field is unsubscribed. Reporting those would make `subscribed` mean
+    // "known to the SDK" rather than "receiving pushes", so drop them.
+    let subs = ctx.subscriptions().await?;
+    Ok(json!({
+        "subscribed": subs
+            .iter()
+            .filter(|s| !s.sub_types.is_empty())
+            .map(|s| json!({ "symbol": s.symbol, "fields": flags_to_names(s.sub_types) }))
+            .collect::<Vec<_>>(),
+    }))
+}
+
+fn flags_to_names(flags: SubFlags) -> Vec<&'static str> {
+    let mut names = Vec::new();
+    if flags.contains(SubFlags::QUOTE) {
+        names.push("quote");
+    }
+    if flags.contains(SubFlags::DEPTH) {
+        names.push("depth");
+    }
+    if flags.contains(SubFlags::BROKER) {
+        names.push("brokers");
+    }
+    if flags.contains(SubFlags::TRADE) {
+        names.push("trades");
+    }
+    names
+}
+
+/// Translate one WebSocket push into a client notification.
+///
+/// The `Push*` structs are among the few SDK types without `Serialize`, so
+/// their fields are mirrored by hand — under the SDK's own names, so the
+/// payload still tracks the upstream contract rather than a shape of our
+/// invention. `None` drops event kinds the protocol does not expose yet.
+pub fn push_to_notification(event: PushEvent) -> Option<Message> {
+    let symbol = event.symbol;
+    let (method, mut params) = match event.detail {
+        PushEventDetail::Quote(q) => (
+            "quote.updated",
+            json!({
+                "last_done": q.last_done,
+                "open": q.open,
+                "high": q.high,
+                "low": q.low,
+                "timestamp": crate::utils::datetime::fmt_rfc3339(q.timestamp),
+                "volume": q.volume,
+                "turnover": q.turnover,
+                // `TradeStatus` has no `Serialize`; its Debug name is the same
+                // spelling the CLI prints.
+                "trade_status": format!("{:?}", q.trade_status),
+                "trade_session": q.trade_session,
+                "current_volume": q.current_volume,
+                "current_turnover": q.current_turnover,
+            }),
+        ),
+        PushEventDetail::Depth(d) => ("quote.depth", json!({ "asks": d.asks, "bids": d.bids })),
+        PushEventDetail::Brokers(b) => (
+            "quote.brokers",
+            json!({ "ask_brokers": b.ask_brokers, "bid_brokers": b.bid_brokers }),
+        ),
+        PushEventDetail::Trade(t) => ("quote.trades", json!({ "trades": t.trades })),
+        PushEventDetail::Candlestick(_) => return None,
+    };
+    // Splice the symbol in: the push payload carries only the data, and a
+    // notification without a symbol is useless to a client tracking a list.
+    params
+        .as_object_mut()?
+        .insert("symbol".into(), symbol.into());
+    Some(Message::notification(method, params))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Extract the `async fn` names declared by a trait in `src/cli/api.rs`.
+    fn trait_methods(trait_name: &str) -> Vec<String> {
+        let src = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/cli/api.rs"),
+        )
+        .expect("read src/cli/api.rs");
+        let start = src
+            .find(&format!("pub trait {trait_name}"))
+            .unwrap_or_else(|| panic!("trait {trait_name} not found"));
+        let body = &src[start..];
+        let end = body.find("\n}").expect("trait end");
+        body[..end]
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                let rest = line.strip_prefix("async fn ")?;
+                Some(rest.split('(').next()?.trim().to_string())
+            })
+            .collect()
+    }
+
+    /// The guard that keeps `serve` from becoming a separate development
+    /// track: every `QuoteApi`/`TradeApi` method — the seam every SDK-backed
+    /// CLI command goes through — must be reachable over RPC. Adding a trait
+    /// method without exposing it fails here.
+    #[test]
+    fn serve_exposes_every_api_trait_method() {
+        for (trait_name, prefix, exposed) in [
+            ("QuoteApi", QUOTE_PREFIX, quote_method_names()),
+            ("TradeApi", TRADE_PREFIX, trade_method_names()),
+        ] {
+            let declared = trait_methods(trait_name);
+            assert!(
+                !declared.is_empty(),
+                "failed to parse {trait_name} from src/cli/api.rs"
+            );
+            let missing: Vec<_> = declared
+                .iter()
+                .filter(|m| !exposed.contains(&m.as_str()))
+                .collect();
+            assert!(
+                missing.is_empty(),
+                "{trait_name} methods not exposed by `serve`: {missing:?}\n\
+                 Add them to `{prefix}` dispatch so third-party clients keep parity with the CLI."
+            );
+
+            // And the reverse: no method advertised that the trait dropped.
+            let stale: Vec<_> = exposed
+                .iter()
+                .filter(|m| !declared.iter().any(|d| d == *m))
+                .collect();
+            assert!(
+                stale.is_empty(),
+                "{trait_name}: stale serve methods {stale:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_advertised_method_is_routable() {
+        let catalog = method_catalog();
+        for method in &catalog {
+            assert!(is_known(method), "{method} advertised but not routable");
+        }
+        // The catalog is the client's only discovery surface, so it must list
+        // the whole seam, mutating methods included.
+        for expected in [
+            "api.get",
+            "quote.watchlist",
+            "quote.subscribe",
+            "trade.submit_order",
+            "trade.stock_positions",
+        ] {
+            assert!(
+                catalog.contains(&expected.to_string()),
+                "{expected} missing from catalog"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_and_near_miss_methods_are_rejected() {
+        assert!(!is_known("quote.nope"));
+        assert!(!is_known("nope.quote"));
+        assert!(!is_known("quote"));
+        assert!(!is_known(""));
+        assert!(is_known("quote.watchlist"));
+        assert!(is_known("trade.stock_positions"));
+        assert!(is_known("api.get"));
+    }
+
+    #[test]
+    fn fields_default_to_quote_and_combine() {
+        let v = json!({});
+        assert_eq!(parse_fields(Params(Some(&v))).unwrap(), SubFlags::QUOTE);
+        let v = json!({"fields": ["quote", "depth"]});
+        assert_eq!(
+            parse_fields(Params(Some(&v))).unwrap(),
+            SubFlags::QUOTE | SubFlags::DEPTH
+        );
+        let v = json!({"fields": ["candles"]});
+        let err = parse_fields(Params(Some(&v))).unwrap_err().to_string();
+        assert!(err.contains("candles") && err.contains("depth"), "{err}");
+    }
+
+    #[test]
+    fn decimals_are_parsed_from_strings_not_floats() {
+        assert_eq!(
+            decimal("123.456", "price").unwrap(),
+            rust_decimal::Decimal::new(123_456, 3)
+        );
+        let err = decimal("abc", "price").unwrap_err().to_string();
+        assert!(err.starts_with("`price`"), "{err}");
+    }
+
+    #[test]
+    fn order_side_accepts_either_case() {
+        use longbridge::trade::OrderSide;
+        assert_eq!(parse_side("buy").unwrap(), OrderSide::Buy);
+        assert_eq!(parse_side("SELL").unwrap(), OrderSide::Sell);
+        assert!(parse_side("hold").unwrap_err().to_string().contains("side"));
+    }
+
+    #[test]
+    fn watchlist_update_defaults_to_add_and_omits_empty_securities() {
+        use longbridge::quote::SecuritiesUpdateMode;
+        let v = json!({"id": 42});
+        let req = update_group_request(Params(Some(&v))).unwrap();
+        assert_eq!(req.id, 42);
+        assert!(req.securities.is_none());
+        assert!(matches!(req.mode, SecuritiesUpdateMode::Add));
+
+        let v = json!({"id": 1, "mode": "replace", "securities": ["700.HK"]});
+        let req = update_group_request(Params(Some(&v))).unwrap();
+        assert_eq!(req.securities.unwrap(), vec!["700.HK".to_string()]);
+        assert!(matches!(req.mode, SecuritiesUpdateMode::Replace));
+
+        let v = json!({"id": 1, "mode": "obliterate"});
+        assert!(update_group_request(Params(Some(&v)))
+            .unwrap_err()
+            .to_string()
+            .contains("obliterate"));
+    }
+
+    #[test]
+    fn flag_names_round_trip() {
+        assert_eq!(flags_to_names(SubFlags::QUOTE), vec!["quote"]);
+        assert_eq!(
+            flags_to_names(SubFlags::all()),
+            vec!["quote", "depth", "brokers", "trades"]
+        );
+    }
+}

--- a/src/cli/serve/mod.rs
+++ b/src/cli/serve/mod.rs
@@ -46,6 +46,63 @@ use protocol::{
     Message, API_ERROR, INVALID_PARAMS, INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR,
 };
 
+/// The method list appended to `serve -h`.
+///
+/// Generated from the [`methods`] routing tables, not written out a second
+/// time, so the help cannot advertise a surface the dispatcher does not have.
+/// Only names: parameters follow the Longbridge `OpenAPI` request for the same
+/// call, and a second hand-maintained copy of them here would be one more
+/// thing to drift.
+pub fn method_reference() -> String {
+    use std::fmt::Write;
+
+    let mut out = String::from(
+        "PROTOCOL\n\
+         \x20 Newline-delimited JSON-RPC 2.0 on stdin/stdout: one compact JSON object per\n\
+         \x20 line, UTF-8.\n\n\
+         \x20 request       {\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"<method>\",\"params\":{…}}\n\
+         \x20 response      {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":…}\n\
+         \x20 error         {\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32602,\"message\":\"…\"}}\n\
+         \x20 notification  {\"jsonrpc\":\"2.0\",\"method\":\"quote.updated\",\"params\":{…}}\n\n\
+         \x20 Requests are answered concurrently, so responses may arrive out of order —\n\
+         \x20 correlate them by id. Codes follow JSON-RPC: -32700 parse, -32600 invalid\n\
+         \x20 request, -32601 unknown method, -32602 bad params, -32000 upstream failure.\n\
+         \x20 A -32602 message names the offending field. The process exits on stdin EOF.\n\n\
+         PARAMS AND RESULTS\n\
+         \x20 Both are the raw Longbridge OpenAPI shapes for the same call, not the\n\
+         \x20 reshaped JSON the equivalent CLI command prints. Look a method up under its\n\
+         \x20 own name at https://open.longbridge.com/docs for its fields; quote.* and\n\
+         \x20 trade.* are named after the SDK calls they forward to.\n\n\
+         NOTIFICATIONS\n\
+         \x20 quote.updated, quote.depth, quote.brokers, quote.trades — delivered for the\n\
+         \x20 securities and fields named in quote.subscribe, each carrying its symbol.\n\n\
+         METHODS\n",
+    );
+
+    // Two per line: 50 names down a single column would bury the sections
+    // above it in scrollback.
+    let names = methods::all_methods();
+    for pair in names.chunks(2) {
+        let _ = match pair {
+            [a, b] => writeln!(out, "  {a:<38}{b}"),
+            [a] => writeln!(out, "  {a}"),
+            _ => Ok(()),
+        };
+    }
+
+    out.push_str(
+        "\n\x20 `initialize` returns this same list, so a client can discover it in-band.\n\n\
+         EXAMPLE\n\
+         \x20 $ longbridge serve\n\
+         \x20 → {\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"quote.quote\",\"params\":{\"symbols\":[\"700.HK\"]}}\n\
+         \x20 ← {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[{\"symbol\":\"700.HK\",\"last_done\":\"445.600\",…}]}\n\
+         \x20 → {\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"quote.subscribe\",\"params\":{\"symbols\":[\"700.HK\"]}}\n\
+         \x20 ← {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"subscribed\":[{\"symbol\":\"700.HK\",\"fields\":[\"quote\"]}]}}\n\
+         \x20 ← {\"jsonrpc\":\"2.0\",\"method\":\"quote.updated\",\"params\":{\"symbol\":\"700.HK\",\"last_done\":\"446.000\",…}}\n",
+    );
+    out
+}
+
 /// Classify a handler error into a JSON-RPC code.
 ///
 /// Parameter validation is the caller's fault (`INVALID_PARAMS`); anything else

--- a/src/cli/serve/mod.rs
+++ b/src/cli/serve/mod.rs
@@ -1,0 +1,186 @@
+//! `longbridge serve` — a long-lived JSON-RPC 2.0 endpoint for third-party
+//! clients (desktop widgets, bar plugins, scripts).
+//!
+//! # Why this exists
+//!
+//! Without it, a client polls by spawning `longbridge <cmd> --format json` on a
+//! timer. Every spawn re-does region detection, token load, WebSocket connect,
+//! one request, exit — so the cost dominates, and the client is stuck at
+//! poll-interval latency with no way to see a tick.
+//!
+//! `serve` pays that cost once and keeps the connection. Quotes then arrive as
+//! server-initiated notifications at WebSocket speed.
+//!
+//! # Wire format
+//!
+//! Newline-delimited JSON-RPC 2.0 over stdio: one compact JSON object per
+//! line. This is the base protocol LSP, MCP and ACP share, so a client needs
+//! only a JSON parser and a line splitter — no protocol library.
+//!
+//! Requests are handled concurrently: a slow `trade.stock_positions` must not
+//! stall the quote feed, so each one runs in its own task and every writer
+//! funnels through a single channel that owns stdout. Responses may therefore
+//! arrive out of order — correlate them by `id`, as JSON-RPC intends.
+//!
+//! ```text
+//! → {"jsonrpc":"2.0","id":1,"method":"quote.quote","params":{"symbols":["700.HK"]}}
+//! ← {"jsonrpc":"2.0","id":1,"result":[{"symbol":"700.HK","last_done":"320.000",...}]}
+//! → {"jsonrpc":"2.0","id":2,"method":"quote.subscribe","params":{"symbols":["700.HK"]}}
+//! ← {"jsonrpc":"2.0","id":2,"result":{"subscribed":[{"symbol":"700.HK","fields":["quote"]}]}}
+//! ← {"jsonrpc":"2.0","method":"quote.updated","params":{"symbol":"700.HK","last_done":"320.200",...}}
+//! ```
+//!
+//! See [`methods`] for where the method surface comes from and why its payloads
+//! are the raw upstream shapes rather than the CLI's `--format json` output.
+
+pub mod methods;
+pub mod params;
+pub mod protocol;
+
+use anyhow::Result;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::mpsc;
+use tokio_stream::{Stream, StreamExt};
+
+use protocol::{
+    Message, API_ERROR, INVALID_PARAMS, INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR,
+};
+
+/// Classify a handler error into a JSON-RPC code.
+///
+/// Parameter validation is the caller's fault (`INVALID_PARAMS`); anything else
+/// came back from Longbridge and is ours or the network's (`API_ERROR`).
+/// The distinction matters to a client deciding whether a retry can help.
+fn error_code_for(err: &anyhow::Error) -> i32 {
+    let msg = err.to_string();
+    if msg.starts_with("missing required parameter")
+        || msg.starts_with('`')
+        || msg.starts_with("unknown field")
+    {
+        INVALID_PARAMS
+    } else {
+        API_ERROR
+    }
+}
+
+/// Serve until stdin closes or the client calls `shutdown`.
+///
+/// `quote_stream` is the WebSocket push feed from `openapi::init_contexts`,
+/// which every other CLI command discards.
+pub async fn run(
+    quote_stream: impl Stream<Item = longbridge::quote::PushEvent> + Send + Unpin + 'static,
+) -> Result<()> {
+    let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+
+    // Sole owner of stdout. Serializing writes through one task is what keeps
+    // concurrent handlers and the push feed from interleaving mid-line.
+    let writer = tokio::spawn(async move {
+        let mut out = tokio::io::stdout();
+        while let Some(line) = rx.recv().await {
+            if out.write_all(line.as_bytes()).await.is_err()
+                || out.write_all(b"\n").await.is_err()
+                || out.flush().await.is_err()
+            {
+                // The client is gone; further writes cannot succeed either.
+                break;
+            }
+        }
+    });
+
+    let push_tx = tx.clone();
+    let pusher = tokio::spawn(async move {
+        let mut quote_stream = quote_stream;
+        while let Some(event) = quote_stream.next().await {
+            if let Some(message) = methods::push_to_notification(event) {
+                if push_tx.send(message.to_line()).is_err() {
+                    break;
+                }
+            }
+        }
+    });
+
+    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+    // EOF on stdin means the client exited: shut down rather than linger as an
+    // orphan holding a WebSocket open.
+    while let Some(line) = lines.next_line().await? {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let request: protocol::Request = match serde_json::from_str(line) {
+            Ok(request) => request,
+            Err(e) => {
+                let code = if serde_json::from_str::<serde_json::Value>(line).is_ok() {
+                    // Valid JSON, wrong shape (e.g. no `method`).
+                    INVALID_REQUEST
+                } else {
+                    PARSE_ERROR
+                };
+                let _ = tx.send(Message::error(None, code, e.to_string()).to_line());
+                continue;
+            }
+        };
+
+        if request.method == "shutdown" {
+            if let Some(id) = request.id {
+                let _ = tx.send(Message::result(id, serde_json::Value::Null).to_line());
+            }
+            break;
+        }
+
+        if !methods::is_known(&request.method) {
+            // Unknown notifications are silently ignored, as JSON-RPC requires.
+            if let Some(id) = request.id {
+                let message = format!("unknown method `{}`", request.method);
+                let _ = tx.send(Message::error(Some(id), METHOD_NOT_FOUND, message).to_line());
+            }
+            continue;
+        }
+
+        // One task per request so a slow call cannot block the read loop —
+        // that is the whole point of holding the connection open.
+        let reply_tx = tx.clone();
+        tokio::spawn(async move {
+            let outcome = methods::call(&request.method, request.params).await;
+            // A notification (no `id`) still runs; it just owes no reply.
+            let Some(id) = request.id else { return };
+            let message = match outcome {
+                Ok(result) => Message::result(id, result),
+                Err(e) => Message::error(Some(id), error_code_for(&e), e.to_string()),
+            };
+            let _ = reply_tx.send(message.to_line());
+        });
+    }
+
+    // Drop the last sender so the writer drains what is queued and stops.
+    drop(tx);
+    pusher.abort();
+    let _ = writer.await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parameter_mistakes_and_upstream_failures_get_different_codes() {
+        assert_eq!(
+            error_code_for(&anyhow::anyhow!("missing required parameter `symbols`")),
+            INVALID_PARAMS
+        );
+        assert_eq!(
+            error_code_for(&anyhow::anyhow!("`symbols` must not be empty")),
+            INVALID_PARAMS
+        );
+        assert_eq!(
+            error_code_for(&anyhow::anyhow!("unknown field `candles`; expected quote")),
+            INVALID_PARAMS
+        );
+        assert_eq!(
+            error_code_for(&anyhow::anyhow!("connection reset by peer")),
+            API_ERROR
+        );
+    }
+}

--- a/src/cli/serve/mod.rs
+++ b/src/cli/serve/mod.rs
@@ -21,6 +21,7 @@
 //! stall the quote feed, so each one runs in its own task and every writer
 //! funnels through a single channel that owns stdout. Responses may therefore
 //! arrive out of order — correlate them by `id`, as JSON-RPC intends.
+//! [`MAX_CONCURRENT_REQUESTS`] bounds how much of that reaches Longbridge.
 //!
 //! ```text
 //! → {"jsonrpc":"2.0","id":1,"method":"quote.quote","params":{"symbols":["700.HK"]}}
@@ -37,14 +38,34 @@ pub mod methods;
 pub mod params;
 pub mod protocol;
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use anyhow::Result;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Semaphore};
 use tokio_stream::{Stream, StreamExt};
 
+use params::ParamError;
 use protocol::{
     Message, API_ERROR, INVALID_PARAMS, INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR,
 };
+
+/// How many requests may be in flight upstream at once.
+///
+/// Longbridge allows on the order of 10 requests a second. A one-shot CLI
+/// invocation cannot get near that, but this process lives long enough for a
+/// client to queue lines faster than the network answers them, and every
+/// request runs in its own task — without a cap, one burst becomes one burst
+/// upstream and the whole session starts getting throttled.
+const MAX_CONCURRENT_REQUESTS: usize = 8;
+
+/// How long to wait for in-flight requests after `shutdown` or stdin EOF.
+///
+/// The writer only stops once every handler has dropped its sender, so a
+/// single request stuck upstream would otherwise hold the process open after
+/// its client is gone — the exact orphan the EOF handling exists to prevent.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The method list appended to `serve -h`.
 ///
@@ -59,23 +80,34 @@ pub fn method_reference() -> String {
     let mut out = String::from(
         "PROTOCOL\n\
          \x20 Newline-delimited JSON-RPC 2.0 on stdin/stdout: one compact JSON object per\n\
-         \x20 line, UTF-8.\n\n\
+         \x20 line, UTF-8. One request per line — batches (a JSON array) are not accepted,\n\
+         \x20 as in LSP and MCP.\n\n\
          \x20 request       {\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"<method>\",\"params\":{…}}\n\
          \x20 response      {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":…}\n\
          \x20 error         {\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32602,\"message\":\"…\"}}\n\
          \x20 notification  {\"jsonrpc\":\"2.0\",\"method\":\"quote.updated\",\"params\":{…}}\n\n\
          \x20 Requests are answered concurrently, so responses may arrive out of order —\n\
-         \x20 correlate them by id. Codes follow JSON-RPC: -32700 parse, -32600 invalid\n\
-         \x20 request, -32601 unknown method, -32602 bad params, -32000 upstream failure.\n\
-         \x20 A -32602 message names the offending field. The process exits on stdin EOF.\n\n\
+         \x20 correlate them by id. Up to 8 run upstream at once; the rest queue, so a\n\
+         \x20 burst is never dropped, only paced. Codes follow JSON-RPC: -32700 parse,\n\
+         \x20 -32600 invalid request, -32601 unknown method, -32602 bad params, -32000\n\
+         \x20 upstream failure. A -32602 message names the offending field and means\n\
+         \x20 retrying as-is will not help; -32000 may. The process exits on stdin EOF.\n\n\
          PARAMS AND RESULTS\n\
          \x20 Both are the raw Longbridge OpenAPI shapes for the same call, not the\n\
          \x20 reshaped JSON the equivalent CLI command prints. Look a method up under its\n\
          \x20 own name at https://open.longbridge.com/docs for its fields; quote.* and\n\
-         \x20 trade.* are named after the SDK calls they forward to.\n\n\
+         \x20 trade.* are named after the SDK calls they forward to. api.get/api.post\n\
+         \x20 return the response body as received, less the account-identifying fields\n\
+         \x20 the CLI also strips (aaid, account_channel).\n\n\
          NOTIFICATIONS\n\
          \x20 quote.updated, quote.depth, quote.brokers, quote.trades — delivered for the\n\
-         \x20 securities and fields named in quote.subscribe, each carrying its symbol.\n\n\
+         \x20 securities and fields named in quote.subscribe, each carrying its symbol.\n\
+         \x20 quote.updated is a tick, not a full quote: it carries last_done, open, high,\n\
+         \x20 low, volume, turnover, current_volume, current_turnover, trade_status,\n\
+         \x20 trade_session and timestamp. quote.subscribe returns a `quotes` snapshot to\n\
+         \x20 start from (omitted if that one call failed; fall back to quote.quote). A\n\
+         \x20 push may still be older than the snapshot, so keep whichever timestamp is\n\
+         \x20 newer.\n\n\
          METHODS\n",
     );
 
@@ -106,14 +138,12 @@ pub fn method_reference() -> String {
 /// Classify a handler error into a JSON-RPC code.
 ///
 /// Parameter validation is the caller's fault (`INVALID_PARAMS`); anything else
-/// came back from Longbridge and is ours or the network's (`API_ERROR`).
-/// The distinction matters to a client deciding whether a retry can help.
+/// came back from Longbridge and is ours or the network's (`API_ERROR`). The
+/// distinction matters to a client deciding whether a retry can help, so it is
+/// carried by [`ParamError`]'s type — an upstream message that happens to be
+/// worded like a parameter complaint must not be blamed on the client.
 fn error_code_for(err: &anyhow::Error) -> i32 {
-    let msg = err.to_string();
-    if msg.starts_with("missing required parameter")
-        || msg.starts_with('`')
-        || msg.starts_with("unknown field")
-    {
+    if err.downcast_ref::<ParamError>().is_some() {
         INVALID_PARAMS
     } else {
         API_ERROR
@@ -128,6 +158,7 @@ pub async fn run(
     quote_stream: impl Stream<Item = longbridge::quote::PushEvent> + Send + Unpin + 'static,
 ) -> Result<()> {
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+    let permits = Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS));
 
     // Sole owner of stdout. Serializing writes through one task is what keeps
     // concurrent handlers and the push feed from interleaving mid-line.
@@ -196,9 +227,14 @@ pub async fn run(
         }
 
         // One task per request so a slow call cannot block the read loop —
-        // that is the whole point of holding the connection open.
+        // that is the whole point of holding the connection open. The permit
+        // is what keeps "concurrent" from meaning "unbounded": it is taken
+        // inside the task so the read loop keeps accepting lines while
+        // requests queue for their turn upstream.
         let reply_tx = tx.clone();
+        let permits = Arc::clone(&permits);
         tokio::spawn(async move {
+            let _permit = permits.acquire().await;
             let outcome = methods::call(&request.method, request.params).await;
             // A notification (no `id`) still runs; it just owes no reply.
             let Some(id) = request.id else { return };
@@ -210,10 +246,12 @@ pub async fn run(
         });
     }
 
-    // Drop the last sender so the writer drains what is queued and stops.
+    // Drop the last sender so the writer drains what is queued and stops once
+    // the in-flight handlers drop theirs — bounded, so one wedged upstream
+    // call cannot keep the process alive after its client is gone.
     drop(tx);
     pusher.abort();
-    let _ = writer.await;
+    let _ = tokio::time::timeout(DRAIN_TIMEOUT, writer).await;
     Ok(())
 }
 
@@ -224,20 +262,44 @@ mod tests {
     #[test]
     fn parameter_mistakes_and_upstream_failures_get_different_codes() {
         assert_eq!(
-            error_code_for(&anyhow::anyhow!("missing required parameter `symbols`")),
-            INVALID_PARAMS
-        );
-        assert_eq!(
-            error_code_for(&anyhow::anyhow!("`symbols` must not be empty")),
-            INVALID_PARAMS
-        );
-        assert_eq!(
-            error_code_for(&anyhow::anyhow!("unknown field `candles`; expected quote")),
+            error_code_for(&params::param_err("missing required parameter `symbols`")),
             INVALID_PARAMS
         );
         assert_eq!(
             error_code_for(&anyhow::anyhow!("connection reset by peer")),
             API_ERROR
         );
+    }
+
+    /// The reason the classification is by type: an upstream failure worded
+    /// like a parameter complaint used to be reported as the client's fault,
+    /// telling it not to retry something a retry would have fixed.
+    #[test]
+    fn an_upstream_error_worded_like_a_parameter_complaint_is_still_upstream() {
+        for msg in [
+            "`700.HK` is not available in your region",
+            "missing required parameter `symbols` (upstream said so)",
+            "unknown field in response",
+        ] {
+            assert_eq!(
+                error_code_for(&anyhow::anyhow!(msg)),
+                API_ERROR,
+                "misclassified: {msg}"
+            );
+        }
+    }
+
+    /// A `ParamError` keeps its meaning through the `?` chain that carries it
+    /// out of a handler, which is where the classification actually happens.
+    #[test]
+    fn a_param_error_survives_being_wrapped_by_anyhow() {
+        fn inner() -> Result<()> {
+            Err(params::param_err("`side` must be buy or sell"))
+        }
+        fn outer() -> Result<()> {
+            inner()?;
+            Ok(())
+        }
+        assert_eq!(error_code_for(&outer().unwrap_err()), INVALID_PARAMS);
     }
 }

--- a/src/cli/serve/params.rs
+++ b/src/cli/serve/params.rs
@@ -1,0 +1,264 @@
+//! Typed extraction of JSON-RPC `params` fields.
+//!
+//! Every accessor names the offending field in its error so a client gets a
+//! message it can act on rather than a bare "invalid params". Errors start
+//! with a backtick or a known prefix; `serve::error_code_for` keys off that to
+//! return `INVALID_PARAMS` instead of `API_ERROR`.
+
+use anyhow::{bail, Result};
+use serde_json::Value;
+
+/// Borrowed view over a request's `params` object.
+#[derive(Clone, Copy)]
+pub struct Params<'a>(pub Option<&'a Value>);
+
+impl<'a> Params<'a> {
+    fn get(self, key: &str) -> Option<&'a Value> {
+        self.0.and_then(|p| p.get(key))
+    }
+
+    pub fn str(self, key: &str) -> Result<String> {
+        match self.get(key) {
+            Some(Value::String(s)) => Ok(s.clone()),
+            Some(_) => bail!("`{key}` must be a string"),
+            None => bail!("missing required parameter `{key}`"),
+        }
+    }
+
+    pub fn str_opt(self, key: &str) -> Result<Option<String>> {
+        match self.get(key) {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::String(s)) => Ok(Some(s.clone())),
+            Some(_) => bail!("`{key}` must be a string"),
+        }
+    }
+
+    pub fn strs(self, key: &str) -> Result<Vec<String>> {
+        let Some(value) = self.get(key) else {
+            bail!("missing required parameter `{key}`");
+        };
+        let Some(list) = value.as_array() else {
+            bail!("`{key}` must be an array of strings");
+        };
+        let mut out = Vec::with_capacity(list.len());
+        for item in list {
+            let Some(s) = item.as_str() else {
+                bail!("`{key}` must be an array of strings");
+            };
+            out.push(s.to_string());
+        }
+        if out.is_empty() {
+            bail!("`{key}` must not be empty");
+        }
+        Ok(out)
+    }
+
+    /// Optional string array; an absent key yields an empty list rather than
+    /// an error, for genuinely optional filters.
+    pub fn strs_opt(self, key: &str) -> Result<Vec<String>> {
+        match self.get(key) {
+            None | Some(Value::Null) => Ok(Vec::new()),
+            Some(_) => self.strs(key),
+        }
+    }
+
+    pub fn i64(self, key: &str) -> Result<i64> {
+        match self.get(key) {
+            Some(v) => v
+                .as_i64()
+                .ok_or_else(|| anyhow::anyhow!("`{key}` must be an integer")),
+            None => bail!("missing required parameter `{key}`"),
+        }
+    }
+
+    pub fn usize_or(self, key: &str, default: usize) -> Result<usize> {
+        match self.get(key) {
+            None | Some(Value::Null) => Ok(default),
+            Some(v) => {
+                let n = v
+                    .as_u64()
+                    .ok_or_else(|| anyhow::anyhow!("`{key}` must be a non-negative integer"))?;
+                Ok(usize::try_from(n).unwrap_or(usize::MAX))
+            }
+        }
+    }
+
+    pub fn bool_or(self, key: &str, default: bool) -> Result<bool> {
+        match self.get(key) {
+            None | Some(Value::Null) => Ok(default),
+            Some(Value::Bool(b)) => Ok(*b),
+            Some(_) => bail!("`{key}` must be a boolean"),
+        }
+    }
+
+    /// A `YYYY-MM-DD` date, parsed by the same helper the CLI flags use.
+    pub fn date(self, key: &str) -> Result<time::Date> {
+        let raw = self.str(key)?;
+        crate::cli::output::parse_date(&raw)
+            .map_err(|_| anyhow::anyhow!("`{key}` must be a date in YYYY-MM-DD form, got `{raw}`"))
+    }
+
+    pub fn date_opt(self, key: &str) -> Result<Option<time::Date>> {
+        match self.str_opt(key)? {
+            None => Ok(None),
+            Some(raw) => crate::cli::output::parse_date(&raw).map(Some).map_err(|_| {
+                anyhow::anyhow!("`{key}` must be a date in YYYY-MM-DD form, got `{raw}`")
+            }),
+        }
+    }
+
+    /// Market code, accepted in the same spellings as the CLI (`HK`, `US`,
+    /// `CN`/`SH`/`SZ`, `SG`).
+    pub fn market(self, key: &str) -> Result<longbridge::Market> {
+        let raw = self.str(key)?;
+        crate::cli::quote::parse_market(&raw).map_err(|e| anyhow::anyhow!("`{key}`: {e}"))
+    }
+
+    pub fn period(self, key: &str) -> Result<longbridge::quote::Period> {
+        let raw = self.str(key)?;
+        crate::cli::quote::parse_period(&raw).map_err(|e| anyhow::anyhow!("`{key}`: {e}"))
+    }
+
+    /// Adjustment type; defaults to `none`, matching `kline --adjust`.
+    pub fn adjust(self, key: &str) -> Result<longbridge::quote::AdjustType> {
+        match self.str_opt(key)? {
+            None => Ok(longbridge::quote::AdjustType::NoAdjust),
+            Some(raw) => {
+                crate::cli::quote::parse_adjust(&raw).map_err(|e| anyhow::anyhow!("`{key}`: {e}"))
+            }
+        }
+    }
+
+    /// Raw query-string pairs for the REST passthrough. Scalars are stringified
+    /// so a client can pass `{"count": 20}` as well as `{"count": "20"}`.
+    pub fn query(self, key: &str) -> Result<Vec<(String, String)>> {
+        let Some(value) = self.get(key) else {
+            return Ok(Vec::new());
+        };
+        if value.is_null() {
+            return Ok(Vec::new());
+        }
+        let Some(map) = value.as_object() else {
+            bail!("`{key}` must be an object of string values");
+        };
+        map.iter()
+            .map(|(k, v)| match v {
+                Value::String(s) => Ok((k.clone(), s.clone())),
+                Value::Bool(_) | Value::Number(_) => Ok((k.clone(), v.to_string())),
+                _ => bail!("`{key}.{k}` must be a string, number or boolean"),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn p(v: &Value) -> Params<'_> {
+        Params(Some(v))
+    }
+
+    #[test]
+    fn a_missing_field_is_named_in_the_error() {
+        let v = json!({});
+        assert_eq!(
+            p(&v).str("symbol").unwrap_err().to_string(),
+            "missing required parameter `symbol`"
+        );
+        assert_eq!(
+            Params(None).strs("symbols").unwrap_err().to_string(),
+            "missing required parameter `symbols`"
+        );
+    }
+
+    #[test]
+    fn a_wrong_type_is_named_in_the_error() {
+        let v = json!({"symbol": 7, "symbols": "700.HK", "flag": "yes"});
+        assert_eq!(
+            p(&v).str("symbol").unwrap_err().to_string(),
+            "`symbol` must be a string"
+        );
+        assert_eq!(
+            p(&v).strs("symbols").unwrap_err().to_string(),
+            "`symbols` must be an array of strings"
+        );
+        assert_eq!(
+            p(&v).bool_or("flag", false).unwrap_err().to_string(),
+            "`flag` must be a boolean"
+        );
+    }
+
+    #[test]
+    fn optional_fields_fall_back_without_erroring() {
+        let v = json!({});
+        assert_eq!(p(&v).str_opt("x").unwrap(), None);
+        assert_eq!(p(&v).strs_opt("x").unwrap(), Vec::<String>::new());
+        assert_eq!(p(&v).usize_or("count", 20).unwrap(), 20);
+        assert!(p(&v).bool_or("flag", true).unwrap());
+        assert_eq!(p(&v).date_opt("start").unwrap(), None);
+        assert_eq!(
+            p(&v).adjust("adjust").unwrap(),
+            longbridge::quote::AdjustType::NoAdjust
+        );
+        // An explicit null is the same as absent: clients serialize optionals
+        // that way, and rejecting it would make every optional field awkward.
+        let nulls = json!({"x": null, "count": null, "start": null});
+        assert_eq!(p(&nulls).str_opt("x").unwrap(), None);
+        assert_eq!(p(&nulls).usize_or("count", 5).unwrap(), 5);
+        assert_eq!(p(&nulls).date_opt("start").unwrap(), None);
+    }
+
+    #[test]
+    fn enums_accept_the_same_spellings_as_cli_flags() {
+        let v = json!({"market": "hk", "period": "1d", "adjust": "forward"});
+        assert_eq!(p(&v).market("market").unwrap(), longbridge::Market::HK);
+        assert_eq!(
+            p(&v).period("period").unwrap(),
+            longbridge::quote::Period::Day
+        );
+        assert_eq!(
+            p(&v).adjust("adjust").unwrap(),
+            longbridge::quote::AdjustType::ForwardAdjust
+        );
+    }
+
+    #[test]
+    fn a_bad_enum_or_date_names_the_field_and_the_input() {
+        let v = json!({"market": "MARS", "start": "07/01/2026"});
+        let err = p(&v).market("market").unwrap_err().to_string();
+        assert!(err.starts_with("`market`"), "{err}");
+        assert!(err.contains("MARS"), "{err}");
+
+        let err = p(&v).date("start").unwrap_err().to_string();
+        assert!(err.starts_with("`start`"), "{err}");
+        assert!(err.contains("07/01/2026"), "{err}");
+    }
+
+    #[test]
+    fn query_stringifies_scalars() {
+        let v = json!({"q": {"count": 20, "symbol": "700.HK", "all": true}});
+        let mut got = p(&v).query("q").unwrap();
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                ("all".to_string(), "true".to_string()),
+                ("count".to_string(), "20".to_string()),
+                ("symbol".to_string(), "700.HK".to_string()),
+            ]
+        );
+        assert!(p(&json!({})).query("q").unwrap().is_empty());
+        assert!(p(&json!({"q": {"bad": []}})).query("q").is_err());
+    }
+
+    #[test]
+    fn an_empty_required_array_is_rejected() {
+        let v = json!({"symbols": []});
+        assert_eq!(
+            p(&v).strs("symbols").unwrap_err().to_string(),
+            "`symbols` must not be empty"
+        );
+    }
+}

--- a/src/cli/serve/params.rs
+++ b/src/cli/serve/params.rs
@@ -1,12 +1,46 @@
 //! Typed extraction of JSON-RPC `params` fields.
 //!
 //! Every accessor names the offending field in its error so a client gets a
-//! message it can act on rather than a bare "invalid params". Errors start
-//! with a backtick or a known prefix; `serve::error_code_for` keys off that to
-//! return `INVALID_PARAMS` instead of `API_ERROR`.
+//! message it can act on rather than a bare "invalid params", and every such
+//! error is a [`ParamError`] so `serve::error_code_for` can classify it by
+//! type.
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use serde_json::Value;
+
+/// A parameter the client got wrong, as opposed to a failure that came back
+/// from Longbridge.
+///
+/// The distinction decides the JSON-RPC code, and a client keys its retry
+/// logic off that code: `INVALID_PARAMS` means retrying the same request is
+/// pointless, `API_ERROR` means it may not be. Carrying the distinction in the
+/// type rather than in the wording of the message is what keeps an upstream
+/// failure phrased like a parameter complaint from being blamed on the client.
+#[derive(Debug)]
+pub struct ParamError(String);
+
+impl std::fmt::Display for ParamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ParamError {}
+
+/// Build a [`ParamError`] as an `anyhow::Error`, ready to `?` or return.
+pub fn param_err(message: impl Into<String>) -> anyhow::Error {
+    anyhow::Error::new(ParamError(message.into()))
+}
+
+/// `bail!` for parameter mistakes: same ergonomics, but the error keeps its
+/// type so it cannot be mistaken for an upstream failure.
+macro_rules! bail_param {
+    ($($arg:tt)*) => {
+        return ::std::result::Result::Err($crate::cli::serve::params::param_err(format!($($arg)*)))
+    };
+}
+
+pub(crate) use bail_param;
 
 /// Borrowed view over a request's `params` object.
 #[derive(Clone, Copy)]
@@ -20,8 +54,8 @@ impl<'a> Params<'a> {
     pub fn str(self, key: &str) -> Result<String> {
         match self.get(key) {
             Some(Value::String(s)) => Ok(s.clone()),
-            Some(_) => bail!("`{key}` must be a string"),
-            None => bail!("missing required parameter `{key}`"),
+            Some(_) => bail_param!("`{key}` must be a string"),
+            None => bail_param!("missing required parameter `{key}`"),
         }
     }
 
@@ -29,26 +63,26 @@ impl<'a> Params<'a> {
         match self.get(key) {
             None | Some(Value::Null) => Ok(None),
             Some(Value::String(s)) => Ok(Some(s.clone())),
-            Some(_) => bail!("`{key}` must be a string"),
+            Some(_) => bail_param!("`{key}` must be a string"),
         }
     }
 
     pub fn strs(self, key: &str) -> Result<Vec<String>> {
         let Some(value) = self.get(key) else {
-            bail!("missing required parameter `{key}`");
+            bail_param!("missing required parameter `{key}`");
         };
         let Some(list) = value.as_array() else {
-            bail!("`{key}` must be an array of strings");
+            bail_param!("`{key}` must be an array of strings");
         };
         let mut out = Vec::with_capacity(list.len());
         for item in list {
             let Some(s) = item.as_str() else {
-                bail!("`{key}` must be an array of strings");
+                bail_param!("`{key}` must be an array of strings");
             };
             out.push(s.to_string());
         }
         if out.is_empty() {
-            bail!("`{key}` must not be empty");
+            bail_param!("`{key}` must not be empty");
         }
         Ok(out)
     }
@@ -66,8 +100,8 @@ impl<'a> Params<'a> {
         match self.get(key) {
             Some(v) => v
                 .as_i64()
-                .ok_or_else(|| anyhow::anyhow!("`{key}` must be an integer")),
-            None => bail!("missing required parameter `{key}`"),
+                .ok_or_else(|| param_err(format!("`{key}` must be an integer"))),
+            None => bail_param!("missing required parameter `{key}`"),
         }
     }
 
@@ -77,32 +111,29 @@ impl<'a> Params<'a> {
             Some(v) => {
                 let n = v
                     .as_u64()
-                    .ok_or_else(|| anyhow::anyhow!("`{key}` must be a non-negative integer"))?;
+                    .ok_or_else(|| param_err(format!("`{key}` must be a non-negative integer")))?;
                 Ok(usize::try_from(n).unwrap_or(usize::MAX))
             }
-        }
-    }
-
-    pub fn bool_or(self, key: &str, default: bool) -> Result<bool> {
-        match self.get(key) {
-            None | Some(Value::Null) => Ok(default),
-            Some(Value::Bool(b)) => Ok(*b),
-            Some(_) => bail!("`{key}` must be a boolean"),
         }
     }
 
     /// A `YYYY-MM-DD` date, parsed by the same helper the CLI flags use.
     pub fn date(self, key: &str) -> Result<time::Date> {
         let raw = self.str(key)?;
-        crate::cli::output::parse_date(&raw)
-            .map_err(|_| anyhow::anyhow!("`{key}` must be a date in YYYY-MM-DD form, got `{raw}`"))
+        crate::cli::output::parse_date(&raw).map_err(|_| {
+            param_err(format!(
+                "`{key}` must be a date in YYYY-MM-DD form, got `{raw}`"
+            ))
+        })
     }
 
     pub fn date_opt(self, key: &str) -> Result<Option<time::Date>> {
         match self.str_opt(key)? {
             None => Ok(None),
             Some(raw) => crate::cli::output::parse_date(&raw).map(Some).map_err(|_| {
-                anyhow::anyhow!("`{key}` must be a date in YYYY-MM-DD form, got `{raw}`")
+                param_err(format!(
+                    "`{key}` must be a date in YYYY-MM-DD form, got `{raw}`"
+                ))
             }),
         }
     }
@@ -111,21 +142,20 @@ impl<'a> Params<'a> {
     /// `CN`/`SH`/`SZ`, `SG`).
     pub fn market(self, key: &str) -> Result<longbridge::Market> {
         let raw = self.str(key)?;
-        crate::cli::quote::parse_market(&raw).map_err(|e| anyhow::anyhow!("`{key}`: {e}"))
+        crate::cli::quote::parse_market(&raw).map_err(|e| param_err(format!("`{key}`: {e}")))
     }
 
     pub fn period(self, key: &str) -> Result<longbridge::quote::Period> {
         let raw = self.str(key)?;
-        crate::cli::quote::parse_period(&raw).map_err(|e| anyhow::anyhow!("`{key}`: {e}"))
+        crate::cli::quote::parse_period(&raw).map_err(|e| param_err(format!("`{key}`: {e}")))
     }
 
     /// Adjustment type; defaults to `none`, matching `kline --adjust`.
     pub fn adjust(self, key: &str) -> Result<longbridge::quote::AdjustType> {
         match self.str_opt(key)? {
             None => Ok(longbridge::quote::AdjustType::NoAdjust),
-            Some(raw) => {
-                crate::cli::quote::parse_adjust(&raw).map_err(|e| anyhow::anyhow!("`{key}`: {e}"))
-            }
+            Some(raw) => crate::cli::quote::parse_adjust(&raw)
+                .map_err(|e| param_err(format!("`{key}`: {e}"))),
         }
     }
 
@@ -139,13 +169,15 @@ impl<'a> Params<'a> {
             return Ok(Vec::new());
         }
         let Some(map) = value.as_object() else {
-            bail!("`{key}` must be an object of string values");
+            bail_param!("`{key}` must be an object of string values");
         };
         map.iter()
             .map(|(k, v)| match v {
                 Value::String(s) => Ok((k.clone(), s.clone())),
                 Value::Bool(_) | Value::Number(_) => Ok((k.clone(), v.to_string())),
-                _ => bail!("`{key}.{k}` must be a string, number or boolean"),
+                _ => Err(param_err(format!(
+                    "`{key}.{k}` must be a string, number or boolean"
+                ))),
             })
             .collect()
     }
@@ -175,7 +207,7 @@ mod tests {
 
     #[test]
     fn a_wrong_type_is_named_in_the_error() {
-        let v = json!({"symbol": 7, "symbols": "700.HK", "flag": "yes"});
+        let v = json!({"symbol": 7, "symbols": "700.HK"});
         assert_eq!(
             p(&v).str("symbol").unwrap_err().to_string(),
             "`symbol` must be a string"
@@ -184,10 +216,34 @@ mod tests {
             p(&v).strs("symbols").unwrap_err().to_string(),
             "`symbols` must be an array of strings"
         );
-        assert_eq!(
-            p(&v).bool_or("flag", false).unwrap_err().to_string(),
-            "`flag` must be a boolean"
-        );
+    }
+
+    /// Every rejection here is the client's fault, and the code that says so
+    /// downcasts rather than reading the message — so the type, not the
+    /// wording, is what the test pins.
+    #[test]
+    fn every_rejection_carries_the_param_error_type() {
+        let v = json!({"symbol": 7, "market": "MARS", "start": "07/01/2026", "id": "x", "q": {"bad": []}});
+        let errors = [
+            p(&v).str("missing").unwrap_err(),
+            p(&v).str("symbol").unwrap_err(),
+            p(&v).strs("missing").unwrap_err(),
+            p(&json!({"symbols": []})).strs("symbols").unwrap_err(),
+            p(&v).i64("id").unwrap_err(),
+            p(&v).usize_or("market", 1).unwrap_err(),
+            p(&v).date("start").unwrap_err(),
+            p(&v).date_opt("start").unwrap_err(),
+            p(&v).market("market").unwrap_err(),
+            p(&v).period("market").unwrap_err(),
+            p(&v).adjust("market").unwrap_err(),
+            p(&v).query("q").unwrap_err(),
+        ];
+        for err in &errors {
+            assert!(
+                err.downcast_ref::<ParamError>().is_some(),
+                "not a ParamError: {err}"
+            );
+        }
     }
 
     #[test]
@@ -196,7 +252,6 @@ mod tests {
         assert_eq!(p(&v).str_opt("x").unwrap(), None);
         assert_eq!(p(&v).strs_opt("x").unwrap(), Vec::<String>::new());
         assert_eq!(p(&v).usize_or("count", 20).unwrap(), 20);
-        assert!(p(&v).bool_or("flag", true).unwrap());
         assert_eq!(p(&v).date_opt("start").unwrap(), None);
         assert_eq!(
             p(&v).adjust("adjust").unwrap(),

--- a/src/cli/serve/protocol.rs
+++ b/src/cli/serve/protocol.rs
@@ -1,0 +1,165 @@
+//! JSON-RPC 2.0 message types for `longbridge serve`.
+//!
+//! The wire format is newline-delimited JSON (NDJSON): exactly one compact
+//! JSON object per line, UTF-8, no framing headers. This is the same base
+//! protocol LSP, MCP and ACP build on, so a client needs nothing beyond a
+//! JSON parser and a line splitter.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Protocol revision reported by `initialize`. Bump on a breaking change to
+/// method names, parameters, or result shapes.
+pub const PROTOCOL_VERSION: &str = "1";
+
+/// Standard JSON-RPC 2.0 error codes.
+pub const PARSE_ERROR: i32 = -32700;
+pub const INVALID_REQUEST: i32 = -32600;
+pub const METHOD_NOT_FOUND: i32 = -32601;
+pub const INVALID_PARAMS: i32 = -32602;
+
+/// Application error: the request was well-formed but the upstream Longbridge
+/// call failed (network, permission, unknown symbol, ...).
+pub const API_ERROR: i32 = -32000;
+
+/// An incoming JSON-RPC request.
+///
+/// `id` is absent for notifications, which take no response. Both are parsed
+/// by the same type because the only difference is whether a reply is owed.
+#[derive(Debug, Deserialize)]
+pub struct Request {
+    #[serde(default)]
+    pub id: Option<Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorObject {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+/// A response or a server-initiated notification.
+///
+/// JSON-RPC distinguishes them by the presence of `id`, so one struct with
+/// skipped-when-absent fields covers both and keeps the writer path single.
+#[derive(Debug, Serialize)]
+pub struct Message {
+    pub jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorObject>,
+}
+
+impl Message {
+    fn base() -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id: None,
+            method: None,
+            params: None,
+            result: None,
+            error: None,
+        }
+    }
+
+    /// A successful response. `result` is always present — JSON-RPC requires
+    /// exactly one of `result`/`error`, and `null` is a valid result.
+    pub fn result(id: Value, result: Value) -> Self {
+        Self {
+            id: Some(id),
+            result: Some(result),
+            ..Self::base()
+        }
+    }
+
+    pub fn error(id: Option<Value>, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            id,
+            error: Some(ErrorObject {
+                code,
+                message: message.into(),
+                data: None,
+            }),
+            ..Self::base()
+        }
+    }
+
+    /// A server-initiated notification (no `id`, so the client owes no reply).
+    pub fn notification(method: &'static str, params: Value) -> Self {
+        Self {
+            method: Some(method),
+            params: Some(params),
+            ..Self::base()
+        }
+    }
+
+    /// Serialize to a single NDJSON line. Compact on purpose: a pretty-printed
+    /// object would span lines and break the framing.
+    pub fn to_line(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|e| {
+            // Only reachable if a handler produced a non-serializable value.
+            // Degrade to a valid frame rather than desynchronizing the stream.
+            format!(
+                r#"{{"jsonrpc":"2.0","error":{{"code":{API_ERROR},"message":"failed to serialize response: {}"}}}}"#,
+                e.to_string().replace('"', "'")
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn result_and_error_are_mutually_exclusive_on_the_wire() {
+        let ok = Message::result(Value::from(1), serde_json::json!({"a": 1})).to_line();
+        assert_eq!(ok, r#"{"jsonrpc":"2.0","id":1,"result":{"a":1}}"#);
+
+        let err = Message::error(Some(Value::from(2)), METHOD_NOT_FOUND, "nope").to_line();
+        assert_eq!(
+            err,
+            r#"{"jsonrpc":"2.0","id":2,"error":{"code":-32601,"message":"nope"}}"#
+        );
+    }
+
+    #[test]
+    fn notifications_carry_no_id() {
+        let line = Message::notification("quote.updated", serde_json::json!({"symbol": "700.HK"}))
+            .to_line();
+        assert_eq!(
+            line,
+            r#"{"jsonrpc":"2.0","method":"quote.updated","params":{"symbol":"700.HK"}}"#
+        );
+    }
+
+    #[test]
+    fn a_request_without_id_parses_as_a_notification() {
+        let req: Request =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","method":"shutdown"}"#).unwrap();
+        assert!(req.id.is_none());
+        assert_eq!(req.method, "shutdown");
+    }
+
+    #[test]
+    fn every_frame_is_a_single_line() {
+        let line = Message::result(
+            Value::from(1),
+            serde_json::json!({"nested": {"deep": [1, 2, 3]}}),
+        )
+        .to_line();
+        assert!(!line.contains('\n'));
+    }
+}

--- a/src/cli/trade.rs
+++ b/src/cli/trade.rs
@@ -28,7 +28,7 @@ fn risk_level_name(level: i32) -> &'static str {
     }
 }
 
-fn parse_order_type(s: &str) -> Result<OrderType> {
+pub fn parse_order_type(s: &str) -> Result<OrderType> {
     match s.to_uppercase().as_str() {
         "LO" => Ok(OrderType::LO),
         "MO" => Ok(OrderType::MO),
@@ -47,7 +47,7 @@ fn parse_order_type(s: &str) -> Result<OrderType> {
     }
 }
 
-fn parse_tif(s: &str) -> Result<TimeInForceType> {
+pub fn parse_tif(s: &str) -> Result<TimeInForceType> {
     match s.to_lowercase().as_str() {
         "day" => Ok(TimeInForceType::Day),
         "gtc" | "goodtilcanceled" => Ok(TimeInForceType::GoodTilCanceled),
@@ -625,7 +625,7 @@ pub async fn cmd_executions(
     Ok(())
 }
 
-fn parse_outside_rth(s: &str) -> Result<OutsideRTH> {
+pub fn parse_outside_rth(s: &str) -> Result<OutsideRTH> {
     match s.to_uppercase().as_str() {
         "RTH_ONLY" => Ok(OutsideRTH::RTHOnly),
         "ANY_TIME" => Ok(OutsideRTH::AnyTime),

--- a/src/cli/watchlist.rs
+++ b/src/cli/watchlist.rs
@@ -30,28 +30,36 @@ fn sorted_securities(
     sorted
 }
 
+/// Render watchlist groups as the JSON array that `watchlist --format json`
+/// emits.
+fn groups_to_json(groups: &[longbridge::quote::WatchlistGroup]) -> Vec<serde_json::Value> {
+    groups
+        .iter()
+        .map(|g| {
+            serde_json::json!({
+                "id": g.id,
+                "name": g.name,
+                "securities": sorted_securities(&g.securities).iter().map(|s| serde_json::json!({
+                    "symbol": s.symbol,
+                    "name": s.name,
+                    "market": format!("{:?}", s.market),
+                    "is_pinned": s.is_pinned,
+                })).collect::<Vec<_>>(),
+            })
+        })
+        .collect()
+}
+
 async fn cmd_list(format: &OutputFormat) -> Result<()> {
     let ctx = crate::openapi::quote_cmd();
     let groups = ctx.watchlist().await?;
 
     match format {
         OutputFormat::Json => {
-            let val: Vec<_> = groups
-                .iter()
-                .map(|g| {
-                    serde_json::json!({
-                        "id": g.id,
-                        "name": g.name,
-                        "securities": sorted_securities(&g.securities).iter().map(|s| serde_json::json!({
-                            "symbol": s.symbol,
-                            "name": s.name,
-                            "market": format!("{:?}", s.market),
-                            "is_pinned": s.is_pinned,
-                        })).collect::<Vec<_>>(),
-                    })
-                })
-                .collect();
-            println!("{}", serde_json::to_string_pretty(&val)?);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&groups_to_json(&groups))?
+            );
         }
         OutputFormat::Pretty => {
             for group in &groups {

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,6 +289,27 @@ async fn main() {
             return;
         }
 
+        // `serve` is the only command that keeps the market WebSocket: every
+        // other one discards the push stream after `init_contexts`.
+        Some(cli::Commands::Serve) => {
+            let (quote_receiver, using_api_key, _) = match openapi::init_contexts().await {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("Authentication failed: {e}");
+                    std::process::exit(1);
+                }
+            };
+            if let Err(e) = openapi::quote().member_id().await {
+                print_cli_error(&anyhow::anyhow!(e), using_api_key);
+                std::process::exit(1);
+            }
+            if let Err(e) = cli::serve::run(quote_receiver).await {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+            return;
+        }
+
         Some(cli::Commands::Init { invite_code }) => {
             if let Err(e) = cli::init::cmd_init(&invite_code) {
                 eprintln!("Error: {e}");


### PR DESCRIPTION
## What

Adds `longbridge serve`: a long-lived JSON-RPC 2.0 endpoint on stdin/stdout for third-party clients — desktop widgets, bar plugins, dashboards.

Today such a client polls by spawning `longbridge <cmd> --format json` on a timer. Each spawn redoes region detection, token load and WebSocket connect for one request, so it pays the startup cost every time and can never see a price tick between polls.

`serve` pays that cost once and keeps the connection:

```jsonc
→ {"jsonrpc":"2.0","id":1,"method":"quote.quote","params":{"symbols":["700.HK"]}}
← {"jsonrpc":"2.0","id":1,"result":[{"symbol":"700.HK","last_done":"445.600", ...}]}
→ {"jsonrpc":"2.0","id":2,"method":"quote.subscribe","params":{"symbols":["700.HK"]}}
← {"jsonrpc":"2.0","id":2,"result":{"subscribed":[{"symbol":"700.HK","fields":["quote"]}]}}
← {"jsonrpc":"2.0","method":"quote.updated","params":{"symbol":"700.HK","last_done":"446.000", ...}}
```

Newline-delimited JSON-RPC 2.0 is the base protocol LSP, MCP and ACP all build on, so a client needs only a JSON parser and a line splitter — no protocol library. MCP itself was considered and rejected for the live feed: its `notifications/resources/updated` carries a URI only, so every tick would cost a `resources/read` round trip.

## Method surface

`serve` sits *below* the CLI commands, at the API seam all of them share:

| Namespace | Covers |
| --- | --- |
| `quote.*` | Every `QuoteApi` call — `quote.quote`, `quote.depth`, `quote.candlesticks`, `quote.watchlist`, … |
| `trade.*` | Every `TradeApi` call — `trade.stock_positions`, `trade.account_balance`, `trade.submit_order`, … |
| `api.get` / `api.post` | Raw passthrough to any REST endpoint. This is how the fundamentals, screener, IPO and news commands reach their data. |
| `quote.subscribe` / `quote.unsubscribe` | Live feed over `quote`, `depth`, `brokers`, `trades`. No one-shot CLI equivalent. |
| `initialize` / `shutdown` | Session control; `initialize` returns the full method list so clients discover the surface rather than hard-code it. |

Notifications: `quote.updated`, `quote.depth`, `quote.brokers`, `quote.trades`.

## Two properties worth calling out

**Payloads are the raw upstream shapes**, not the CLI's JSON. `--format json` reshapes data for AI consumption and is free to change with it; `serve` is a contract for other people's software, so it tracks the Longbridge OpenAPI instead. `trade.account_balance` returns SDK field names (`buy_power`, `cash_infos`, `max_finance_amount`); `api.get /v1/quote/market-status` returns `trade_status: 204` rather than a rendered label.

**`serve` cannot drift behind the CLI.** Because it mirrors the `QuoteApi`/`TradeApi` traits plus a REST passthrough, a new command either reuses an existing seam (already exposed) or adds a trait method — and `serve_exposes_every_api_trait_method` reads `src/cli/api.rs` and fails the build in that case. The check runs both directions, so a stale method left behind after a trait change also fails.

Derived views the CLI computes locally — `portfolio`, which merges balances, positions and FX rates — are deliberately *not* methods. A client composes them from `trade.account_balance`, `trade.stock_positions` and `quote.quote` rather than depending on our arithmetic.

## Behaviour notes

- Requests are answered concurrently, so a slow `trade.stock_positions` never stalls the quote feed. Responses may therefore arrive out of order — correlate by `id`.
- The process exits when stdin closes, so it cannot outlive the client that spawned it.
- Parameter errors return `-32602` and name the field and the offending value (`` `market`: Unknown market 'MARS'. Use: HK US CN SG ``); upstream failures return `-32000`.

## Testing

- 20 new unit tests (protocol framing, parameter extraction, method routing, trait-coverage guard).
- Full suite green: 547 tests, `cargo fmt` and `cargo clippy` clean.
- Exercised live end to end against a real account: `initialize`, `quote.watchlist`, `trade.account_balance`, `quote.trading_days`, `api.get`, subscribe/unsubscribe with tick-level pushes, parameter-error handling, `shutdown`.
- Verified the `quote`/`watchlist` JSON refactors are byte-identical to the released binary's output.

Docs: README gains a command entry and an "Embedding in another app" section. The skills repo (`references/cli/overview.md`) still needs the corresponding update — it is not checked out locally.

## Follow-up from design review

Three things the endpoint promised but did not keep, plus a project rule.

**Error codes told clients the wrong thing to do.** The `-32602`/`-32000` split was decided by matching the error *text* — a leading backtick, `missing required parameter` — so an upstream failure phrased like a parameter complaint was blamed on the client, telling it not to retry something a retry would have fixed. Parameter rejections now carry a `ParamError` type through the `?` chain and the classification downcasts, so wording cannot change the meaning.

**Concurrency was unbounded in both directions.** A client that queued 200 lines got 200 requests in flight against an upstream that allows about 10 a second. A semaphore now caps how many reach Longbridge at once (8); the read loop keeps accepting lines, so a burst is paced rather than dropped. At the other end, `shutdown` and stdin EOF waited on the writer, which cannot finish until every handler drops its sender — one wedged request kept the process alive after its client was gone, the exact orphan the EOF handling exists to prevent. That drain is now bounded. Note this is a concurrency cap, not a rate limit: the token-bucket `RateLimiter` already in `src/openapi/rate_limiter.rs` is not yet wired into `serve`.

**`quote.subscribe` handed clients a race.** The guidance was to paint the first screen with `quote.quote`, but responses are deliberately out of order, so that response could arrive after a push and overwrite a newer price with an older one. `subscribe` now returns the snapshot itself, taken after the subscription is live so nothing falls between the two. A push can still be the older of the two, which is why the docs now state the rule a client needs either way: keep whichever `timestamp` is newer. If only the snapshot call fails the field is omitted rather than failing a subscription that is already live.

`serve -h` and the README also now state what was true but unwritten: batches are not accepted, `quote.updated` is a tick rather than a full quote, and `api.get`/`api.post` strip the account-identifying fields the CLI strips.

Separately, `CLAUDE.md` now records the **convention-over-configuration rule**: no new environment variable, CLI flag or config option without explicit approval — pick the right default and say why, rather than deferring the choice to the caller. (A `serve --read-only` flag was proposed here and turned down; it is not in this branch.)

Re-verified end to end against live data: unknown method → `-32601`, missing/bad params → `-32602`, upstream failures → `-32000` (including `openapi error: code=404000`), out-of-order responses, the subscribe snapshot, and live `quote.updated` pushes for `700.HK` / `AAPL.US`. 537 tests pass, `cargo fmt` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
