### PR TITLE
feat(news): drive news detail off GET /v1/content/news/:id

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3650,7 +3650,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             }
         }
         Commands::News { symbol, count, cmd } => match cmd {
-            Some(NewsCmd::Detail { id }) => news::cmd_news_detail(id).await,
+            Some(NewsCmd::Detail { id }) => news::cmd_news_detail(id, format).await,
             Some(NewsCmd::Search { keyword, count }) => {
                 search::cmd_search(keyword, "news", count, format, verbose).await
             }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2969,14 +2969,16 @@ pub enum OrderCmd {
 
 #[derive(Subcommand)]
 pub enum NewsCmd {
-    /// Full Markdown content of a news article
+    /// Full detail of a news article (Markdown body)
     ///
-    /// Fetches the article from longbridge.com (or longbridge.cn for CN region).
-    /// Use the global --lang flag to select language (zh-CN or en).
+    /// Fetches `GET /v1/content/news/{id}`. Prints the title,
+    /// published time, author, related tickers, URL, and the Markdown body.
+    /// With --format json: the full item (id, title, description, body, url,
+    /// author, images, counters, `published_at`, tickers).
     /// Example: longbridge news detail 12345678
-    /// Example: longbridge --lang zh-CN news detail 12345678
+    /// Example: longbridge news detail 12345678 --format json
     Detail {
-        /// News article ID (from `longbridge news <SYMBOL>`)
+        /// News article ID (from `longbridge news <SYMBOL>` or `news search`)
         id: String,
     },
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3652,7 +3652,7 @@ pub async fn dispatch(cmd: Commands, format: &OutputFormat, verbose: bool) -> Re
             }
         }
         Commands::News { symbol, count, cmd } => match cmd {
-            Some(NewsCmd::Detail { id }) => news::cmd_news_detail(id, format).await,
+            Some(NewsCmd::Detail { id }) => news::cmd_news_detail(id, format, verbose).await,
             Some(NewsCmd::Search { keyword, count }) => {
                 search::cmd_search(keyword, "news", count, format, verbose).await
             }

--- a/src/cli/news.rs
+++ b/src/cli/news.rs
@@ -326,21 +326,30 @@ pub async fn cmd_news_detail(id: String, format: &OutputFormat, verbose: bool) -
     }
     let item = crate::openapi::news::news_detail(id).await?;
     // A 200 with an empty/absent `item` means the article doesn't exist —
-    // don't print an empty shell with exit code 0.
-    if item.id == 0 && item.title.is_empty() && item.body.is_empty() {
+    // don't print an empty shell with exit code 0. (Some gateways echo the
+    // requested id back in an otherwise-empty object, so don't rely on id.)
+    if item.id == 0
+        || (item.title.is_empty() && item.body.is_empty() && item.description.is_empty())
+    {
         bail!("News article {id} not found");
     }
 
     // RFC3339, matching the `news` list output (which an agent chains from).
-    let published_at = time::OffsetDateTime::from_unix_timestamp(item.published_at)
-        .map(fmt_rfc3339)
-        .unwrap_or_default();
+    // A missing/invalid timestamp is treated as absent, not 1970-01-01.
+    let published_at = (item.published_at > 0)
+        .then(|| {
+            time::OffsetDateTime::from_unix_timestamp(item.published_at)
+                .map(fmt_rfc3339)
+                .ok()
+        })
+        .flatten();
 
     if matches!(format, OutputFormat::Json) {
         // Same field representations as the `news` list: string id, RFC3339
         // timestamp — so list → detail chaining needs no type juggling.
         let record = serde_json::json!({
             "id": item.id.to_string(),
+            "published_at": published_at,
             "title": item.title,
             "description": item.description,
             "body": item.body,
@@ -354,7 +363,6 @@ pub async fn cmd_news_detail(id: String, format: &OutputFormat, verbose: bool) -
             "comments_count": item.comments_count,
             "likes_count": item.likes_count,
             "shares_count": item.shares_count,
-            "published_at": published_at,
             "tickers": item.tickers,
         });
         println!("{}", serde_json::to_string_pretty(&record)?);
@@ -367,7 +375,10 @@ pub async fn cmd_news_detail(id: String, format: &OutputFormat, verbose: bool) -
         item.title.clone()
     };
     println!("# {title}");
-    let mut meta = vec![published_at];
+    let mut meta = Vec::new();
+    if let Some(published_at) = &published_at {
+        meta.push(published_at.clone());
+    }
     if !item.author.name.is_empty() {
         meta.push(item.author.name.clone());
     }
@@ -417,7 +428,11 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::Response
                 super::schema::field("comments_count", "number", "Comments count"),
                 super::schema::field("likes_count", "number", "Likes count"),
                 super::schema::field("shares_count", "number", "Shares count"),
-                super::schema::field("published_at", "string", "Published time (RFC3339)"),
+                super::schema::field(
+                    "published_at",
+                    "string | null",
+                    "Published time (RFC3339); null when absent",
+                ),
                 super::schema::field(
                     "tickers",
                     "string[]",

--- a/src/cli/news.rs
+++ b/src/cli/news.rs
@@ -317,19 +317,57 @@ pub async fn cmd_topic_detail(id: String) -> Result<()> {
 }
 
 /// Fetch one news article's full detail: `GET /v1/content/news/{id}`.
-pub async fn cmd_news_detail(id: String, format: &OutputFormat) -> Result<()> {
+pub async fn cmd_news_detail(id: String, format: &OutputFormat, verbose: bool) -> Result<()> {
     let id: i64 = id
         .parse()
         .map_err(|_| anyhow::anyhow!("Invalid news id: {id} (expected a numeric article ID)"))?;
+    if verbose {
+        eprintln!("* GET /v1/content/news/{id}");
+    }
     let item = crate::openapi::news::news_detail(id).await?;
+    // A 200 with an empty/absent `item` means the article doesn't exist —
+    // don't print an empty shell with exit code 0.
+    if item.id == 0 && item.title.is_empty() && item.body.is_empty() {
+        bail!("News article {id} not found");
+    }
+
+    // RFC3339, matching the `news` list output (which an agent chains from).
+    let published_at = time::OffsetDateTime::from_unix_timestamp(item.published_at)
+        .map(fmt_rfc3339)
+        .unwrap_or_default();
 
     if matches!(format, OutputFormat::Json) {
-        println!("{}", serde_json::to_string_pretty(&item)?);
+        // Same field representations as the `news` list: string id, RFC3339
+        // timestamp — so list → detail chaining needs no type juggling.
+        let record = serde_json::json!({
+            "id": item.id.to_string(),
+            "title": item.title,
+            "description": item.description,
+            "body": item.body,
+            "url": item.url,
+            "author": {
+                "id": item.author.id.to_string(),
+                "name": item.author.name,
+                "avatar": item.author.avatar,
+            },
+            "images": item.images,
+            "comments_count": item.comments_count,
+            "likes_count": item.likes_count,
+            "shares_count": item.shares_count,
+            "published_at": published_at,
+            "tickers": item.tickers,
+        });
+        println!("{}", serde_json::to_string_pretty(&record)?);
         return Ok(());
     }
 
-    println!("# {}", item.title);
-    let mut meta = vec![super::output::fmt_unix_ts(item.published_at)];
+    let title = if item.title.is_empty() {
+        truncate_display(&item.description, 70)
+    } else {
+        item.title.clone()
+    };
+    println!("# {title}");
+    let mut meta = vec![published_at];
     if !item.author.name.is_empty() {
         meta.push(item.author.name.clone());
     }
@@ -365,21 +403,26 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::Response
                 "comments_count",
             ],
         ),
-        "news detail" => super::schema::object(
+        "news detail" => super::schema::schema(
             "Full news article detail",
-            &[
-                "id",
-                "title",
-                "description",
-                "body",
-                "url",
-                "author",
-                "images",
-                "comments_count",
-                "likes_count",
-                "shares_count",
-                "published_at",
-                "tickers",
+            super::schema::RootKind::Object,
+            vec![
+                super::schema::field("id", "string", "News article ID (numeric string)"),
+                super::schema::field("title", "string", "Title"),
+                super::schema::field("description", "string", "Plain-text excerpt, no HTML"),
+                super::schema::field("body", "string", "Markdown content"),
+                super::schema::field("url", "string", "Full article page URL"),
+                super::schema::field("author", "object", "{id, name, avatar}"),
+                super::schema::field("images", "object[]", "{url, width, height}"),
+                super::schema::field("comments_count", "number", "Comments count"),
+                super::schema::field("likes_count", "number", "Likes count"),
+                super::schema::field("shares_count", "number", "Shares count"),
+                super::schema::field("published_at", "string", "Published time (RFC3339)"),
+                super::schema::field(
+                    "tickers",
+                    "string[]",
+                    "Related tickers, {symbol}.{market} e.g. [\"AAPL.US\", \"700.HK\"]",
+                ),
             ],
         ),
         "news search" => array(

--- a/src/cli/news.rs
+++ b/src/cli/news.rs
@@ -3,8 +3,6 @@ use anyhow::{bail, Result};
 use super::{output::print_table, OutputFormat};
 use crate::utils::datetime::fmt_rfc3339;
 
-const NEWS_DETAIL_HOST: &str = "https://longbridge.com";
-
 /// Return `s` truncated to `max` chars with a trailing `…`, or the original if it fits.
 pub(crate) fn truncate_display(s: &str, max: usize) -> String {
     if s.chars().count() > max {
@@ -318,38 +316,36 @@ pub async fn cmd_topic_detail(id: String) -> Result<()> {
     Ok(())
 }
 
-/// Build the news detail URL for the given id.
-///
-/// Always uses longbridge.com as host.
-/// Language prefix is determined by the global content language (`crate::locale::get()`).
-fn news_detail_url(id: &str) -> String {
-    match crate::locale::get() {
-        "zh-CN" => format!("{NEWS_DETAIL_HOST}/zh-CN/news/{id}.md"),
-        "zh-HK" => format!("{NEWS_DETAIL_HOST}/zh-HK/news/{id}.md"),
-        _ => format!("{NEWS_DETAIL_HOST}/news/{id}.md"),
-    }
-}
+/// Fetch one news article's full detail: `GET /v1/content/news/{id}`.
+pub async fn cmd_news_detail(id: String, format: &OutputFormat) -> Result<()> {
+    let id: i64 = id
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Invalid news id: {id} (expected a numeric article ID)"))?;
+    let item = crate::openapi::news::news_detail(id).await?;
 
-/// Fetch full news article as Markdown.
-///
-/// URL pattern:
-/// - English: `https://longbridge.com/news/{id}.md`
-/// - Chinese: `https://longbridge.com/zh-CN/news/{id}.md`
-pub async fn cmd_news_detail(id: String) -> Result<()> {
-    let url = news_detail_url(&id);
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(&url)
-        .header("User-Agent", "Mozilla/5.0")
-        .send()
-        .await?;
-
-    if !resp.status().is_success() {
-        bail!("Failed to fetch news detail: HTTP {}", resp.status());
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&item)?);
+        return Ok(());
     }
 
-    let content = resp.text().await?;
-    print!("{content}");
+    println!("# {}", item.title);
+    let mut meta = vec![super::output::fmt_unix_ts(item.published_at)];
+    if !item.author.name.is_empty() {
+        meta.push(item.author.name.clone());
+    }
+    if !item.tickers.is_empty() {
+        meta.push(item.tickers.join(" "));
+    }
+    println!("{}", meta.join(" · "));
+    if !item.url.is_empty() {
+        println!("{}", item.url);
+    }
+    println!();
+    if item.body.is_empty() {
+        println!("{}", item.description);
+    } else {
+        println!("{}", item.body);
+    }
     Ok(())
 }
 
@@ -369,7 +365,23 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::Response
                 "comments_count",
             ],
         ),
-        "news detail" => text("Full news article Markdown content"),
+        "news detail" => super::schema::object(
+            "Full news article detail",
+            &[
+                "id",
+                "title",
+                "description",
+                "body",
+                "url",
+                "author",
+                "images",
+                "comments_count",
+                "likes_count",
+                "shares_count",
+                "published_at",
+                "tickers",
+            ],
+        ),
         "news search" => array(
             "News search results",
             &["id", "title", "url", "source_name", "time", "excerpt"],

--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -328,10 +328,14 @@ async fn init_contexts_with_auth(
     AGENT_CTX.set(agent_ctx);
 
     // Also inject into the standalone HttpClient used for direct REST calls.
+    // Unlike the SDK contexts (whose config carries `.language(...)`), the raw
+    // client has no language field — forward the effective content language
+    // ourselves so `--lang` keeps working on raw endpoints.
     let mut http_client = longbridge::httpclient::HttpClient::new(http_client_config);
     http_client = http_client
         .header("user-agent", user_agent)
-        .header("x-app-id", CLI_APP_ID);
+        .header("x-app-id", CLI_APP_ID)
+        .header("accept-language", crate::locale::get());
     if !cli_cmd.is_empty() {
         http_client = http_client.header("x-cli-cmd", cli_cmd.as_str());
     }

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -4,6 +4,7 @@ pub mod chats;
 pub mod context;
 pub mod helpers;
 pub mod login;
+pub mod news;
 pub mod quote;
 pub mod rate_limiter;
 pub mod search;

--- a/src/openapi/news.rs
+++ b/src/openapi/news.rs
@@ -1,0 +1,93 @@
+//! Shared client for the news-content REST endpoints.
+//!
+//! `GET /v1/content/news/{id}` is **not** part of the language SDKs; it is
+//! called here directly through the SDK's signed HTTP client
+//! ([`crate::openapi::http_client`]), following the same pattern as
+//! [`crate::openapi::chats`].
+
+use anyhow::{Context, Result};
+use longbridge::httpclient::{Json, Method};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// proto3 JSON encodes `int64` as a string — accept both forms.
+fn i64_lenient<'de, D: Deserializer<'de>>(deserializer: D) -> Result<i64, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Value {
+        Number(i64),
+        String(String),
+    }
+    Ok(match Value::deserialize(deserializer)? {
+        Value::Number(value) => value,
+        Value::String(value) => value.parse().unwrap_or_default(),
+    })
+}
+
+/// Author of a [`NewsDetail`] article.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct NewsAuthor {
+    #[serde(deserialize_with = "i64_lenient")]
+    pub id: i64,
+    pub name: String,
+    pub avatar: String,
+}
+
+/// An image attached to a [`NewsDetail`] article.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct NewsImage {
+    pub url: String,
+    pub width: i32,
+    pub height: i32,
+}
+
+/// A full news article, as returned by [`news_detail`].
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct NewsDetail {
+    #[serde(deserialize_with = "i64_lenient")]
+    pub id: i64,
+    pub title: String,
+    /// Plain-text excerpt, no HTML tags.
+    pub description: String,
+    /// Markdown content.
+    pub body: String,
+    pub url: String,
+    pub author: NewsAuthor,
+    pub images: Vec<NewsImage>,
+    pub comments_count: i32,
+    pub likes_count: i32,
+    pub shares_count: i32,
+    /// Unix timestamp in seconds (UTC).
+    #[serde(deserialize_with = "i64_lenient")]
+    pub published_at: i64,
+    /// `{symbol}.{market}`, e.g. `["AAPL.US", "700.HK"]`.
+    pub tickers: Vec<String>,
+}
+
+/// `GET /v1/content/news/{id}` — fetch one news article's full detail.
+pub async fn news_detail(id: i64) -> Result<NewsDetail> {
+    #[derive(Default, Deserialize)]
+    #[serde(default)]
+    struct Response {
+        item: NewsDetail,
+    }
+
+    let path = format!("/v1/content/news/{id}");
+    let resp = crate::openapi::global_rate_limiter()
+        .execute("news_detail", || {
+            let path = path.clone();
+            Box::pin(async move {
+                crate::openapi::http_client()
+                    .request(Method::GET, path)
+                    .response::<Json<Response>>()
+                    .send()
+                    .await
+                    .map(|json| json.0)
+            })
+        })
+        .await
+        .context("Failed to get news detail")?;
+    Ok(resp.item)
+}

--- a/src/openapi/news.rs
+++ b/src/openapi/news.rs
@@ -9,18 +9,22 @@ use anyhow::{Context, Result};
 use longbridge::httpclient::{Json, Method};
 use serde::{Deserialize, Deserializer, Serialize};
 
-/// proto3 JSON encodes `int64` as a string — accept both forms.
+/// proto3 JSON encodes `int64` as a string — accept both forms (and `null`,
+/// which `#[serde(default)]` alone does not cover). A malformed string is a
+/// hard error rather than silently becoming `0`.
 fn i64_lenient<'de, D: Deserializer<'de>>(deserializer: D) -> Result<i64, D::Error> {
     #[derive(Deserialize)]
     #[serde(untagged)]
     enum Value {
         Number(i64),
         String(String),
+        Null,
     }
-    Ok(match Value::deserialize(deserializer)? {
-        Value::Number(value) => value,
-        Value::String(value) => value.parse().unwrap_or_default(),
-    })
+    match Value::deserialize(deserializer)? {
+        Value::Number(value) => Ok(value),
+        Value::String(value) => value.parse().map_err(serde::de::Error::custom),
+        Value::Null => Ok(0),
+    }
 }
 
 /// Author of a [`NewsDetail`] article.

--- a/src/openapi/news.rs
+++ b/src/openapi/news.rs
@@ -17,11 +17,17 @@ fn i64_lenient<'de, D: Deserializer<'de>>(deserializer: D) -> Result<i64, D::Err
     #[serde(untagged)]
     enum Value {
         Number(i64),
+        Float(f64),
         String(String),
         Null,
     }
     match Value::deserialize(deserializer)? {
         Value::Number(value) => Ok(value),
+        Value::Float(value) => Err(serde::de::Error::custom(format!(
+            "expected an integer, got {value}"
+        ))),
+        // Gateways may encode an absent int64 as "" — treat like null.
+        Value::String(value) if value.trim().is_empty() => Ok(0),
         Value::String(value) => value.parse().map_err(serde::de::Error::custom),
         Value::Null => Ok(0),
     }

--- a/src/tui/systems/stock_news.rs
+++ b/src/tui/systems/stock_news.rs
@@ -185,36 +185,31 @@ pub fn fetch_news_detail(id: String, tx: mpsc::UnboundedSender<CommandQueue>) {
     }
 
     RT.get().unwrap().spawn(async move {
-        let url = match crate::locale::get() {
-            "zh-CN" => format!("https://longbridge.com/zh-CN/news/{id}.md"),
-            "zh-HK" => format!("https://longbridge.com/zh-HK/news/{id}.md"),
-            _ => format!("https://longbridge.com/news/{id}.md"),
+        // Same source as `longbridge news detail`: GET /v1/content/news/{id}
+        // via the signed OpenAPI client (the old longbridge.com/news/{id}.md
+        // scrape is gone).
+        let result = match id.parse::<i64>() {
+            Ok(id) => crate::openapi::news::news_detail(id).await,
+            Err(_) => Err(anyhow::anyhow!("invalid news id: {id}")),
         };
-        let client = reqwest::Client::new();
-        let result = client
-            .get(&url)
-            .header("User-Agent", "Mozilla/5.0")
-            .send()
-            .await;
         match result {
-            Ok(resp) if resp.status().is_success() => match resp.text().await {
-                Ok(text) => {
-                    if let Ok(mut content) = NEWS_DETAIL_CONTENT.lock() {
-                        *content = prepare_article(&text);
-                    }
+            Ok(item) => {
+                let mut text = format!("# {}\n", item.title);
+                let mut meta = vec![crate::cli::output::fmt_unix_ts(item.published_at)];
+                if !item.author.name.is_empty() {
+                    meta.push(item.author.name.clone());
                 }
-                Err(e) => {
-                    tracing::error!("Failed to read news detail body: {e}");
-                    if let Ok(mut content) = NEWS_DETAIL_CONTENT.lock() {
-                        *content = t!("News.ErrorContent", error = e.to_string()).to_string();
-                    }
+                if !item.tickers.is_empty() {
+                    meta.push(item.tickers.join(" "));
                 }
-            },
-            Ok(resp) => {
-                let status = resp.status();
-                tracing::error!("Failed to fetch news detail: HTTP {status}");
+                text.push_str(&format!("\n{}\n\n", meta.join(" · ")));
+                text.push_str(if item.body.is_empty() {
+                    &item.description
+                } else {
+                    &item.body
+                });
                 if let Ok(mut content) = NEWS_DETAIL_CONTENT.lock() {
-                    *content = t!("News.ErrorHttp", status = status.to_string()).to_string();
+                    *content = prepare_article(&text);
                 }
             }
             Err(e) => {

--- a/src/tui/systems/stock_news.rs
+++ b/src/tui/systems/stock_news.rs
@@ -194,7 +194,6 @@ pub fn fetch_news_detail(id: String, tx: mpsc::UnboundedSender<CommandQueue>) {
         };
         match result {
             Ok(item) => {
-                let mut text = format!("# {}\n", item.title);
                 let mut meta = vec![crate::cli::output::fmt_unix_ts(item.published_at)];
                 if !item.author.name.is_empty() {
                     meta.push(item.author.name.clone());
@@ -202,12 +201,12 @@ pub fn fetch_news_detail(id: String, tx: mpsc::UnboundedSender<CommandQueue>) {
                 if !item.tickers.is_empty() {
                     meta.push(item.tickers.join(" "));
                 }
-                text.push_str(&format!("\n{}\n\n", meta.join(" · ")));
-                text.push_str(if item.body.is_empty() {
+                let body = if item.body.is_empty() {
                     &item.description
                 } else {
                     &item.body
-                });
+                };
+                let text = format!("# {}\n\n{}\n\n{body}", item.title, meta.join(" · "));
                 if let Ok(mut content) = NEWS_DETAIL_CONTENT.lock() {
                     *content = prepare_article(&text);
                 }

--- a/src/tui/systems/stock_news.rs
+++ b/src/tui/systems/stock_news.rs
@@ -206,7 +206,12 @@ pub fn fetch_news_detail(id: String, tx: mpsc::UnboundedSender<CommandQueue>) {
                 } else {
                     &item.body
                 };
-                let text = format!("# {}\n\n{}\n\n{body}", item.title, meta.join(" · "));
+                let title = if item.title.is_empty() {
+                    crate::cli::news::truncate_display(&item.description, 70)
+                } else {
+                    item.title.clone()
+                };
+                let text = format!("# {title}\n\n{}\n\n{body}", meta.join(" · "));
                 if let Ok(mut content) = NEWS_DETAIL_CONTENT.lock() {
                     *content = prepare_article(&text);
                 }


### PR DESCRIPTION
## What

Replace the web-scrape implementation of `news detail` (fetching `longbridge.com/news/{id}.md` with a plain reqwest GET) with the official signed OpenAPI endpoint `GET /v1/content/news/:id`. The endpoint is intentionally **not** added to the language SDKs — it is called through the SDK's signed raw HTTP client, following the `openapi::chats` pattern.

## Changes

- New `src/openapi/news.rs`: typed `NewsDetail` / `NewsAuthor` / `NewsImage` and a rate-limited `news_detail(id)` fetcher. proto3 JSON encodes `int64` as a string, so `id` / `author.id` / `published_at` accept both string and number forms.
- `news detail <ID>`: renders `# title`, published time · author · tickers, URL, then the Markdown `body` (falls back to `description`); `--format json` prints the full item.
- `--schema` coverage for `news detail` updated from free text to the typed object.

## Verified

- Live against staging (`openapi.longbridge.xyz`): pretty and JSON output both correct, all fields populated (production returns code=12 — endpoint not yet deployed there).
- `cargo clippy` clean, 514 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)