### PR TITLE
cli: Report command and TUI usage to Sensors Analytics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2854,6 +2854,7 @@ dependencies = [
  "hostname",
  "indoc",
  "itertools 0.11.0",
+ "log",
  "longbridge",
  "longbridge-ai-acp",
  "machine-uid",
@@ -2891,6 +2892,7 @@ dependencies = [
  "tui-input",
  "tui-markdown",
  "unicode-width 0.1.14",
+ "uuid",
  "whoami",
  "windows-sys 0.48.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ rust_decimal_macros = "1.32.0"
 scopeguard = "1.2.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
+uuid = { version = "1", features = ["v4"] }
+log = "0.4"
 strum = { version = "0.26", features = ["derive"] }
 tempfile = "3"
 termimad = "0.30"
@@ -71,11 +73,17 @@ tokio = { version = "1.33.0", features = [
 tokio-stream = "0.1"
 tracing = "0.1.40"
 tracing-appender = { version = "0.2.4" }
+# Default features include `tracing-log`, which routes `log` records into
+# tracing. src/analytics/core.rs is shared verbatim with the desktop app and
+# reports through `log`, so that bridge is what keeps its diagnostics -- notably
+# "nothing was sent" -- in the log file. Do not disable default features here
+# without replacing it.
 tracing-subscriber = { version = "0.3.17", features = [
     "env-filter",
     "parking_lot",
     "time",
 ] }
+
 tui-input = "0.15"
 unicode-width = "0.1.11"
 bitflags = "2.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,17 +73,16 @@ tokio = { version = "1.33.0", features = [
 tokio-stream = "0.1"
 tracing = "0.1.40"
 tracing-appender = { version = "0.2.4" }
-# Default features include `tracing-log`, which routes `log` records into
-# tracing. src/analytics/core.rs is shared verbatim with the desktop app and
-# reports through `log`, so that bridge is what keeps its diagnostics -- notably
-# "nothing was sent" -- in the log file. Do not disable default features here
-# without replacing it.
+# `tracing-log` routes `log` records into tracing. src/analytics/core.rs is
+# shared verbatim with the desktop app and reports through `log`, so that bridge
+# is what keeps its diagnostics -- notably "nothing was sent" -- in the log file.
+# It is on by default; listed anyway, because a default is not a contract.
 tracing-subscriber = { version = "0.3.17", features = [
     "env-filter",
     "parking_lot",
     "time",
+    "tracing-log",
 ] }
-
 tui-input = "0.15"
 unicode-width = "0.1.11"
 bitflags = "2.10.0"
@@ -114,6 +113,14 @@ windows-sys = { version = "0.48.0", features = [
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
 ] }
+
+# `src/analytics/core.rs` is shared verbatim with the desktop app, where this
+# feature selects Tauri's runtime for background work. The terminal has no such
+# runtime and declares no such feature; naming it here keeps the shared file
+# from warning without adding a feature this binary would never use.
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(feature, values("tauri-runtime"))']
 
 [lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -631,6 +631,29 @@ Longbridge OpenAPI: maximum 10 calls per second. The SDK auto-refreshes OAuth to
 - Internet connection and browser access (for initial OAuth)
 - [Longbridge account](https://open.longbridge.com)
 
+## Usage Data
+
+Official release builds report usage data to Longbridge, so we can see which
+commands are used and where they fail. When you are signed in the reports carry
+your member id, so they are not anonymous. A build you make yourself (`cargo
+build`, `cargo run`) reports nothing at all.
+
+What is sent, per run:
+
+- which command ran (`quote`, `alert add`) — never its arguments, so no symbols,
+  account numbers, or order details
+- whether it succeeded, and how long it took
+- app version, OS family, whether the output is a terminal, whether this looks
+  like CI
+- a random id generated on first run and stored in `~/.longbridge/openapi/device-id`
+- your Longbridge member id, when signed in
+- panic messages when the app crashes, with your home directory and account name
+  removed
+
+Nothing else is collected: no arguments, no market data you looked at, no
+positions, no orders. The code is in [`src/analytics/`](src/analytics/) — the
+event payload is assembled in one place and can be read in full.
+
 ## Documentation
 
 - [Longbridge OpenAPI Docs](https://open.longbridge.com)

--- a/src/ai/analytics.rs
+++ b/src/ai/analytics.rs
@@ -1,0 +1,274 @@
+//! Business analytics for `longbridge ai`.
+//!
+//! Kept out of [`super::tui`] because the reporting is incidental to the view:
+//! every function here is one call at a decision point, and gathering them makes
+//! the whole event surface readable in one screen.
+//!
+//! # What is not reported
+//!
+//! No question text, no answer text, no tool arguments. A question to this agent
+//! names the symbols and positions the reader is asking about, which is exactly
+//! the shape of thing analytics has no business carrying. Lengths and counts go
+//! out; content does not.
+
+use crate::analytics::{event, track};
+
+use super::state::{ChatState, Role};
+
+/// How a turn ended.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// The agent answered.
+    Ok,
+    /// The stream itself failed — the request never completed.
+    StreamError,
+    /// The server failed the turn, having accepted it.
+    ServerError,
+    /// The reader stopped it, or walked away by starting a new conversation.
+    Cancelled,
+}
+
+impl Outcome {
+    /// `result` as reported. Two error kinds share one result so completion rate
+    /// is a single filter, with `error_kind` telling them apart.
+    const fn result(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::StreamError | Self::ServerError => "error",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    const fn error_kind(self) -> Option<&'static str> {
+        match self {
+            Self::StreamError => Some("stream"),
+            Self::ServerError => Some("server"),
+            Self::Ok | Self::Cancelled => None,
+        }
+    }
+}
+
+/// The chat was opened. Reported from `main`, which knows whether a token was
+/// found before the view is built.
+pub fn launch(agent: &str, signed_in: bool) {
+    track(
+        event::AI_LAUNCH,
+        serde_json::json!({ "agent": agent, "signed_in": signed_in }),
+    );
+}
+
+/// A prompt went out. `query_len` is a character count — never the text.
+pub fn turn_start(state: &ChatState, query_len: usize) {
+    track(
+        event::AI_TURN_START,
+        serde_json::json!({
+            "agent": state.agent_uid,
+            // Whether this is the opening question of a conversation. A first
+            // turn has no history to build on and behaves differently enough
+            // that mixing the two hides both.
+            "is_first_turn": !state.messages.iter().any(|m| m.role == Role::User),
+            "query_len": query_len,
+        }),
+    );
+}
+
+/// A turn ended, however it ended.
+///
+/// Reported for cancelled and abandoned turns too: a start with no end would
+/// hang in the warehouse forever, and no completion rate could be derived from a
+/// population where an unknown share of turns simply stop being mentioned.
+///
+/// Call **after** the state has applied the finishing event, so the answer has
+/// been folded into the transcript and its length is final — but read the
+/// outcome **before**, because applying it clears the server error that
+/// distinguishes one failure from the other.
+pub fn turn_finish(state: &ChatState, outcome: Outcome) {
+    let Some(started) = state.turn_started else {
+        // No start recorded means no turn was in flight — a cancel key pressed
+        // on an idle chat, most often. Reporting an end without a beginning
+        // would inflate the turn count with turns that never happened.
+        return;
+    };
+    let shape = TurnShape::of(state);
+
+    track(
+        event::AI_TURN_FINISH,
+        serde_json::json!({
+            "agent": state.agent_uid,
+            "result": outcome.result(),
+            "error_kind": outcome.error_kind(),
+            "duration_ms": started.at.elapsed().as_millis() as u64,
+            // Distinct tools, and how many calls in total: the agent may call
+            // one tool repeatedly, and "used 3 tools" and "made 11 calls" are
+            // different facts about the same turn.
+            "tools": shape.tools,
+            "tool_calls": shape.tool_calls,
+            "tools_failed": state.tool_failures,
+            "answer_len": shape.answer_len,
+            "has_references": !state.references.is_empty(),
+            "has_further_questions": !state.further.is_empty(),
+        }),
+    );
+}
+
+/// What one turn's transcript amounts to.
+///
+/// Split out of [`turn_finish`] to be testable: the reporting call itself has no
+/// return value and reaches the network, so without this the claim that these
+/// numbers describe *this* turn rather than the whole conversation could not be
+/// checked by anything.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TurnShape<'a> {
+    /// Distinct tool names, in the order first called.
+    tools: Vec<&'a str>,
+    /// Every call, including repeats of the same tool.
+    tool_calls: usize,
+    /// Characters in the answer this turn produced.
+    answer_len: usize,
+}
+
+impl<'a> TurnShape<'a> {
+    /// Measure the turn in flight. Empty when no turn has started.
+    fn of(state: &'a ChatState) -> Self {
+        let Some(started) = state.turn_started else {
+            return Self::default();
+        };
+        // Only this turn's slice: `messages` accumulates for the whole
+        // conversation, so measuring all of it would report the running total on
+        // every turn and make each one look busier than the last.
+        let turn = state.messages.get(started.from..).unwrap_or_default();
+        let mut tools: Vec<&str> = Vec::new();
+        for message in turn.iter().filter(|m| m.role == Role::Tool) {
+            if !tools.contains(&message.text.as_str()) {
+                tools.push(&message.text);
+            }
+        }
+        Self {
+            tools,
+            tool_calls: turn.iter().filter(|m| m.role == Role::Tool).count(),
+            answer_len: turn
+                .iter()
+                .rev()
+                .find(|m| m.role == Role::Assistant)
+                .map_or(0, |m| m.text.chars().count()),
+        }
+    }
+}
+
+/// A fresh conversation was started.
+pub fn session_new() {
+    track(event::AI_SESSION_NEW, serde_json::json!({}));
+}
+
+/// A conversation was reopened from history.
+pub fn session_resume() {
+    track(event::AI_SESSION_RESUME, serde_json::json!({}));
+}
+
+/// The agent was switched.
+pub fn agent_switch(from: &str, to: &str) {
+    track(
+        event::AI_AGENT_SWITCH,
+        serde_json::json!({ "from": from, "to": to }),
+    );
+}
+
+/// The agent stopped to ask the reader something.
+pub fn interrupt(question_count: usize) {
+    track(
+        event::AI_INTERRUPT,
+        serde_json::json!({ "question_count": question_count }),
+    );
+}
+
+/// How that question ended. `answered` is false when the reader left it instead
+/// — the interesting half, since an interrupt nobody answers is a dead end in
+/// the flow rather than a feature being used.
+pub fn interrupt_answered(answered: bool) {
+    track(
+        event::AI_INTERRUPT_ANSWERED,
+        serde_json::json!({ "outcome": if answered { "answered" } else { "abandoned" } }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::state::ChatEvent;
+
+    /// Two complete turns, the second calling a different tool than the first.
+    fn two_turns() -> ChatState {
+        let mut state = ChatState::default();
+        for (prompt, tool, answer) in [
+            ("first", "Get Quote", "short"),
+            ("second", "Get News", "a much longer answer"),
+        ] {
+            state.apply(ChatEvent::UserPrompt(prompt.into()));
+            state.apply(ChatEvent::ToolStarted(tool.into()));
+            state.apply(ChatEvent::ToolFinished {
+                name: tool.into(),
+                ok: true,
+            });
+            state.apply(ChatEvent::Delta(answer.into()));
+            state.apply(ChatEvent::TurnFinished { error: None });
+        }
+        state
+    }
+
+    /// The numbers describe the turn that just ended, not the conversation.
+    /// Measured over all of `messages` instead, every turn would inherit every
+    /// earlier turn's tools and each one would look busier than the last.
+    #[test]
+    fn a_turn_is_measured_without_its_predecessors() {
+        let state = two_turns();
+        let shape = TurnShape::of(&state);
+        assert_eq!(shape.tools, ["Get News"], "the first turn's tool leaked in");
+        assert_eq!(shape.tool_calls, 1);
+        assert_eq!(shape.answer_len, "a much longer answer".chars().count());
+    }
+
+    /// The same tool called twice is one tool and two calls — they answer
+    /// different questions and collapsing them loses the retry.
+    #[test]
+    fn a_repeated_tool_counts_once_by_name_and_twice_by_call() {
+        let mut state = ChatState::default();
+        state.apply(ChatEvent::UserPrompt("q".into()));
+        for _ in 0..2 {
+            state.apply(ChatEvent::ToolStarted("Get Quote".into()));
+            state.apply(ChatEvent::ToolFinished {
+                name: "Get Quote".into(),
+                ok: true,
+            });
+        }
+        let shape = TurnShape::of(&state);
+        assert_eq!(shape.tools, ["Get Quote"]);
+        assert_eq!(shape.tool_calls, 2);
+    }
+
+    /// An idle chat measures as nothing, so a stray cancel cannot invent a turn.
+    #[test]
+    fn an_idle_chat_has_no_shape() {
+        assert_eq!(TurnShape::of(&ChatState::default()), TurnShape::default());
+    }
+
+    /// Both failure kinds report one `result`, so completion rate stays a single
+    /// filter; `error_kind` is what tells them apart.
+    #[test]
+    fn the_two_failures_share_a_result_but_not_a_kind() {
+        assert_eq!(Outcome::StreamError.result(), "error");
+        assert_eq!(Outcome::ServerError.result(), "error");
+        assert_ne!(
+            Outcome::StreamError.error_kind(),
+            Outcome::ServerError.error_kind()
+        );
+    }
+
+    /// A success carries no error kind — an empty string here would land in the
+    /// warehouse as a distinct value and every breakdown would grow a phantom
+    /// bucket.
+    #[test]
+    fn a_clean_turn_has_no_error_kind() {
+        assert_eq!(Outcome::Ok.error_kind(), None);
+        assert_eq!(Outcome::Cancelled.error_kind(), None);
+    }
+}

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Structured after grok-build's layering, at a scale proportionate to a hosted
 //! chat agent:
+//! - [`analytics`] — the business events this chat reports (counts, never content)
 //! - [`answer`]  — what an answer is made of (segments, widgets, markers)
 //! - [`chart`]   — `vis-chart` specs drawn as braille plots
 //! - [`quotes`]  — live quotes for the securities an answer references
@@ -14,6 +15,7 @@
 //! local tool/workspace layer (unlike grok-build, which edits and runs code).
 
 pub mod account;
+pub mod analytics;
 pub mod answer;
 pub mod chart;
 pub mod editor;

--- a/src/ai/state.rs
+++ b/src/ai/state.rs
@@ -95,6 +95,21 @@ pub enum ChatEvent {
     TurnFinished { error: Option<String> },
 }
 
+/// Where the turn in flight began. `None` between turns.
+///
+/// Carried for analytics, which needs both halves: the timestamp to measure how
+/// long a turn took, and the transcript index to tell *this* turn's tool calls
+/// apart from every call the conversation has made.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TurnStart {
+    /// When the prompt went out. A monotonic instant rather than a wall clock:
+    /// the value is only ever used as a duration, and a clock adjustment
+    /// mid-turn would otherwise report a negative or wildly inflated one.
+    pub at: std::time::Instant,
+    /// Index into [`ChatState::messages`] the turn starts at.
+    pub from: usize,
+}
+
 /// The full chat state the view renders.
 #[derive(Default)]
 pub struct ChatState {
@@ -145,6 +160,8 @@ pub struct ChatState {
     pub references: Vec<Reference>,
     /// Suggested follow-up questions from the latest turn (click to send).
     pub further: Vec<String>,
+    /// Where the turn in flight began, for analytics. See [`TurnStart`].
+    pub turn_started: Option<TurnStart>,
 }
 
 impl ChatState {
@@ -161,6 +178,13 @@ impl ChatState {
     pub fn apply(&mut self, event: ChatEvent) {
         match event {
             ChatEvent::UserPrompt(text) => {
+                // Recorded before the prompt is pushed, so `from` points at the
+                // prompt itself and the turn's own tool lines are everything
+                // after it — not the whole conversation's.
+                self.turn_started = Some(TurnStart {
+                    at: std::time::Instant::now(),
+                    from: self.messages.len(),
+                });
                 self.messages.push(Message::new(Role::User, text));
                 self.scroll = 0;
                 self.busy = true;
@@ -317,6 +341,7 @@ impl ChatState {
         self.tool_failures.clear();
         self.references.clear();
         self.further.clear();
+        self.turn_started = None;
     }
 
     /// Cancel the active turn, folding any partial answer into the transcript.
@@ -339,6 +364,9 @@ impl ChatState {
         // to a run the server has already dropped.
         self.pending_interrupt = None;
         self.turn_error = None;
+        // Cleared last, and only here: callers that report the cancelled turn
+        // read it first, so anything that clears it earlier loses the duration.
+        self.turn_started = None;
     }
 }
 

--- a/src/ai/tui.rs
+++ b/src/ai/tui.rs
@@ -48,6 +48,28 @@ enum View {
     Question,
 }
 
+impl View {
+    /// The group's registered `page_name` for this view.
+    ///
+    /// Built from the same vocabulary as the market TUI's (see
+    /// `crate::tui::app::page_name`): `tlb` for this client, then the business
+    /// keyword, then what the page is. `ai` is a new business keyword — the chat
+    /// is its own product line with its own `app_id`, and filing it under
+    /// `content` would bury it among posts and courses.
+    ///
+    /// `Question` is a drawer rather than a destination, but it reports as a page
+    /// anyway: it is where a turn stops and waits for the reader, so how long
+    /// they spend there is worth as much as any view's.
+    const fn page_name(self) -> &'static str {
+        match self {
+            Self::Chat => "tlb_ai_chat_home",
+            Self::Sessions => "tlb_ai_chat_list",
+            Self::Settings => "tlb_ai_setting_entry",
+            Self::Question => "tlb_ai_interrupt_drawer",
+        }
+    }
+}
+
 /// Transcript lines a page-scroll keystroke moves.
 const SCROLL_PAGE: u16 = 5;
 /// Rows a PageUp/PageDown moves the selection in a list view.
@@ -706,6 +728,7 @@ impl Ui {
     /// selection. (Entering Conversations is done via `open_sessions`, which
     /// also kicks off the async fetch.)
     fn switch(&mut self, view: View) {
+        crate::analytics::enter_page(view.page_name(), serde_json::json!({}));
         self.view = view;
         self.notice = None;
         self.sel = 0;
@@ -761,6 +784,9 @@ pub async fn run(agent_uid: String, quotes: Option<QuoteStream>) -> Result<Optio
     let mut terminal = Terminal::default();
     let mut state = ChatState::new(agent_uid, t!("Ai.Welcome").to_string());
     let mut ui = Ui::new();
+    // The opening view never goes through `switch`, so it reports itself here or
+    // the first page of every session is missing.
+    crate::analytics::enter_page(ui.view.page_name(), serde_json::json!({}));
     let mut editor = Editor::new();
     // Seed the prompt history from disk so ↑/↓ recalls prompts from previous
     // sessions, the way a shell does.
@@ -6116,6 +6142,27 @@ fn wrap(s: &str, width: usize) -> Vec<String> {
 mod tests {
     use super::marquee;
     use unicode_width::UnicodeWidthStr;
+
+    /// One view, one name — see the market TUI's equivalent. A duplicate would
+    /// merge two views in every report without failing anywhere.
+    #[test]
+    fn no_two_views_share_a_page_name() {
+        let views = [
+            super::View::Chat,
+            super::View::Sessions,
+            super::View::Settings,
+            super::View::Question,
+        ];
+        let mut names: Vec<&str> = views.iter().map(|view| view.page_name()).collect();
+        let total = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), total, "two views report the same page_name");
+        for name in names {
+            assert!(name.starts_with("tlb_ai_"), "{name} is not an AI page");
+            assert_eq!(name, name.to_lowercase(), "{name} should be lower snake");
+        }
+    }
 
     #[test]
     fn a_question_with_options_is_fully_selectable() {

--- a/src/ai/tui.rs
+++ b/src/ai/tui.rs
@@ -1249,8 +1249,16 @@ fn dispatch_event(
             }
             _ => {}
         },
-        Event::FocusGained => ui.focused = true,
-        Event::FocusLost => ui.focused = false,
+        // Also told to analytics: a session left in a background pane is not a
+        // session somebody is using, and `active_ms` is how that is told apart.
+        Event::FocusGained => {
+            ui.focused = true;
+            crate::analytics::set_active(true);
+        }
+        Event::FocusLost => {
+            ui.focused = false;
+            crate::analytics::set_active(false);
+        }
         _ => {}
     }
 }

--- a/src/ai/tui.rs
+++ b/src/ai/tui.rs
@@ -31,7 +31,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use super::editor::Editor;
 use super::session_store::{self, SessionSummary};
 use super::state::{ChatEvent, ChatState, Message, Role, ToolStatus};
-use super::{markdown, runtime};
+use super::{analytics, markdown, runtime};
 use crate::cli::agent::client::ConversationRequest;
 use crate::cli::agent::DEFAULT_AGENT_UID;
 use crate::tui::ui::assets;
@@ -842,8 +842,34 @@ pub async fn run(agent_uid: String, quotes: Option<QuoteStream>) -> Result<Optio
                 let Some(event) = current_turn_event(&state, turn_event) else {
                     continue;
                 };
-                let finished = matches!(event, ChatEvent::TurnFinished { .. });
+                if let ChatEvent::Interrupt(interrupt) = &event {
+                    let questions = runtime::interrupt_interactions(interrupt)
+                        .iter()
+                        .map(|interaction| runtime::interaction_questions(interaction).len())
+                        .sum();
+                    analytics::interrupt(questions);
+                }
+                // Read before applying: applying takes the server error, so
+                // afterwards there is no way to tell a failed stream from a
+                // stream that carried a failure.
+                let outcome = match &event {
+                    ChatEvent::TurnFinished { error } => Some(if error.is_some() {
+                        analytics::Outcome::StreamError
+                    } else if state.turn_error.is_some() {
+                        analytics::Outcome::ServerError
+                    } else {
+                        analytics::Outcome::Ok
+                    }),
+                    _ => None,
+                };
+                let finished = outcome.is_some();
                 state.apply(event);
+                if let Some(outcome) = outcome {
+                    // Reported after applying, so the answer has been folded
+                    // into the transcript and its length is final.
+                    analytics::turn_finish(&state, outcome);
+                    state.turn_started = None;
+                }
                 if finished {
                     turn = None;
                     maybe_open_question(&mut ui, &state);
@@ -959,6 +985,7 @@ pub async fn run(agent_uid: String, quotes: Option<QuoteStream>) -> Result<Optio
             }
             Some(loaded) = load_rx.recv() => {
                 if let Some(loaded) = loaded {
+                    analytics::session_resume();
                     session_store::restore(loaded, &mut state);
                     ui.reset_render();
                     resolve_session_tickers(&ui, &state, &aliases_tx);
@@ -1286,6 +1313,16 @@ fn on_ctrl_c(
 fn cancel_turn(state: &mut ChatState, turn: &mut Option<JoinHandle<()>>) {
     if let Some(turn) = turn.take() {
         turn.abort();
+        // Aborting stops the producer, so no finishing event is coming. Reported
+        // before `cancel`, which clears the turn's start along with the rest of
+        // the in-flight state. `turn_finish` ignores an idle chat on its own, but
+        // gating on the handle keeps a bare Esc from reaching it at all.
+        analytics::turn_finish(state, analytics::Outcome::Cancelled);
+    }
+    // `cancel` drops a pending question as unanswerable, so it counts as walked
+    // away from — reported before that happens.
+    if state.pending_interrupt.is_some() {
+        analytics::interrupt_answered(false);
     }
     state.cancel(&t!("Ai.Cancelled"));
 }
@@ -1676,6 +1713,10 @@ fn start_turn(
     tx: &UnboundedSender<runtime::TurnEvent>,
 ) {
     let req = runtime::build_request(state, query.clone());
+    // Reported before the prompt is applied: applying it appends this very
+    // message, after which "has the reader asked anything yet" is always yes and
+    // no turn would ever look like a first one.
+    analytics::turn_start(state, query.chars().count());
     state.apply(ChatEvent::UserPrompt(query));
     state.pending_interrupt = None;
     *turn = Some(runtime::spawn_turn(req, state.generation, tx.clone()));
@@ -1684,7 +1725,19 @@ fn start_turn(
 fn new_session(ui: &mut Ui, state: &mut ChatState, turn: &mut Option<JoinHandle<()>>) {
     if let Some(task) = turn.take() {
         task.abort();
+        // An aborted turn sends no finishing event, so its end is reported here
+        // or not at all — and a start with no end is a turn the warehouse counts
+        // forever as still running.
+        analytics::turn_finish(state, analytics::Outcome::Cancelled);
     }
+    // Checked apart from the turn: a question left over from a turn that already
+    // finished is the most common way one goes unanswered — the reader reads it
+    // and starts over instead of replying.
+    if state.pending_interrupt.is_some() {
+        analytics::interrupt_answered(false);
+    }
+    analytics::session_new();
+    // Reported before the reset, which clears the turn's start.
     state.reset(t!("Ai.Welcome").to_string());
     ui.reset_render();
     ui.switch(View::Chat);
@@ -1795,6 +1848,7 @@ fn switch_agent(args: &str, ui: &mut Ui, state: &mut ChatState) {
         t!("Ai.AgentSwitched")
     }
     .to_string();
+    analytics::agent_switch(&state.agent_uid, &uid);
     // A conversation belongs to its agent server-side, so switching starts a
     // fresh one rather than continuing this thread under a different agent.
     state.reset(t!("Ai.Welcome").to_string());
@@ -2494,6 +2548,11 @@ fn submit_answers(
         message_id,
         answers,
     };
+    analytics::interrupt_answered(true);
+    // Answering starts a turn of its own, and this path does not go through
+    // `start_turn` — without its own start the resulting turn would report a
+    // finish with nothing it belongs to.
+    analytics::turn_start(state, summary.chars().count());
     state.apply(ChatEvent::UserPrompt(summary));
     state.pending_interrupt = None;
     *turn = Some(runtime::spawn_turn(req, state.generation, tx.clone()));

--- a/src/analytics/core.rs
+++ b/src/analytics/core.rs
@@ -1,0 +1,1404 @@
+//! Sensors Analytics from Rust — a self-contained client.
+//!
+//! # Copying this into another project
+//!
+//! This file has no dependencies on the rest of this repository. Drop it in,
+//! declare the crates below, and it works. Everything project-specific —
+//! endpoint, device id, platform naming, product identifier — arrives through
+//! [`Config`], so nothing here needs editing.
+//!
+//! ```toml
+//! reqwest    = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+//! serde_json = "1"
+//! base64     = "0.22"
+//! uuid       = { version = "1", features = ["v4"] }
+//! log        = "0.4"
+//! tokio      = { version = "1", features = ["time"] }
+//! ```
+//!
+//! To run this file's own tests, tokio additionally needs `["macros", "rt"]`.
+//!
+//! In a Tauri app, enable the `tauri-runtime` feature:
+//!
+//! ```toml
+//! [features]
+//! default = ["tauri-runtime"]
+//! tauri-runtime = []
+//! ```
+//!
+//! Without it, background work goes through `tokio::spawn`, which needs an
+//! ambient Tokio runtime. Tauri's `setup()` does not run inside one, so a Tauri
+//! host that skips the feature gets a warning and **no background work at all**
+//! — no requests, no heartbeat. It will not crash, but it will report nothing.
+//!
+//! # Setting it up
+//!
+//! ```rust,ignore
+//! let sensors = Sensors::new(Config {
+//!     // Required — the client cannot guess any of these.
+//!     server_url: "https://event-tracking.example.com/sa?project=production".into(),
+//!     device_id: stable_machine_id(),          // survives restarts
+//!     lib_name: "Rust".into(),                 // name YOUR client, see Config::lib_name
+//!     lib_version: env!("CARGO_PKG_VERSION").into(),
+//!     base_properties: properties,             // platform, product, app version, env
+//!
+//!     // Optional — omit to disable.
+//!     heartbeat: Some(Heartbeat {
+//!         event: "app_heartbeat".into(),
+//!         ..Default::default()                 // every 60s, only while active
+//!     }),
+//!     crash: Some(Crash {
+//!         path: data_dir.join("last-crash.json"),
+//!         event: "app_crash".into(),
+//!     }),
+//!     ..Config::default()
+//! })?;
+//! ```
+//!
+//! Then wire the host to it. **Each of these is a feature that silently does
+//! nothing if skipped**, which is why they are listed rather than left to be
+//! discovered:
+//!
+//! ```rust,ignore
+//! // 1. Report events. Before the identity is known these are held, not sent.
+//! sensors.track("app_launch", json!({ "channel": channel }));
+//!
+//! // 2. Identity. Required for events to reach the account — see the note
+//! //    below. Call on every session change; `None` means signed out, and is
+//! //    what releases held events for a guest.
+//! sensors.set_member(Some(member_id));
+//!
+//! // 3. Activity, from window focus/blur. Without it every session looks
+//! //    unbroken, and an app left open overnight reads as an all-night session.
+//! sensors.set_active(focused);
+//!
+//! // 4. Crashes. Chain the previous hook — replacing it takes the panic
+//! //    message off stderr, where anyone debugging looks first.
+//! let previous = std::panic::take_hook();
+//! let reporter = sensors.clone();
+//! std::panic::set_hook(Box::new(move |info| {
+//!     reporter.note_crash(&info.to_string());
+//!     previous(info);
+//! }));
+//!
+//! // 5. SHORT-LIVED PROCESSES ONLY — a CLI, a one-shot command. Reports run on
+//! //    background tasks, and `#[tokio::main]` cancels those when `main`
+//! //    returns, so without this most events never leave. Nothing appears in
+//! //    the log either: the failure is a request that was never made.
+//! sensors.flush(Duration::from_secs(3)).await;
+//! ```
+//!
+//! A long-running app (GUI, daemon, TUI) does not need step 5 — it outlives its
+//! own requests. A CLI needs nothing *but* steps 1 and 5.
+//!
+//! # What it sends
+//!
+//! Every event carries `base_properties` plus whatever is passed to `track`.
+//! The two built-in events add:
+//!
+//! | event       | properties                                                    |
+//! |-------------|---------------------------------------------------------------|
+//! | heartbeat   | `active`, `interval_ms`, `uptime_ms`, `active_ms`             |
+//! | crash       | `recovered`, `crashed_at`, `crashed_after_ms`, `crashed_after_active_ms`, `info` |
+//!
+//! `active_ms` is time the host reported as active, accumulated across focus
+//! changes — not inferred from beat counts, so a burst shorter than one
+//! interval still counts.
+//!
+//! # Hosting a WebView that also runs the JS SDK
+//!
+//! Call [`seed_script`] and inject the result before any page script. Without
+//! it the SDK mints its own anonymous id, and the two halves report as two
+//! different users — visible only as roughly doubled user counts, never as an
+//! error. The host must also configure the SDK with `cross_subdomain: false`;
+//! see that function's documentation.
+//!
+//! # Why the wire format is hand-written
+//!
+//! Sensors publishes no Rust SDK. This reproduces what the JavaScript SDK
+//! (`sa-sdk-javascript` 1.21.13) puts on the wire, which is:
+//!
+//! ```text
+//! POST <server_url>            Content-Type: application/x-www-form-urlencoded
+//! data=<urlencode(base64(json))>&ext=<urlencode("crc=" + hash(base64))>
+//! ```
+//!
+//! Three details are easy to get wrong from memory and are pinned by tests:
+//! nothing is compressed (the SDK has no gzip path at all); the checksum is
+//! computed over the **base64 text**, not the JSON; and `_track_id` /
+//! `_flush_time` are not optional — the SDK adds both unconditionally.
+//!
+//! # Two things learned the hard way
+//!
+//! **Events must carry the member id.** Reporting under a device id alone and
+//! expecting the browser SDK's `$SignUp` to associate the two does not work on
+//! a client that was already signed in when analytics shipped: that event is
+//! only emitted when the member id *changes*. Identical payloads differing only
+//! in `distinct_id` were measured landing or vanishing accordingly.
+//!
+//! **The first events happen before the identity is known.** A launch event
+//! fires before any UI exists, so sending it immediately pins the most useful
+//! event in the product to an anonymous id forever. [`Sensors::track`] holds
+//! events until [`Sensors::set_member`] is called or the wait expires.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::Engine as _;
+
+// ───────────────────────────────────────────────────────────── configuration
+
+/// Everything the client needs that it cannot work out for itself.
+#[derive(Clone, Debug)]
+pub struct Config {
+    /// Full ingest URL including the project, e.g.
+    /// `https://event-tracking.example.com/sa?project=production`.
+    pub server_url: String,
+    /// Stable per-machine identifier. Used as the anonymous id, and as
+    /// `distinct_id` until a member is bound.
+    pub device_id: String,
+    /// `$lib`. Name the thing that actually produced the event. Do **not**
+    /// borrow a browser SDK's name: a payload claiming `js` while carrying no
+    /// `$screen_*`, `$url` or `$title`, sent from a non-browser agent,
+    /// contradicts itself.
+    pub lib_name: String,
+    /// `$lib_version`. Usually `env!("CARGO_PKG_VERSION")`.
+    pub lib_version: String,
+    /// Properties attached to every event — platform, product, app version,
+    /// environment. Per-event properties override these.
+    pub base_properties: serde_json::Map<String, serde_json::Value>,
+    /// How long to hold early events waiting to learn who is signed in.
+    /// Bounded because a signed-out session never resolves.
+    pub identity_wait: Duration,
+    /// How many events to hold while waiting. Past this they go out as-is —
+    /// a mis-attributed event beats a missing one.
+    pub max_deferred: usize,
+    /// How many failed request bodies to retain for retry. Oldest dropped first.
+    pub max_pending: usize,
+    /// Per-request timeout. Nothing upstream waits on the answer.
+    pub request_timeout: Duration,
+    /// Log the first payload of each identity, in full, at debug level.
+    ///
+    /// Worth turning on when bringing this up somewhere new: this wire format
+    /// is a transcription of a JavaScript SDK's, and a transcription can be
+    /// wrong while every other signal — HTTP 200, a log line, a passing test —
+    /// says it is fine. Printing what actually goes out lets it be diffed
+    /// against what that SDK sends, which is how one mismatch was caught.
+    pub log_first_payload: bool,
+    /// Periodic proof that the app is still being used. `None` disables it.
+    pub heartbeat: Option<Heartbeat>,
+    /// Where to record a crash so the *next* launch can report it. `None`
+    /// disables crash reporting.
+    pub crash: Option<Crash>,
+}
+
+/// Liveness reporting.
+///
+/// A launch event says the app was opened; nothing says it is still open. With
+/// only launches, an hour of use and a mistaken double-click are the same
+/// datapoint. Each beat carries `uptime_ms` and `active_ms` so a session's
+/// length can be reconstructed even when the last beat is the last thing ever
+/// heard from a client — which is the normal case, since processes are killed
+/// far more often than they are closed politely.
+#[derive(Clone, Debug)]
+pub struct Heartbeat {
+    /// How often to beat. A minute is a reasonable default: fine-grained enough
+    /// to measure a session, coarse enough not to matter as traffic.
+    pub interval: Duration,
+    /// Event name, e.g. `desktop_heartbeat`.
+    pub event: String,
+    /// Beat only while the host reports the app as active (see
+    /// [`Sensors::set_active`]).
+    ///
+    /// `true` — the default — makes "beats × interval" a usable proxy for time
+    /// actually spent in the app. `false` beats regardless and tags each one
+    /// with `active`, leaving the filtering to whoever queries. Changing this
+    /// later changes what every duration metric means, so it is worth deciding
+    /// once.
+    pub only_when_active: bool,
+}
+
+impl Default for Heartbeat {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(60),
+            event: "heartbeat".into(),
+            only_when_active: true,
+        }
+    }
+}
+
+/// Crash reporting.
+///
+/// A crashing process cannot send an HTTP request — there is no time, and on an
+/// abort no unwinding either. So a crash is written to disk synchronously and
+/// reported by the *next* launch, which is also why this belongs in the client
+/// rather than in the host: the replay has to happen inside [`Sensors::new`],
+/// before anything else can report.
+#[derive(Clone, Debug)]
+pub struct Crash {
+    /// File to record a crash in. Must be somewhere that survives a restart and
+    /// is writable without allocation-heavy setup — a panic hook runs in a
+    /// process that is already failing.
+    pub path: std::path::PathBuf,
+    /// Event name, e.g. `desktop_crash`.
+    pub event: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            server_url: String::new(),
+            device_id: String::new(),
+            lib_name: "Rust".into(),
+            lib_version: "0.0.0".into(),
+            base_properties: serde_json::Map::new(),
+            identity_wait: Duration::from_secs(10),
+            max_deferred: 32,
+            max_pending: 64,
+            request_timeout: Duration::from_secs(10),
+            log_first_payload: false,
+            heartbeat: None,
+            crash: None,
+        }
+    }
+}
+
+/// Who an event belongs to. `member_id` is present only while signed in.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Identity {
+    pub device_id: String,
+    pub member_id: Option<String>,
+}
+
+// ─────────────────────────────────────────────────────────────────── client
+
+/// An analytics client. Cheap to clone; all clones share one queue.
+#[derive(Clone)]
+pub struct Sensors(Arc<Inner>);
+
+struct Inner {
+    http: reqwest::Client,
+    config: Config,
+    identity: Mutex<Identity>,
+    settled: AtomicBool,
+    deferred: Mutex<Vec<Deferred>>,
+    pending: Mutex<VecDeque<String>>,
+    /// Guards the one-shot payload dump; re-armed whenever the identity changes,
+    /// since the first payload of a process is always anonymous.
+    payload_logged: AtomicBool,
+    /// Requests started but not yet finished. Only [`Sensors::flush`] reads it —
+    /// a short-lived process needs to know when it is safe to exit.
+    in_flight: AtomicUsize,
+    /// Whether the host currently counts as in use. Drives the heartbeat, and
+    /// is reported alongside it.
+    active: AtomicBool,
+    /// Process start, for `uptime_ms`.
+    started_ms: u64,
+    /// Milliseconds spent active so far, excluding the stretch in progress.
+    active_accumulated_ms: Mutex<u64>,
+    /// When the current active stretch began, if one is in progress.
+    active_since_ms: Mutex<Option<u64>>,
+}
+
+/// An event waiting for an identity. Unencoded, because its `distinct_id` is
+/// not knowable yet — which is the whole reason it waits. `occurred_ms` keeps
+/// it on the timeline where it happened rather than where it was released.
+struct Deferred {
+    event: String,
+    properties: serde_json::Value,
+    occurred_ms: u64,
+}
+
+impl Sensors {
+    /// Builds a client and starts the identity timer.
+    ///
+    /// Returns `None` only if the HTTP client cannot be constructed, which
+    /// should cost telemetry and nothing else — callers are expected to carry
+    /// on without analytics rather than fail.
+    ///
+    /// Must be called where background tasks can be spawned: inside a Tokio
+    /// runtime, or anywhere at all with the `tauri` feature.
+    pub fn new(config: Config) -> Option<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(config.request_timeout)
+            .build()
+            .map_err(|error| log::warn!("[sensors] no reporting client: {error}"))
+            .ok()?;
+
+        let device_id = config.device_id.clone();
+        let wait = config.identity_wait;
+        let sensors = Self(Arc::new(Inner {
+            http,
+            config,
+            identity: Mutex::new(Identity {
+                device_id,
+                member_id: None,
+            }),
+            settled: AtomicBool::new(false),
+            deferred: Mutex::new(Vec::new()),
+            pending: Mutex::new(VecDeque::new()),
+            payload_logged: AtomicBool::new(false),
+            in_flight: AtomicUsize::new(0),
+            // Hosts that never call `set_active` still get heartbeats: assuming
+            // "in use" until told otherwise is the safer default, since the
+            // alternative is silently measuring nothing.
+            active: AtomicBool::new(true),
+            started_ms: now_ms(),
+            active_accumulated_ms: Mutex::new(0),
+            active_since_ms: Mutex::new(Some(now_ms())),
+        }));
+
+        // The backstop for a session nobody signs in on: without it those
+        // events would be held until the process exits and then be lost.
+        let timer = sensors.clone();
+        spawn(async move {
+            sleep(wait).await;
+            timer.settle("timed out");
+        });
+
+        // A crash from the previous run, if any. Reported through the normal
+        // path, so it waits for the identity like everything else — a crash is
+        // worth attributing to whoever hit it.
+        sensors.replay_crash();
+
+        if let Some(heartbeat) = sensors.0.config.heartbeat.clone() {
+            let beating = sensors.clone();
+            spawn(async move {
+                loop {
+                    sleep(heartbeat.interval).await;
+                    beating.beat(&heartbeat);
+                }
+            });
+        }
+
+        Some(sensors)
+    }
+
+    /// Reports one event. Returns immediately.
+    ///
+    /// Never fails loudly: no caller should have to handle a network error to
+    /// record that something happened.
+    pub fn track(&self, event: &str, properties: serde_json::Value) {
+        let now = now_ms();
+
+        if !self.0.settled.load(Ordering::Relaxed) {
+            match self.hold(event, properties, now) {
+                None => return,
+                // Queue full — send as-is rather than drop.
+                Some(returned) => self.dispatch(event, returned, now),
+            }
+            return;
+        }
+
+        self.dispatch(event, properties, now);
+    }
+
+    /// Attaches subsequent events to a member, or detaches on sign-out.
+    ///
+    /// Also the signal that the identity question has an answer at all, which
+    /// is what releases anything held — a signed-out session resolves here too,
+    /// with `None`.
+    pub fn set_member(&self, member_id: Option<String>) {
+        let member_id = member_id.filter(|id| !id.is_empty());
+        let bound = member_id.is_some();
+
+        // Scoped so the lock is released before `settle`, which dispatches held
+        // events — and dispatching reads this same lock. A std Mutex is not
+        // reentrant, so holding it across that call deadlocks the first sign-in.
+        {
+            let Ok(mut identity) = self.0.identity.lock() else {
+                return;
+            };
+            if identity.member_id != member_id {
+                log::debug!("[sensors] identity {}", if bound { "bound" } else { "cleared" });
+                identity.member_id = member_id;
+                // The first payload of a process is always anonymous — the
+                // launch event precedes any sign-in — so re-arm, otherwise the
+                // log never shows what a signed-in payload looks like.
+                self.0.payload_logged.store(false, Ordering::Relaxed);
+            }
+        }
+
+        self.settle(if bound { "member bound" } else { "signed out" });
+    }
+
+    /// Tells the client whether the app currently counts as in use.
+    ///
+    /// Hosts call this on focus and blur. Without it every launch looks like an
+    /// unbroken session, and an app left open overnight reads the same as one
+    /// somebody used all night.
+    ///
+    /// Time is accounted here rather than inferred from beat counts so that a
+    /// stretch shorter than one interval still shows up.
+    pub fn set_active(&self, active: bool) {
+        if self.0.active.swap(active, Ordering::Relaxed) == active {
+            return;
+        }
+        let now = now_ms();
+        let Ok(mut since) = self.0.active_since_ms.lock() else {
+            return;
+        };
+        match (active, since.take()) {
+            // Went active: start a new stretch.
+            (true, _) => *since = Some(now),
+            // Went idle: bank the stretch that just ended.
+            (false, Some(started)) => {
+                if let Ok(mut total) = self.0.active_accumulated_ms.lock() {
+                    *total = total.saturating_add(now.saturating_sub(started));
+                }
+            }
+            (false, None) => {}
+        }
+        log::debug!("[sensors] {}", if active { "active" } else { "idle" });
+    }
+
+    /// Milliseconds spent active so far, including any stretch in progress.
+    pub fn active_ms(&self) -> u64 {
+        let banked = self
+            .0
+            .active_accumulated_ms
+            .lock()
+            .map(|total| *total)
+            .unwrap_or(0);
+        let current = self
+            .0
+            .active_since_ms
+            .lock()
+            .ok()
+            .and_then(|since| *since)
+            .map(|started| now_ms().saturating_sub(started))
+            .unwrap_or(0);
+        banked.saturating_add(current)
+    }
+
+    /// Milliseconds since the client was constructed.
+    pub fn uptime_ms(&self) -> u64 {
+        now_ms().saturating_sub(self.0.started_ms)
+    }
+
+    /// Records a crash for the next launch to report.
+    ///
+    /// Call from a panic hook. Writes synchronously and does nothing else: the
+    /// process is already failing, and anything asynchronous would not outlive
+    /// it. Reported on the next [`Sensors::new`].
+    pub fn note_crash(&self, info: &str) {
+        let Some(crash) = &self.0.config.crash else {
+            return;
+        };
+        let record = serde_json::json!({
+            "time": now_ms(),
+            "info": truncate(info, 2000),
+            "uptime_ms": self.uptime_ms(),
+            "active_ms": self.active_ms(),
+        });
+        if let Some(parent) = crash.path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&crash.path, record.to_string());
+    }
+
+    /// Reports a crash recorded by a previous run, if there is one, then clears
+    /// it. Called from [`Sensors::new`].
+    fn replay_crash(&self) {
+        let Some(crash) = &self.0.config.crash else {
+            return;
+        };
+        let Ok(contents) = std::fs::read_to_string(&crash.path) else {
+            return;
+        };
+        // Removed before reporting, not after: a malformed record that somehow
+        // caused trouble downstream would otherwise be retried on every launch
+        // for the life of the installation.
+        let _ = std::fs::remove_file(&crash.path);
+
+        let mut properties = serde_json::json!({ "recovered": true });
+        if let Ok(serde_json::Value::Object(record)) = serde_json::from_str(&contents) {
+            for (key, value) in record {
+                // The crash's own timing, not this launch's.
+                let key = match key.as_str() {
+                    "time" => "crashed_at".to_string(),
+                    "uptime_ms" => "crashed_after_ms".to_string(),
+                    "active_ms" => "crashed_after_active_ms".to_string(),
+                    _ => key,
+                };
+                properties[key] = value;
+            }
+        }
+        log::info!("[sensors] reporting a crash from the previous run");
+        self.track(&crash.event, properties);
+    }
+
+    /// Emits one heartbeat, unless the app is idle and the config says to skip
+    /// those.
+    fn beat(&self, heartbeat: &Heartbeat) {
+        let active = self.0.active.load(Ordering::Relaxed);
+        if heartbeat.only_when_active && !active {
+            return;
+        }
+        self.track(
+            &heartbeat.event,
+            serde_json::json!({
+                "active": active,
+                "interval_ms": heartbeat.interval.as_millis() as u64,
+                "uptime_ms": self.uptime_ms(),
+                "active_ms": self.active_ms(),
+            }),
+        );
+    }
+
+    /// Waits for reporting to finish. **Short-lived processes must call this.**
+    ///
+    /// Reports are sent on background tasks, and a process that exits does not
+    /// wait for them: under `#[tokio::main]` the runtime is dropped when `main`
+    /// returns and anything still in flight is cancelled. For a CLI whose whole
+    /// life is shorter than one HTTP round trip, that means most events never
+    /// leave — with nothing in the logs to say so, since the failure is the
+    /// absence of a request rather than a failed one.
+    ///
+    /// Also settles the identity first, so events still held for a sign-in that
+    /// never came are sent rather than dropped on the floor.
+    ///
+    /// Returns whether everything drained before the deadline. Long-running
+    /// hosts do not need this at all — they outlive their own requests.
+    ///
+    /// ```rust,ignore
+    /// sensors.track("command_run", json!({ "command": name }));
+    /// sensors.flush(Duration::from_secs(3)).await;   // before main returns
+    /// ```
+    pub async fn flush(&self, timeout: Duration) -> bool {
+        // Anything held for an identity would otherwise be discarded at exit:
+        // for a process this short, "we never learned who this was" is the
+        // normal outcome, not an edge case.
+        self.settle("flushing");
+
+        let deadline = now_ms().saturating_add(timeout.as_millis() as u64);
+        while self.0.in_flight.load(Ordering::Relaxed) > 0 {
+            if now_ms() >= deadline {
+                log::warn!(
+                    "[sensors] flush timed out with {} still in flight",
+                    self.0.in_flight.load(Ordering::Relaxed)
+                );
+                return false;
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+        true
+    }
+
+    /// The identity events currently report under. Mostly useful for logging —
+    /// analytics that cannot be inspected is analytics nobody trusts.
+    pub fn identity(&self) -> Identity {
+        self.0
+            .identity
+            .lock()
+            .map(|held| held.clone())
+            .unwrap_or_default()
+    }
+
+    fn hold(
+        &self,
+        event: &str,
+        properties: serde_json::Value,
+        occurred_ms: u64,
+    ) -> Option<serde_json::Value> {
+        let Ok(mut queue) = self.0.deferred.lock() else {
+            return Some(properties);
+        };
+        if queue.len() >= self.0.config.max_deferred {
+            return Some(properties);
+        }
+        log::debug!("[sensors] holding {event} until the identity is known");
+        queue.push(Deferred {
+            event: event.to_string(),
+            properties,
+            occurred_ms,
+        });
+        None
+    }
+
+    /// Releases held events. Idempotent; only the first call flushes.
+    fn settle(&self, reason: &str) {
+        if self.0.settled.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        let held: Vec<Deferred> = self
+            .0
+            .deferred
+            .lock()
+            .map(|mut queue| queue.drain(..).collect())
+            .unwrap_or_default();
+        if !held.is_empty() {
+            log::debug!("[sensors] identity settled ({reason}); releasing {}", held.len());
+        }
+        for event in held {
+            self.dispatch(&event.event, event.properties, event.occurred_ms);
+        }
+    }
+
+    fn dispatch(&self, event: &str, properties: serde_json::Value, occurred_ms: u64) {
+        let mut props = self.0.config.base_properties.clone();
+        if let Some(extra) = properties.as_object() {
+            for (key, value) in extra {
+                props.insert(key.clone(), value.clone());
+            }
+        }
+
+        let now = now_ms();
+        let payload = build_event(
+            event,
+            serde_json::Value::Object(props),
+            &self.identity(),
+            &self.0.config,
+            occurred_ms,
+            now,
+            track_id(now),
+        );
+        let body = encode_body(&payload);
+        log::debug!("[sensors] reporting {event}");
+        if self.0.config.log_first_payload
+            && !self.0.payload_logged.swap(true, Ordering::Relaxed)
+        {
+            log::debug!(
+                "[sensors] payload {}",
+                serde_json::to_string(&payload).unwrap_or_default()
+            );
+        }
+
+        let client = self.clone();
+        self.0.in_flight.fetch_add(1, Ordering::Relaxed);
+        spawn(async move {
+            // Decremented on every exit from this task, including the early
+            // return below — a leaked count would make `flush` wait out its
+            // whole timeout on every call.
+            let _guard = InFlightGuard(client.clone());
+            // Drain first, so a recovered connection also clears what an outage
+            // held back, in the order it happened. On the first failure the
+            // whole remainder goes back — putting back only the failed body
+            // would discard the rest of the backlog, and lose most of it
+            // exactly when the outage is longest.
+            let mut backlog = client.take_pending().into_iter();
+            while let Some(queued) = backlog.next() {
+                if !client.send(&queued).await {
+                    for item in retry_batch(queued, backlog, body) {
+                        client.requeue(item);
+                    }
+                    return;
+                }
+            }
+            if !client.send(&body).await {
+                client.requeue(body);
+            }
+        });
+    }
+
+    async fn send(&self, body: &str) -> bool {
+        let result = self
+            .0
+            .http
+            .post(&self.0.config.server_url)
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(body.to_string())
+            .send()
+            .await;
+        match result {
+            Ok(response) if response.status().is_success() => {
+                // Logged on success too. Analytics has no visible effect
+                // anywhere, so without this a client reporting nothing and one
+                // reporting everything read identically in the log.
+                log::debug!("[sensors] reported");
+                true
+            }
+            Ok(response) => {
+                let status = response.status();
+                log::warn!("[sensors] ingest refused the report: {status}");
+                // 4xx is about this payload; replaying it would only be refused
+                // again. 5xx says nothing about the payload — that is what the
+                // buffer is for.
+                !status.is_server_error()
+            }
+            Err(error) => {
+                log::warn!("[sensors] could not report: {error}");
+                false
+            }
+        }
+    }
+
+    fn take_pending(&self) -> Vec<String> {
+        self.0
+            .pending
+            .lock()
+            .map(|mut queue| queue.drain(..).collect())
+            .unwrap_or_default()
+    }
+
+    fn requeue(&self, body: String) {
+        if let Ok(mut queue) = self.0.pending.lock() {
+            while queue.len() >= self.0.config.max_pending {
+                queue.pop_front();
+            }
+            queue.push_back(body);
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────── wire format
+
+/// Builds the event object the JS SDK would have built.
+///
+/// The identity block follows the SDK's own `getUnionId()`: signed out, the
+/// device id is both `distinct_id` and `anonymous_id`; signed in, `distinct_id`
+/// becomes the member id and the device id stays as `anonymous_id`. The
+/// `identities` map follows suit — on login the SDK drops
+/// `$identity_anonymous_id`, keeping `$identity_login_id` beside the cookie id.
+///
+/// `occurred_ms` is when it happened, `flush_ms` when it is being sent. They
+/// differ for anything that waited, and reporting the queue time as the event
+/// time would misplace every deferred event on the timeline.
+pub fn build_event(
+    name: &str,
+    properties: serde_json::Value,
+    identity: &Identity,
+    config: &Config,
+    occurred_ms: u64,
+    flush_ms: u64,
+    track_id: u64,
+) -> serde_json::Value {
+    let device = identity.device_id.as_str();
+    let mut payload = serde_json::json!({
+        "type": "track",
+        "event": name,
+        "time": occurred_ms,
+        "anonymous_id": device,
+        "lib": {
+            "$lib": config.lib_name,
+            "$lib_method": "code",
+            "$lib_version": config.lib_version,
+        },
+        "properties": properties,
+        "_track_id": track_id,
+        "_flush_time": flush_ms,
+    });
+
+    let map = payload.as_object_mut().expect("event is an object");
+    match identity.member_id.as_deref().filter(|id| !id.is_empty()) {
+        Some(member) => {
+            map.insert("distinct_id".into(), member.into());
+            map.insert("login_id".into(), member.into());
+            map.insert(
+                "identities".into(),
+                serde_json::json!({
+                    "$identity_login_id": member,
+                    "$identity_cookie_id": device,
+                }),
+            );
+        }
+        None => {
+            map.insert("distinct_id".into(), device.into());
+            map.insert(
+                "identities".into(),
+                serde_json::json!({
+                    "$identity_cookie_id": device,
+                    "$identity_anonymous_id": device,
+                }),
+            );
+        }
+    }
+    payload
+}
+
+/// Encodes one event into a request body: `data=…&ext=crc=…`, no compression.
+pub fn encode_body(event: &serde_json::Value) -> String {
+    let json = serde_json::to_string(event).unwrap_or_else(|_| "{}".into());
+    let encoded = base64::engine::general_purpose::STANDARD.encode(json.as_bytes());
+    format!(
+        "data={}&ext={}",
+        percent_encode(&encoded),
+        percent_encode(&format!("crc={}", crc(&encoded)))
+    )
+}
+
+/// The SDK's `hashCode`: `h = h * 31 + c`, truncated to a signed 32-bit int at
+/// every step, computed over the **base64 text** rather than the JSON.
+fn crc(encoded: &str) -> i32 {
+    encoded
+        .bytes()
+        .fold(0i32, |hash, byte| hash.wrapping_mul(31).wrapping_add(i32::from(byte)))
+}
+
+/// `encodeURIComponent`, which leaves `-_.!~*'()` and alphanumerics alone.
+fn percent_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' => out.push(byte as char),
+            b'-' | b'_' | b'.' | b'!' | b'~' | b'*' | b'\'' | b'(' | b')' => out.push(byte as char),
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
+    out
+}
+
+/// The SDK's `_track_id`: three random digits, two random digits, then the last
+/// four of the millisecond clock. The JS version can emit fewer digits when a
+/// random draw starts with a zero; fixed widths keep the shape stable.
+fn track_id(now_ms: u64) -> u64 {
+    let random = uuid::Uuid::new_v4();
+    let bytes = random.as_bytes();
+    let first = 100 + (u64::from(bytes[0]) * 900 / 256);
+    let second = 10 + (u64::from(bytes[1]) * 90 / 256);
+    format!("{first}{second}{:04}", now_ms % 10_000)
+        .parse()
+        .unwrap_or(now_ms)
+}
+
+/// Decrements the in-flight count however the sending task ends, including on
+/// an early return. A leaked count would make every later [`Sensors::flush`]
+/// wait out its full timeout.
+struct InFlightGuard(Sensors);
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.0 .0.in_flight.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// What goes back into the queue when a flush stops partway: the body that
+/// failed, everything still behind it, then the event that started the flush.
+fn retry_batch(
+    failed: String,
+    rest: impl Iterator<Item = String>,
+    body: String,
+) -> Vec<String> {
+    let mut batch = vec![failed];
+    batch.extend(rest);
+    batch.push(body);
+    batch
+}
+
+/// Caps a string at `max` bytes, on a character boundary.
+///
+/// Panic messages carry backtraces and user data; neither belongs in an
+/// analytics property, and an oversized one risks the whole event.
+fn truncate(value: &str, max: usize) -> String {
+    if value.len() <= max {
+        return value.to_string();
+    }
+    let mut end = max;
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &value[..end])
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_millis() as u64)
+        .unwrap_or_default()
+}
+
+// ───────────────────────────────────────────────────── WebView identity seed
+
+/// An inline script that seeds the Sensors identity cookie before any page
+/// script runs, for hosts that also run the JS SDK in a WebView.
+///
+/// Without it the two halves report as two different users: the SDK mints its
+/// own anonymous id inside `store.init()`, which the host cannot predict — and
+/// the mismatch surfaces only as inflated user counts, never as an error. The
+/// SDK skips minting when it finds a cookie already carrying a `distinct_id`,
+/// which is the seam this writes into.
+///
+/// The host must configure the SDK with `cross_subdomain: false`. The default
+/// asks the browser to scope the cookie to a domain, and a loopback origin is
+/// an IP literal — the write is refused outright. That setting also selects the
+/// cookie name this mirrors.
+///
+/// Written only when absent: this cookie also carries *login* state, so
+/// overwriting on every launch would sign the user out of analytics on every
+/// restart. `seeded` in the exported global reports whether this run wrote it.
+pub fn seed_script(device_id: &str, server_url: &str) -> String {
+    let id = serde_json::to_string(device_id).unwrap_or_else(|_| "\"\"".into());
+    let url = serde_json::to_string(server_url).unwrap_or_else(|_| "\"\"".into());
+    format!(
+        r#"(function () {{
+  var id = {id};
+  var seeded = false;
+  try {{
+    if (id) {{
+      var host = String((typeof location !== 'undefined' && location.hostname) || '');
+      var name = 'sa_jssdk_2015_' + host.replace(/\./g, '_');
+      if (document.cookie.indexOf(name + '=') === -1) {{
+        var identities = {{ $identity_cookie_id: id, $identity_anonymous_id: id }};
+        var state = {{ distinct_id: id, identities: btoa(JSON.stringify(identities)) }};
+        document.cookie =
+          name + '=' + encodeURIComponent(JSON.stringify(state)) +
+          '; Path=/; SameSite=Lax; Max-Age=63072000';
+        seeded = true;
+      }}
+    }}
+  }} catch (e) {{}}
+  globalThis.__LB_SENSORS__ = {{ deviceId: id, serverUrl: {url}, seeded: seeded }};
+}})();"#
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────── runtime
+
+/// Background work goes onto Tauri's runtime when the `tauri-runtime` feature
+/// is on, and onto the ambient Tokio runtime otherwise.
+///
+/// The distinction matters at exactly one moment: Tauri's `setup()` runs on a
+/// thread that is not inside a Tokio runtime context, so a bare `tokio::spawn`
+/// there panics — and `setup()` is where the launch event is reported.
+/// `tauri::async_runtime::spawn` finds the runtime Tauri manages instead.
+///
+/// Sleeping needs no such split: Tauri's runtime *is* Tokio, so the timer works
+/// either way (Tokio's `time` feature is required).
+#[cfg(feature = "tauri-runtime")]
+fn spawn<F>(future: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    tauri::async_runtime::spawn(future);
+}
+
+#[cfg(not(feature = "tauri-runtime"))]
+fn spawn<F>(future: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    // `tokio::spawn` panics outside a runtime, and analytics must never be the
+    // reason a host goes down — a dropped event is a rounding error, a crash is
+    // an outage. Degrades to a warning instead, and a loud one: silently
+    // reporting nothing is the exact failure this module exists to prevent.
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => {
+            handle.spawn(future);
+        }
+        Err(_) => log::warn!(
+            "[sensors] no Tokio runtime in scope; background work dropped. \
+             Construct inside a runtime, or enable the `tauri-runtime` feature."
+        ),
+    }
+}
+
+async fn sleep(duration: Duration) {
+    tokio::time::sleep(duration).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> Config {
+        Config {
+            server_url: "http://127.0.0.1:1/sa?project=default".into(),
+            device_id: "device-1".into(),
+            lib_name: "Rust".into(),
+            lib_version: "1.2.3".into(),
+            ..Config::default()
+        }
+    }
+
+    fn anonymous() -> Identity {
+        Identity {
+            device_id: "device-1".into(),
+            member_id: None,
+        }
+    }
+
+    fn signed_in() -> Identity {
+        Identity {
+            device_id: "device-1".into(),
+            member_id: Some("member-9".into()),
+        }
+    }
+
+    #[test]
+    fn anonymous_events_report_the_device_id_as_both_ids() {
+        let payload = build_event("e", serde_json::json!({}), &anonymous(), &config(), 1, 1, 2);
+        assert_eq!(payload["distinct_id"], "device-1");
+        assert_eq!(payload["anonymous_id"], "device-1");
+        assert!(payload.get("login_id").is_none());
+        assert_eq!(payload["identities"]["$identity_anonymous_id"], "device-1");
+    }
+
+    /// Signed in, `distinct_id` moves to the member while the device id stays
+    /// as the anonymous one — that pairing is what associates the two, and it
+    /// is the shape measured to actually reach the warehouse.
+    #[test]
+    fn signed_in_events_keep_the_device_id_as_the_anonymous_id() {
+        let payload = build_event("e", serde_json::json!({}), &signed_in(), &config(), 1, 1, 2);
+        assert_eq!(payload["distinct_id"], "member-9");
+        assert_eq!(payload["login_id"], "member-9");
+        assert_eq!(payload["anonymous_id"], "device-1");
+        assert_eq!(payload["identities"]["$identity_login_id"], "member-9");
+        assert!(payload["identities"].get("$identity_anonymous_id").is_none());
+    }
+
+    #[test]
+    fn an_empty_member_id_is_treated_as_signed_out() {
+        let identity = Identity {
+            device_id: "device-1".into(),
+            member_id: Some(String::new()),
+        };
+        let payload = build_event("e", serde_json::json!({}), &identity, &config(), 1, 1, 2);
+        assert_eq!(payload["distinct_id"], "device-1");
+        assert!(payload.get("login_id").is_none());
+    }
+
+    /// The library name is the caller's, never borrowed from a browser SDK.
+    #[test]
+    fn the_library_is_the_one_the_caller_named() {
+        let payload = build_event("e", serde_json::json!({}), &anonymous(), &config(), 1, 1, 2);
+        assert_eq!(payload["lib"]["$lib"], "Rust");
+        assert_eq!(payload["lib"]["$lib_version"], "1.2.3");
+    }
+
+    /// An event held back still belongs at the moment it happened.
+    #[test]
+    fn a_deferred_event_keeps_the_time_it_happened() {
+        let payload = build_event("e", serde_json::json!({}), &anonymous(), &config(), 100, 900, 1);
+        assert_eq!(payload["time"], 100);
+        assert_eq!(payload["_flush_time"], 900);
+    }
+
+    #[test]
+    fn every_event_carries_the_track_and_flush_stamps() {
+        let payload = build_event("e", serde_json::json!({}), &anonymous(), &config(), 42, 99, 7);
+        assert_eq!(payload["_track_id"], 7);
+    }
+
+    /// The exact hash the SDK computes: 0, 97, 97*31+98, and so on.
+    #[test]
+    fn the_crc_matches_the_sdk_hash() {
+        assert_eq!(crc(""), 0);
+        assert_eq!(crc("a"), 97);
+        assert_eq!(crc("ab"), 3105);
+        assert_eq!(crc("abc"), 96354);
+    }
+
+    /// 32-bit truncation is what keeps long payloads agreeing with the SDK;
+    /// without the wrap this overflows and panics in debug builds.
+    #[test]
+    fn the_crc_wraps_like_a_signed_32_bit_int() {
+        let _ = crc(&"A".repeat(4096));
+    }
+
+    #[test]
+    fn base64_padding_and_symbols_are_escaped() {
+        assert_eq!(percent_encode("a+b/c="), "a%2Bb%2Fc%3D");
+        assert_eq!(percent_encode("-_.!~*'()"), "-_.!~*'()");
+        assert_eq!(percent_encode("crc=-12345"), "crc%3D-12345");
+    }
+
+    #[test]
+    fn the_body_has_exactly_the_two_fields_the_sdk_sends() {
+        let payload = build_event("e", serde_json::json!({}), &anonymous(), &config(), 1, 1, 2);
+        let body = encode_body(&payload);
+        assert!(body.starts_with("data="));
+        assert!(body.contains("&ext=crc%3D"));
+        // Nothing is compressed: the SDK has no gzip path at all.
+        assert!(!body.contains("gzip"));
+    }
+
+    /// The checksum must cover the base64 text. Computing it over the JSON
+    /// produces a body that still looks right and is rejected.
+    #[test]
+    fn the_crc_covers_the_encoded_text_not_the_json() {
+        let payload = build_event("e", serde_json::json!({}), &anonymous(), &config(), 1, 1, 2);
+        let json = serde_json::to_string(&payload).unwrap();
+        let encoded = base64::engine::general_purpose::STANDARD.encode(json.as_bytes());
+        let body = encode_body(&payload);
+        assert!(body.contains(&percent_encode(&format!("crc={}", crc(&encoded)))));
+        assert!(!body.contains(&percent_encode(&format!("crc={}", crc(&json)))));
+    }
+
+    #[test]
+    fn track_ids_are_nine_digits() {
+        for ms in [0u64, 1, 999, 1_700_000_000_000] {
+            assert_eq!(track_id(ms).to_string().len(), 9);
+        }
+    }
+
+    fn client() -> Sensors {
+        Sensors::new(config()).expect("the http client builds")
+    }
+
+    /// The launch event fires before any UI exists, so it cannot know who is
+    /// signed in. Sending it straight away would pin the most useful event in
+    /// the product to an anonymous id forever.
+    #[test]
+    fn events_are_held_while_the_identity_is_unknown() {
+        let sensors = client();
+        sensors.track("app_launch", serde_json::json!({}));
+        assert_eq!(sensors.0.deferred.lock().unwrap().len(), 1);
+    }
+
+    /// Holding preserves when the event happened. Releasing it a second later
+    /// must not move it a second down the timeline.
+    #[test]
+    fn holding_preserves_the_moment_the_event_happened() {
+        let sensors = client();
+        let before = now_ms();
+        sensors.track("app_launch", serde_json::json!({}));
+        let queue = sensors.0.deferred.lock().unwrap();
+        assert!(queue[0].occurred_ms >= before);
+    }
+
+    /// Past the bound, an event goes out as-is rather than being dropped: a
+    /// mis-attributed event still beats a missing one.
+    #[test]
+    fn a_full_hold_queue_hands_the_event_back_instead_of_dropping_it() {
+        let sensors = client();
+        for index in 0..sensors.0.config.max_deferred {
+            assert!(sensors
+                .hold("e", serde_json::json!({ "i": index }), 1)
+                .is_none());
+        }
+        assert!(
+            sensors.hold("e", serde_json::json!({}), 1).is_some(),
+            "the event must come back to the caller"
+        );
+    }
+
+    /// Binding a member is what releases the backlog — and it must not be
+    /// possible for that to deadlock: settling dispatches held events, and
+    /// dispatching reads the identity lock the caller just held.
+    #[test]
+    fn binding_a_member_settles_and_releases_everything_held() {
+        let sensors = client();
+        sensors.track("app_launch", serde_json::json!({}));
+        assert_eq!(sensors.0.deferred.lock().unwrap().len(), 1);
+
+        sensors.set_member(Some("member-9".into()));
+
+        assert!(sensors.0.deferred.lock().unwrap().is_empty());
+        assert_eq!(sensors.identity().member_id.as_deref(), Some("member-9"));
+    }
+
+    /// A signed-out session resolves the identity question too — otherwise a
+    /// guest's events would be held until the process exits and then be lost.
+    #[test]
+    fn signing_out_also_settles() {
+        let sensors = client();
+        sensors.track("app_launch", serde_json::json!({}));
+        sensors.set_member(None);
+        assert!(sensors.0.deferred.lock().unwrap().is_empty());
+        assert!(sensors.identity().member_id.is_none());
+    }
+
+    /// After settling, events go straight out rather than accumulating.
+    #[test]
+    fn later_events_are_not_held() {
+        let sensors = client();
+        sensors.set_member(Some("member-9".into()));
+        sensors.track("later", serde_json::json!({}));
+        assert!(sensors.0.deferred.lock().unwrap().is_empty());
+    }
+
+    /// The retry queue is a buffer, not a log. Without the bound, a machine
+    /// offline for an afternoon would hold every event it ever tried to send.
+    #[test]
+    fn the_pending_queue_is_bounded() {
+        let sensors = client();
+        let max = sensors.0.config.max_pending;
+        for index in 0..(max * 2) {
+            sensors.requeue(format!("body-{index}"));
+        }
+        let held = sensors.take_pending();
+        assert_eq!(held.len(), max);
+        // Oldest dropped: the survivors are the most recent ones.
+        assert_eq!(held.last().unwrap(), &format!("body-{}", max * 2 - 1));
+        assert!(sensors.take_pending().is_empty());
+    }
+
+    /// Time is banked when a stretch ends, so a burst of use shorter than one
+    /// heartbeat interval is still counted rather than rounded away.
+    #[test]
+    fn active_time_accumulates_across_stretches() {
+        let sensors = client();
+        assert!(sensors.active_ms() < 1_000, "starts near zero");
+
+        sensors.set_active(false);
+        let banked = sensors.active_ms();
+        // Idle time must not accrue.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert_eq!(sensors.active_ms(), banked, "idle time is not counted");
+
+        sensors.set_active(true);
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert!(sensors.active_ms() > banked, "active time resumes");
+    }
+
+    /// Repeated calls with the same state are ignored — hosts fire focus events
+    /// more than once, and double-counting a stretch would inflate every
+    /// duration metric.
+    #[test]
+    fn repeating_the_same_activity_state_changes_nothing() {
+        let sensors = client();
+        sensors.set_active(true);
+        let first = sensors.active_ms();
+        sensors.set_active(true);
+        assert!(sensors.active_ms() >= first);
+        sensors.set_active(false);
+        let banked = sensors.active_ms();
+        sensors.set_active(false);
+        assert_eq!(sensors.active_ms(), banked);
+    }
+
+    /// A host that never reports activity still gets heartbeats: measuring
+    /// nothing is a worse failure than measuring generously.
+    #[test]
+    fn activity_defaults_to_in_use() {
+        let sensors = client();
+        let heartbeat = Heartbeat::default();
+        sensors.set_member(None); // settle, so the beat is dispatched not held
+        sensors.beat(&heartbeat);
+        assert!(sensors.0.active.load(Ordering::Relaxed));
+    }
+
+    /// An idle beat is skipped under the default policy, which is what makes
+    /// "beats × interval" mean time actually spent in the app.
+    #[test]
+    fn idle_beats_are_skipped_by_default() {
+        let sensors = client();
+        sensors.set_member(None);
+        sensors.set_active(false);
+        sensors.beat(&Heartbeat::default());
+        // Nothing to assert on the wire here; the contract is that the policy
+        // is consulted at all, which the config flag below pins.
+        assert!(Heartbeat::default().only_when_active);
+    }
+
+    /// A crash is written synchronously and replayed by the next launch. The
+    /// record is removed first, so a bad one cannot be retried forever.
+    #[test]
+    fn a_crash_is_recorded_and_cleared_on_replay() {
+        let dir = std::env::temp_dir().join(format!("sensors-crash-{}", uuid::Uuid::new_v4()));
+        let path = dir.join("crash.json");
+        let mut settings = config();
+        settings.crash = Some(Crash {
+            path: path.clone(),
+            event: "crash".into(),
+        });
+
+        let sensors = Sensors::new(settings).expect("client builds");
+        sensors.note_crash("thread panicked at 'boom'");
+        assert!(path.exists(), "the crash is on disk before the process dies");
+
+        let recorded = std::fs::read_to_string(&path).unwrap();
+        assert!(recorded.contains("boom"));
+
+        sensors.replay_crash();
+        assert!(!path.exists(), "replaying clears the record");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Panic messages carry backtraces and whatever the user was doing. Neither
+    /// belongs in an analytics property, and an oversized one risks the event.
+    #[test]
+    fn crash_details_are_truncated() {
+        assert_eq!(truncate("short", 100), "short");
+        let long = "x".repeat(3000);
+        let cut = truncate(&long, 2000);
+        assert!(cut.len() <= 2004, "{} bytes", cut.len());
+        assert!(cut.ends_with('…'));
+    }
+
+    /// Truncation must not split a character in half — that produces invalid
+    /// UTF-8 and would panic inside the panic handler.
+    #[test]
+    fn truncation_respects_character_boundaries() {
+        let text = "中文中文中文";
+        let cut = truncate(text, 7); // lands mid-character
+        assert!(cut.chars().all(|c| c == '中' || c == '文' || c == '…'));
+    }
+
+    /// Nothing is written when crash reporting is off.
+    #[test]
+    fn crashes_are_not_recorded_without_a_path() {
+        let sensors = client();
+        sensors.note_crash("boom");
+        // No panic, no file, nothing to clean up.
+    }
+
+    /// Flushing settles the identity, so events held for a sign-in that never
+    /// came are sent rather than discarded at exit. For a process this short,
+    /// "nobody signed in" is the normal case.
+    #[tokio::test]
+    async fn flushing_releases_events_held_for_an_identity() {
+        let sensors = client();
+        sensors.track("command_run", serde_json::json!({}));
+        assert_eq!(sensors.0.deferred.lock().unwrap().len(), 1);
+
+        sensors.flush(Duration::from_millis(200)).await;
+        assert!(
+            sensors.0.deferred.lock().unwrap().is_empty(),
+            "held events must be released, not dropped"
+        );
+    }
+
+    /// The guard has to decrement on every exit from the sending task. A leaked
+    /// count would make every later flush wait out its whole timeout — turning
+    /// a fast CLI into one that pauses for seconds on exit.
+    #[tokio::test]
+    async fn the_in_flight_count_returns_to_zero() {
+        let sensors = client();
+        sensors.set_member(None);
+        sensors.track("command_run", serde_json::json!({}));
+
+        // The endpoint is unroutable, so this exercises the failure path — the
+        // one where a leak would be easiest to introduce.
+        sensors.flush(Duration::from_secs(5)).await;
+        assert_eq!(sensors.0.in_flight.load(Ordering::Relaxed), 0);
+    }
+
+    /// A flush with nothing outstanding returns immediately rather than
+    /// sleeping out its timeout.
+    #[tokio::test]
+    async fn flushing_an_idle_client_is_immediate() {
+        let sensors = client();
+        sensors.set_member(None);
+        assert!(sensors.flush(Duration::from_secs(5)).await);
+    }
+
+    /// The regression this exists for: an earlier version put back only the
+    /// failed body and the new one, discarding everything queued behind it.
+    #[test]
+    fn a_partial_flush_puts_the_whole_backlog_back() {
+        let rest = vec!["b".to_string(), "c".to_string()];
+        assert_eq!(
+            retry_batch("a".into(), rest.into_iter(), "new".into()),
+            vec!["a", "b", "c", "new"]
+        );
+    }
+
+    #[test]
+    fn the_seed_derives_the_cookie_name_and_leaves_an_existing_one_alone() {
+        let script = seed_script("device-1", "https://example.com/sa?project=default");
+        assert!(script.contains("location.hostname"));
+        assert!(!script.contains("127_0_0_1"));
+        assert!(script.contains("if (document.cookie.indexOf(name + '=') === -1) {"));
+        assert!(script.contains("$identity_cookie_id: id"));
+    }
+
+    /// A quote in the id would close the string literal and turn the rest of
+    /// the seed into syntax errors — silently, since it is wrapped in `try`.
+    #[test]
+    fn the_seed_escapes_its_inputs() {
+        let script = seed_script("a\"b\\c", "https://x/sa");
+        assert!(script.contains(r#""a\"b\\c""#));
+    }
+
+    /// An empty device id must not produce a cookie claiming an empty identity:
+    /// the SDK would take it as authoritative and never mint one of its own.
+    #[test]
+    fn an_empty_device_id_seeds_no_cookie() {
+        assert!(seed_script("", "https://x/sa").contains("if (id) {"));
+    }
+}

--- a/src/analytics/core.rs
+++ b/src/analytics/core.rs
@@ -303,6 +303,35 @@ struct Inner {
     active_since_ms: Mutex<Option<u64>>,
 }
 
+/// Reports what was still unsent when the client went away.
+///
+/// Losing events at exit is the failure this module is most prone to and least
+/// able to show: the request was never made, so nothing appears in the log at
+/// all. This turns that silence into one line.
+///
+/// It fires only when the host actually releases the client. A client parked in
+/// a `static` — an `OnceLock` singleton, which is how both known hosts keep it —
+/// is never dropped at exit, so this is a backstop for hosts that own their
+/// client outright, not a substitute for flushing.
+impl Drop for Inner {
+    fn drop(&mut self) {
+        let in_flight = self.in_flight.load(Ordering::SeqCst);
+        let held = self.deferred.get_mut().map_or(0, |queue| queue.len());
+        let pending = self.pending.get_mut().map_or(0, |queue| queue.len());
+
+        if in_flight > 0 || held > 0 {
+            log::warn!(
+                "[sensors] dropped with {in_flight} request(s) in flight and {held} event(s) \
+                 still held — both are lost. A short-lived process has to flush on every exit \
+                 path, error paths included."
+            );
+        }
+        if pending > 0 {
+            log::warn!("[sensors] dropped with {pending} event(s) awaiting retry — those are lost");
+        }
+    }
+}
+
 /// An event waiting for an identity. Unencoded, because its `distinct_id` is
 /// not knowable yet — which is the whole reason it waits. `occurred_ms` keeps
 /// it on the timeline where it happened rather than where it was released.

--- a/src/analytics/core.rs
+++ b/src/analytics/core.rs
@@ -413,7 +413,10 @@ impl Sensors {
                 return;
             };
             if identity.member_id != member_id {
-                log::debug!("[sensors] identity {}", if bound { "bound" } else { "cleared" });
+                log::debug!(
+                    "[sensors] identity {}",
+                    if bound { "bound" } else { "cleared" }
+                );
                 identity.member_id = member_id;
                 // The first payload of a process is always anonymous — the
                 // launch event precedes any sign-in — so re-arm, otherwise the
@@ -631,7 +634,10 @@ impl Sensors {
             .map(|mut queue| queue.drain(..).collect())
             .unwrap_or_default();
         if !held.is_empty() {
-            log::debug!("[sensors] identity settled ({reason}); releasing {}", held.len());
+            log::debug!(
+                "[sensors] identity settled ({reason}); releasing {}",
+                held.len()
+            );
         }
         for event in held {
             self.dispatch(&event.event, event.properties, event.occurred_ms);
@@ -658,9 +664,7 @@ impl Sensors {
         );
         let body = encode_body(&payload);
         log::debug!("[sensors] reporting {event}");
-        if self.0.config.log_first_payload
-            && !self.0.payload_logged.swap(true, Ordering::Relaxed)
-        {
+        if self.0.config.log_first_payload && !self.0.payload_logged.swap(true, Ordering::Relaxed) {
             log::debug!(
                 "[sensors] payload {}",
                 serde_json::to_string(&payload).unwrap_or_default()
@@ -823,9 +827,9 @@ pub fn encode_body(event: &serde_json::Value) -> String {
 /// The SDK's `hashCode`: `h = h * 31 + c`, truncated to a signed 32-bit int at
 /// every step, computed over the **base64 text** rather than the JSON.
 fn crc(encoded: &str) -> i32 {
-    encoded
-        .bytes()
-        .fold(0i32, |hash, byte| hash.wrapping_mul(31).wrapping_add(i32::from(byte)))
+    encoded.bytes().fold(0i32, |hash, byte| {
+        hash.wrapping_mul(31).wrapping_add(i32::from(byte))
+    })
 }
 
 /// `encodeURIComponent`, which leaves `-_.!~*'()` and alphanumerics alone.
@@ -867,11 +871,7 @@ impl Drop for InFlightGuard {
 
 /// What goes back into the queue when a flush stops partway: the body that
 /// failed, everything still behind it, then the event that started the flush.
-fn retry_batch(
-    failed: String,
-    rest: impl Iterator<Item = String>,
-    body: String,
-) -> Vec<String> {
+fn retry_batch(failed: String, rest: impl Iterator<Item = String>, body: String) -> Vec<String> {
     let mut batch = vec![failed];
     batch.extend(rest);
     batch.push(body);
@@ -1036,7 +1036,9 @@ mod tests {
         assert_eq!(payload["login_id"], "member-9");
         assert_eq!(payload["anonymous_id"], "device-1");
         assert_eq!(payload["identities"]["$identity_login_id"], "member-9");
-        assert!(payload["identities"].get("$identity_anonymous_id").is_none());
+        assert!(payload["identities"]
+            .get("$identity_anonymous_id")
+            .is_none());
     }
 
     #[test]
@@ -1061,14 +1063,30 @@ mod tests {
     /// An event held back still belongs at the moment it happened.
     #[test]
     fn a_deferred_event_keeps_the_time_it_happened() {
-        let payload = build_event("e", serde_json::json!({}), &anonymous(), &config(), 100, 900, 1);
+        let payload = build_event(
+            "e",
+            serde_json::json!({}),
+            &anonymous(),
+            &config(),
+            100,
+            900,
+            1,
+        );
         assert_eq!(payload["time"], 100);
         assert_eq!(payload["_flush_time"], 900);
     }
 
     #[test]
     fn every_event_carries_the_track_and_flush_stamps() {
-        let payload = build_event("e", serde_json::json!({}), &anonymous(), &config(), 42, 99, 7);
+        let payload = build_event(
+            "e",
+            serde_json::json!({}),
+            &anonymous(),
+            &config(),
+            42,
+            99,
+            7,
+        );
         assert_eq!(payload["_track_id"], 7);
     }
 
@@ -1288,7 +1306,10 @@ mod tests {
 
         let sensors = Sensors::new(settings).expect("client builds");
         sensors.note_crash("thread panicked at 'boom'");
-        assert!(path.exists(), "the crash is on disk before the process dies");
+        assert!(
+            path.exists(),
+            "the crash is on disk before the process dies"
+        );
 
         let recorded = std::fs::read_to_string(&path).unwrap();
         assert!(recorded.contains("boom"));

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -10,6 +10,15 @@
 //!   mod.rs    endpoint · product properties · device id · singleton
 //! ```
 //!
+//! # Release builds only
+//!
+//! [`init`] does nothing in a debug build. This repository is public and there
+//! is no staging project to report into, so a contributor running `cargo run`
+//! would otherwise be indistinguishable from a user in every production
+//! dashboard — and would be reporting their own account without ever asking to.
+//! The switch is the build profile, not a flag: nothing to discover, nothing to
+//! keep working across two states.
+//!
 //! # The two process shapes
 //!
 //! This binary is both a short-lived CLI and a long-running TUI, and analytics
@@ -17,18 +26,48 @@
 //!
 //! * **A command** (`longbridge static TSLA.US`) outlives none of its own
 //!   requests. Reports run on background tasks, and `#[tokio::main]` cancels
-//!   those when `main` returns — so a command **must** call [`flush`] before
-//!   exiting, or its events are simply never sent. There is nothing in the log
-//!   to indicate this: the failure is a request that was never made.
+//!   those when `main` returns — so a command **must** call [`finish_command`]
+//!   (or [`flush`]) before exiting, or its events are simply never sent. There
+//!   is nothing in the log to indicate this: the failure is a request that was
+//!   never made.
 //! * **The TUI** runs long enough to report normally, and is the only shape
 //!   where a heartbeat means anything.
 //!
 //! Both are configured from [`init`], which takes the shape as an argument
 //! rather than guessing.
+//!
+//! # When the run event is sent
+//!
+//! One [`event::COMMAND`] per invocation, but at different moments depending on
+//! how the command ends:
+//!
+//! * **One-shot commands** report on the way out, from [`finish_command`], so
+//!   the event carries the outcome and how long the run took. Reporting on the
+//!   way in would cost a round trip less — the request would overlap the
+//!   command's own work — but it cannot say whether the user got an answer,
+//!   which is the question the data exists to answer.
+//! * **Sessions** (`ai`, `serve`, `acp`) report on the way in, through
+//!   [`report_started`]. These are routinely killed rather than exited, and an
+//!   exit-time event for a process that ends on Ctrl-C never arrives at all.
+//!
+//! `tui` reports neither: it has [`event::TUI_LAUNCH`] of its own, and counting
+//! it as a command as well would double every total.
+//!
+//! # What is lost, knowingly
+//!
+//! [`core`]'s retry queue lives in memory, so a report that fails while a
+//! one-shot command is exiting is gone — a command's whole life is shorter than
+//! one retry. Persisting it would mean the next run carrying the last one's
+//! backlog, which is a change to the shared file rather than to this one.
+//! Offline use therefore reports nothing at all, and the numbers should be read
+//! as "runs that reached the ingest", not "runs".
 
-// Shared verbatim with the desktop app, so its lints are waived here rather
-// than fixed in place: editing the file would cost the ability to sync a fix by
-// replacing it wholesale, which is the only reason it is a copy at all.
+// Shared with the desktop app, so its lints are waived here rather than fixed in
+// place: editing the file would cost the ability to sync a fix by replacing it
+// wholesale, which is the only reason it is a copy at all. Not byte-identical
+// though — this project requires `cargo fmt`, which reformats it — so syncing is
+// "copy the file, run `cargo fmt`", and the diff that leaves behind is
+// formatting only.
 #[allow(
     clippy::doc_markdown,
     clippy::duration_suboptimal_units,
@@ -40,44 +79,103 @@
 )]
 pub mod core;
 
-use std::path::PathBuf;
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use self::core::{Config, Crash, Heartbeat, Sensors};
 
 /// Production ingest. The terminal has no staging environment of its own, so
-/// unlike the desktop app there is no environment table here.
+/// unlike the desktop app there is no environment table here — which is also
+/// why nothing reports from a debug build (see the module docs).
 const SERVER_URL: &str = "https://event-tracking.lbctrl.com/sa?project=production";
 
 /// Product identifier, telling this client apart from the desktop app (`LBAI`)
 /// and the mobile clients in the same project.
 ///
-/// TODO(data): confirm before this ships. Getting it wrong is cheap in code and
-/// expensive in the warehouse, where dashboards are keyed on it.
-const TERMINAL_TYPE: &str = "LBTERM";
+/// Dashboards are keyed on this, so changing it later orphans everything built
+/// on the old value.
+const TERMINAL_TYPE: &str = "CLI";
 
-/// How long to wait for reports to drain before a command exits. Long enough
-/// for one request on a normal connection, short enough that a user on a bad
-/// one does not notice the CLI hesitating.
-const FLUSH_TIMEOUT: Duration = Duration::from_secs(3);
+/// How long to wait for reports to drain before a command exits.
+///
+/// A one-shot command now reports on its way out, so this wait is on the
+/// critical path of every invocation rather than overlapping the work — and
+/// this CLI is built to be called from scripts and agents, which call it in
+/// bulk. Long enough for one request on a working connection, short enough that
+/// a user on a broken one does not think the command hung.
+const FLUSH_TIMEOUT: Duration = Duration::from_millis(1500);
 
 static SENSORS: OnceLock<Sensors> = OnceLock::new();
+static COMMAND: OnceLock<Run> = OnceLock::new();
+/// Whether the run event has gone out. Guards against reporting one invocation
+/// twice: a session reports on entry, and the exit path still runs afterwards.
+static REPORTED: AtomicBool = AtomicBool::new(false);
+/// Whether a panic has already been recorded. The TUI installs a hook of its
+/// own that chains to this module's, so a panic there reaches [`note_crash`]
+/// twice; the first record is the one taken before the terminal is restored.
+static CRASH_NOTED: AtomicBool = AtomicBool::new(false);
 
-/// Which shape the process is running as. Decides whether a heartbeat is armed.
+/// The command being run, and when it started.
+struct Run {
+    name: String,
+    started: Instant,
+}
+
+/// Which shape the process is running as. Decides whether a heartbeat is armed,
+/// and which crash file this process owns.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Shape {
     /// A single command that will exit shortly. No heartbeat — the process will
-    /// not live to send a second one — and [`flush`] is required before exit.
+    /// not live to send a second one — and [`finish_command`] is required
+    /// before exit.
     Command,
     /// The full-screen TUI. Runs long enough for liveness to mean something.
     Tui,
 }
 
+impl Shape {
+    /// The `surface` property, and the suffix that keeps the two shapes' crash
+    /// files apart.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Command => "cli",
+            Self::Tui => "tui",
+        }
+    }
+}
+
+/// How a run ended.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// A session that has just opened and will not report again.
+    Started,
+    /// Ran to completion.
+    Ok,
+    /// The command itself failed.
+    Error,
+    /// Never got as far as the command: authentication failed first.
+    AuthFailed,
+}
+
+impl Outcome {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Started => "started",
+            Self::Ok => "ok",
+            Self::Error => "error",
+            Self::AuthFailed => "auth_failed",
+        }
+    }
+}
+
 /// Event names this binary reports under.
 pub mod event {
-    /// A CLI command ran. `command` names it — the subcommand only, never its
-    /// arguments, which carry symbols, account numbers and order details.
+    /// A CLI command ran. `command` names it — the subcommand path only, never
+    /// its arguments, which carry symbols, account numbers and order details.
+    /// Also carries `outcome`, and `duration_ms` for anything that finished.
     pub const COMMAND: &str = "terminal_command_run";
     /// The TUI was opened.
     pub const TUI_LAUNCH: &str = "terminal_tui_launch";
@@ -117,7 +215,13 @@ pub mod event {
 /// Arms analytics. Safe to call more than once; only the first call wins.
 ///
 /// Never fails: a terminal that cannot report is a terminal that still works.
+///
+/// Does nothing in a debug build — see the module docs.
 pub fn init(shape: Shape) {
+    if cfg!(debug_assertions) {
+        return;
+    }
+
     if SENSORS.get().is_some() {
         return;
     }
@@ -144,7 +248,7 @@ pub fn init(shape: Shape) {
             }),
             Shape::Command => None,
         },
-        crash: crash_path().map(|path| Crash {
+        crash: crash_path(shape).map(|path| Crash {
             path,
             event: event::CRASH.into(),
         }),
@@ -162,6 +266,51 @@ pub fn init(shape: Shape) {
     let _ = SENSORS.set(sensors);
 }
 
+/// Records which command is running, without reporting anything yet.
+///
+/// The event itself goes out from [`report_started`] or [`finish_command`],
+/// depending on the shape of the command — see the module docs.
+pub fn arm_command(name: String) {
+    let _ = COMMAND.set(Run {
+        name,
+        started: Instant::now(),
+    });
+}
+
+/// Reports a session's run event now, because it may never exit cleanly.
+pub fn report_started() {
+    report_run(Outcome::Started, None);
+}
+
+/// Reports the run event for a command that is about to exit, then waits for
+/// reports to drain.
+///
+/// **Every command path must call this (or [`flush`]) before returning**, or its
+/// events die with the runtime.
+pub async fn finish_command(outcome: Outcome) {
+    let elapsed = COMMAND.get().map(|run| run.started.elapsed());
+    report_run(outcome, elapsed);
+    flush().await;
+}
+
+/// Emits the one run event for this invocation, if it has not gone out already.
+fn report_run(outcome: Outcome, elapsed: Option<Duration>) {
+    let Some(run) = COMMAND.get() else {
+        return;
+    };
+    if REPORTED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    let mut properties = serde_json::json!({
+        "command": run.name,
+        "outcome": outcome.as_str(),
+    });
+    if let Some(elapsed) = elapsed {
+        properties["duration_ms"] = (elapsed.as_millis() as u64).into();
+    }
+    track(event::COMMAND, properties);
+}
+
 /// Reports one event. No-op before [`init`].
 pub fn track(event: &str, properties: serde_json::Value) {
     if let Some(sensors) = SENSORS.get() {
@@ -169,19 +318,58 @@ pub fn track(event: &str, properties: serde_json::Value) {
     }
 }
 
-/// Waits for reports to drain. **Every command path must call this before
-/// returning**, or its events die with the runtime.
+/// Waits for reports to drain.
 pub async fn flush() {
     if let Some(sensors) = SENSORS.get() {
         sensors.flush(FLUSH_TIMEOUT).await;
     }
 }
 
-/// Records a panic for the next run to report. Called from the panic hook.
-pub fn note_crash(info: &str) {
+/// Tells the client whether the terminal is in the foreground.
+///
+/// Without this every session looks unbroken, and a TUI left open in a
+/// background tmux pane overnight reports the same `active_ms` as one somebody
+/// used all night. Terminals that do not send focus events leave this untouched,
+/// which is the same as assuming the app is in use.
+pub fn set_active(active: bool) {
     if let Some(sensors) = SENSORS.get() {
-        sensors.note_crash(info);
+        sensors.set_active(active);
     }
+}
+
+/// Records a panic for the next run to report. Called from the panic hook.
+///
+/// Only the first panic of a process is recorded: the TUI's hook chains to this
+/// module's, and the earlier record is the one written before the terminal was
+/// restored.
+pub fn note_crash(info: &str) {
+    if CRASH_NOTED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    if let Some(sensors) = SENSORS.get() {
+        sensors.note_crash(&redact(info));
+    }
+}
+
+/// Strips the two things a panic message reliably carries that identify the
+/// person who hit it: their home directory and their account name. Both turn up
+/// in file paths inside panic messages, and neither is any use in a crash
+/// breakdown.
+fn redact(info: &str) -> String {
+    let mut out = info.to_owned();
+    if let Some(home) = dirs::home_dir().and_then(|path| path.to_str().map(str::to_owned)) {
+        // `/` as a home directory would rewrite every path in the message.
+        if home.len() > 1 {
+            out = out.replace(&home, "~");
+        }
+    }
+    let user = whoami::username();
+    // Short names collide with ordinary words; the home-directory rewrite above
+    // already covers the common case.
+    if user.len() > 2 {
+        out = out.replace(&user, "<user>");
+    }
+    out
 }
 
 /// Installs the crash hook, chaining whatever was there before.
@@ -204,21 +392,40 @@ fn base_properties(shape: Shape) -> serde_json::Map<String, serde_json::Value> {
     base.insert("terminal_type".into(), TERMINAL_TYPE.into());
     // Which shape produced the event. A command and the TUI have very different
     // usage patterns, and mixing them would make both unreadable.
-    base.insert(
-        "surface".into(),
-        match shape {
-            Shape::Command => "cli",
-            Shape::Tui => "tui",
-        }
-        .into(),
-    );
+    base.insert("surface".into(), shape.as_str().into());
     base.insert("version".into(), env!("CARGO_PKG_VERSION").into());
     base.insert("report_source".into(), "terminal".into());
+    // This CLI is built for scripting and agent tool-calling, where one task
+    // fires dozens of invocations. Without these two, automation and people are
+    // one undivided number, and the automation is the larger half.
+    base.insert("is_ci".into(), is_ci().into());
+    base.insert("is_tty".into(), std::io::stdout().is_terminal().into());
     // The SDK puts these in `properties` as well as in the `lib` object; other
     // clients in this project do the same, so shell events stay the same shape.
     base.insert("$lib".into(), "Rust".into());
     base.insert("$lib_version".into(), env!("CARGO_PKG_VERSION").into());
     base
+}
+
+/// Whether this looks like a build agent. Checks the variable every CI sets
+/// plus the ones that identify a specific system, since `CI` alone is also set
+/// by hand often enough to be worth corroborating.
+fn is_ci() -> bool {
+    if let Ok(value) = std::env::var("CI") {
+        if !value.is_empty() && value != "false" && value != "0" {
+            return true;
+        }
+    }
+    [
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "BUILDKITE",
+        "CIRCLECI",
+        "JENKINS_URL",
+        "TEAMCITY_VERSION",
+    ]
+    .iter()
+    .any(|name| std::env::var_os(name).is_some())
 }
 
 /// Platform, kept distinct from the desktop app's `desktop-*` so the two
@@ -244,29 +451,38 @@ const fn platform_type() -> &'static str {
 /// gets cleared would turn one user into many, and the count would climb with
 /// no indication of why.
 fn device_id() -> Option<String> {
-    let path = analytics_dir()?.join("device-id");
+    Some(device_id_in(&analytics_dir()?))
+}
+
+/// [`device_id`] against a given directory, so it can be exercised without
+/// writing into the home directory of whoever is running the tests.
+fn device_id_in(dir: &Path) -> String {
+    let path = dir.join("device-id");
     if let Ok(existing) = std::fs::read_to_string(&path) {
         let trimmed = existing.trim();
         if !trimmed.is_empty() {
-            return Some(trimmed.to_owned());
+            return trimmed.to_owned();
         }
     }
 
     let generated = uuid::Uuid::new_v4().to_string();
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
+    let _ = std::fs::create_dir_all(dir);
     // A failed write is not fatal: this run reports under an id that will not
     // be reused, which is worse than a stable one but better than silence.
     if let Err(error) = std::fs::write(&path, &generated) {
         tracing::debug!("could not persist the analytics device id: {error}");
     }
-    Some(generated)
+    generated
 }
 
 /// Where a crash from this run is left for the next one to find.
-fn crash_path() -> Option<PathBuf> {
-    Some(analytics_dir()?.join("last-crash.json"))
+///
+/// One file per shape. The replayed event is built from the properties of
+/// whichever process finds it, so a shared file would report every TUI crash as
+/// a CLI one — the cost being that a TUI crash waits for the next TUI launch
+/// rather than the next command.
+fn crash_path(shape: Shape) -> Option<PathBuf> {
+    Some(analytics_dir()?.join(format!("last-crash-{}.json", shape.as_str())))
 }
 
 /// `~/.longbridge/openapi/`, alongside the token and the invite code.
@@ -278,15 +494,36 @@ fn analytics_dir() -> Option<PathBuf> {
 mod tests {
     use super::*;
 
-    /// A command must not arm a heartbeat: it would schedule a timer the
-    /// process never lives to reach.
+    /// Mixing the two shapes into one breakdown would make both unreadable.
     #[test]
-    fn only_the_tui_beats() {
+    fn each_shape_names_itself() {
         assert_eq!(
             base_properties(Shape::Command).get("surface").unwrap(),
             "cli"
         );
         assert_eq!(base_properties(Shape::Tui).get("surface").unwrap(), "tui");
+    }
+
+    /// A crash is reported by the next process of the *same* shape, because the
+    /// properties around it come from that process.
+    #[test]
+    fn the_shapes_do_not_share_a_crash_file() {
+        let Some((cli, tui)) = crash_path(Shape::Command).zip(crash_path(Shape::Tui)) else {
+            return; // No home directory in this environment.
+        };
+        assert_ne!(cli, tui);
+    }
+
+    /// Every dashboard for this product is keyed on this value; it is pinned
+    /// here so a passing edit cannot orphan them.
+    #[test]
+    fn the_product_identifier_is_the_agreed_one() {
+        assert_eq!(
+            base_properties(Shape::Command)
+                .get("terminal_type")
+                .unwrap(),
+            "CLI"
+        );
     }
 
     /// Sharing a platform name with the desktop app would merge two products
@@ -307,13 +544,53 @@ mod tests {
         assert_eq!(base.get("report_source").unwrap(), "terminal");
     }
 
+    /// Automation calls this CLI in bulk; without a way to tell it apart from a
+    /// person, it is the larger half of every count.
+    #[test]
+    fn automation_is_distinguishable() {
+        let base = base_properties(Shape::Command);
+        assert!(base.get("is_ci").unwrap().is_boolean());
+        assert!(base.get("is_tty").unwrap().is_boolean());
+    }
+
     /// The device id has to survive between runs, or every invocation looks
     /// like a new user.
     #[test]
     fn the_device_id_is_stable_across_calls() {
-        let Some(first) = device_id() else {
-            return; // No home directory in this environment.
-        };
-        assert_eq!(Some(first), device_id());
+        let dir = tempfile::tempdir().unwrap();
+        let first = device_id_in(dir.path());
+        assert_eq!(first, device_id_in(dir.path()));
+    }
+
+    /// Running the tests must not provision an analytics identity in the home
+    /// directory of whoever is running them.
+    #[test]
+    fn the_device_id_is_written_where_it_is_asked_for() {
+        let dir = tempfile::tempdir().unwrap();
+        let _ = device_id_in(&dir.path().join("nested"));
+        assert!(dir.path().join("nested").join("device-id").exists());
+    }
+
+    /// The switch: a build anyone can produce from this public repository must
+    /// not report into the production project.
+    #[test]
+    fn a_debug_build_reports_nothing() {
+        // Guarded rather than asserted outright: `cargo test --release` is a
+        // legitimate thing to run, and there the gate is meant to be open.
+        if !cfg!(debug_assertions) {
+            return;
+        }
+        init(Shape::Command);
+        assert!(SENSORS.get().is_none());
+    }
+
+    /// A panic message routinely contains the path it was compiled from, under
+    /// the home directory of whoever ran the binary.
+    #[test]
+    fn a_crash_report_carries_no_home_path() {
+        let home = dirs::home_dir().unwrap();
+        let info = format!("panicked at {}/work/app/src/main.rs:1:1", home.display());
+        assert!(!redact(&info).contains(home.to_str().unwrap()));
+        assert!(redact(&info).contains("~/work/app/src/main.rs"));
     }
 }

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -87,7 +87,7 @@ pub mod core;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use self::core::{Config, Crash, Heartbeat, Sensors};
@@ -128,6 +128,21 @@ struct Run {
     name: String,
     started: Instant,
 }
+
+/// The page currently on screen, for pairing `$AppPageLeave` with the
+/// `$AppViewScreen` that opened it.
+struct OpenPage {
+    name: String,
+    since: Instant,
+    /// What the view reported alongside the page, repeated on the leave so both
+    /// halves can be filtered the same way.
+    properties: serde_json::Value,
+}
+
+static PAGE: Mutex<Option<OpenPage>> = Mutex::new(None);
+/// The runtime [`init`] was called on, so events reported from threads outside it
+/// still reach it. See [`track`].
+static RUNTIME: OnceLock<tokio::runtime::Handle> = OnceLock::new();
 
 /// Which shape the process is running as. Decides whether a heartbeat is armed,
 /// and which crash file this process owns.
@@ -218,6 +233,14 @@ pub mod event {
     /// A panic from the previous run, replayed on this one.
     pub const CRASH: &str = "terminal_crash";
 
+    /// A page was opened. Sensors' own preset event, so page views from this
+    /// binary land in the same reports as the apps' — which is the whole reason
+    /// to use the group's `page_name` vocabulary rather than inventing one.
+    pub const VIEW_SCREEN: &str = "$AppViewScreen";
+    /// A page was left, carrying `$event_duration`. Always paired with a
+    /// preceding [`VIEW_SCREEN`] for the same page.
+    pub const PAGE_LEAVE: &str = "$AppPageLeave";
+
     /// `longbridge ai` was opened. Carries `agent` and `signed_in`.
     pub const AI_LAUNCH: &str = "terminal_ai_launch";
     /// A question was sent to the agent. Carries `agent`, `is_first_turn` and
@@ -260,6 +283,13 @@ pub fn init(shape: Shape) {
     if opted_out() {
         tracing::debug!("analytics disabled by the environment");
         return;
+    }
+
+    // Captured here because `init` runs on the async main, which is inside the
+    // runtime. Threads that are not — Bevy's executor, most of the market TUI —
+    // borrow it back in `track`.
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        let _ = RUNTIME.set(handle);
     }
 
     if SENSORS.get().is_some() {
@@ -349,16 +379,53 @@ fn report_run(outcome: Outcome, elapsed: Option<Duration>) {
 }
 
 /// Reports one event. No-op before [`init`].
+///
+/// Enters the runtime captured at [`init`] first, because [`core`] sends on a
+/// background task and finds the runtime through `Handle::try_current()` — which
+/// only works on a thread that is already inside one. The market TUI's systems
+/// run on Bevy's executor threads, which are not, and every event reported from
+/// there was dropped with a warning: `track` logged, no request was ever made,
+/// and nothing downstream said otherwise.
 pub fn track(event: &str, properties: serde_json::Value) {
-    if let Some(sensors) = SENSORS.get() {
-        sensors.track(event, properties);
-    }
+    let Some(sensors) = SENSORS.get() else {
+        return;
+    };
+    let _runtime = RUNTIME.get().map(tokio::runtime::Handle::enter);
+    sensors.track(event, properties);
 }
 
 /// Waits for reports to drain.
 pub async fn flush() {
     if let Some(sensors) = SENSORS.get() {
         sensors.flush(FLUSH_TIMEOUT).await;
+    }
+}
+
+/// [`flush`] for a caller that has no `await` to offer.
+///
+/// The TUI's quit path is synchronous and ends in `process::exit`, so there is
+/// nowhere to await and no unwinding afterwards — without a blocking wait its
+/// last events are cancelled with the runtime.
+///
+/// Waits on a thread of its own, because `block_on` panics when called from
+/// inside the runtime and the quit path arrives on both kinds of thread: Bevy's
+/// executor for most of the TUI, but the runtime's own main thread for the
+/// keystroke that quits. Guarding on `Handle::try_current()` instead avoided the
+/// panic and skipped the wait in exactly the case that needed it — the last page
+/// of every session went out and was then cancelled by `process::exit`.
+///
+/// A borrowed thread is cheap here: this runs once, on the way out.
+pub fn flush_blocking() {
+    let Some(handle) = RUNTIME.get().cloned() else {
+        return;
+    };
+    // A newly spawned thread is never inside a runtime, so this is legal
+    // wherever the caller happens to be. `join` is what makes it a wait.
+    if std::thread::spawn(move || handle.block_on(flush()))
+        .join()
+        .is_err()
+    {
+        tracing::debug!("analytics: the flushing thread went away before it finished");
     }
 }
 
@@ -371,6 +438,78 @@ pub async fn flush() {
 pub fn set_active(active: bool) {
     if let Some(sensors) = SENSORS.get() {
         sensors.set_active(active);
+    }
+}
+
+/// Reports that the reader is now looking at `page`.
+///
+/// Sends `$AppViewScreen` for the page being entered and, if another page was
+/// open, `$AppPageLeave` for it first — so the two always come in pairs and the
+/// warehouse can total time per page. Callers only ever say which page they are
+/// on; the pairing, the ordering and the timing are handled here, because a
+/// caller that forgets the leave does not fail visibly — it just makes that one
+/// page look like nobody ever left it.
+///
+/// `page` must be a registered `page_name`. Re-entering the same page is
+/// ignored, so a re-render or a repeated state write does not inflate the count.
+pub fn enter_page(page: &str, properties: serde_json::Value) {
+    let Ok(mut current) = PAGE.lock() else {
+        return;
+    };
+    if current.as_ref().is_some_and(|open| open.name == page) {
+        return;
+    }
+    if let Some(open) = current.take() {
+        report_leave(&open);
+    }
+    *current = Some(OpenPage {
+        name: page.to_owned(),
+        since: Instant::now(),
+        properties: properties.clone(),
+    });
+    let mut props = properties;
+    merge(&mut props, "$screen_name", page.into());
+    merge(&mut props, "page_name", page.into());
+    track(event::VIEW_SCREEN, props);
+}
+
+/// Reports leaving whatever page is open, if any. Call before the process exits:
+/// the last page of a session would otherwise have a view with no leave, and its
+/// time would be missing from every total.
+pub fn leave_page() {
+    let Ok(mut current) = PAGE.lock() else {
+        return;
+    };
+    if let Some(open) = current.take() {
+        report_leave(&open);
+    }
+}
+
+fn report_leave(open: &OpenPage) {
+    let mut props = open.properties.clone();
+    merge(&mut props, "$screen_name", open.name.as_str().into());
+    merge(&mut props, "page_name", open.name.as_str().into());
+    // Seconds, which is what `$event_duration` means to Sensors — milliseconds
+    // here would overstate every page by a factor of a thousand, and read as
+    // plausible.
+    //
+    // TODO(data): the group's spec names the property but not its unit; this
+    // follows the vendor's definition. Worth confirming against one real page
+    // before any dashboard is built on it.
+    let seconds = open.since.elapsed().as_secs_f64();
+    merge(
+        &mut props,
+        "$event_duration",
+        serde_json::Number::from_f64((seconds * 1000.0).round() / 1000.0)
+            .map_or_else(|| 0.into(), serde_json::Value::Number),
+    );
+    track(event::PAGE_LEAVE, props);
+}
+
+/// Adds a key without overwriting one the caller set deliberately.
+fn merge(properties: &mut serde_json::Value, key: &str, value: serde_json::Value) {
+    if let Some(object) = properties.as_object_mut() {
+        object.entry(key).or_insert(value);
     }
 }
 
@@ -441,6 +580,8 @@ fn base_properties(shape: Shape) -> serde_json::Map<String, serde_json::Value> {
     // clients in this project do the same, so shell events stay the same shape.
     base.insert("$lib".into(), "Rust".into());
     base.insert("$lib_version".into(), env!("CARGO_PKG_VERSION").into());
+    // The operating system, kept out of `platform_type` — see that function.
+    base.insert("$os".into(), os_name().into());
     base
 }
 
@@ -465,20 +606,37 @@ fn is_ci() -> bool {
     .any(|name| std::env::var_os(name).is_some())
 }
 
-/// Platform, kept distinct from the desktop app's `desktop-*` so the two
-/// products do not merge into one breakdown.
+/// Platform type, as the group's collection spec defines the term: the kind of
+/// client, not the operating system it runs on.
+///
+/// The spec's own values are `iOS`, `Android`, `Desktop`, `Web`, `H5`, `Golang`
+/// — none carries an OS, and `Desktop` covers mac and Windows alike. This used
+/// to report `cli-mac` / `cli-win` / `cli-linux`, which folded two dimensions
+/// into one field and matched no value in the enumeration. The OS moved to
+/// [`os_name`], which is where the rest of the group already looks for it.
+///
+/// `Terminal` rather than `CLI` because half of this product is full-screen:
+/// two TUIs plus two servers. Which of those produced an event is the
+/// `surface` property's job, one level down.
 const fn platform_type() -> &'static str {
+    "Terminal"
+}
+
+/// `$os`, using the values the group's web clients report so the field means the
+/// same thing across products. A self-named `os_family` would have been one more
+/// thing to register, and would not join to anything.
+const fn os_name() -> &'static str {
     #[cfg(target_os = "macos")]
     {
-        "cli-mac"
+        "macOS"
     }
     #[cfg(target_os = "windows")]
     {
-        "cli-win"
+        "Windows"
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        "cli-linux"
+        "Linux"
     }
 }
 
@@ -617,12 +775,83 @@ mod tests {
         );
     }
 
-    /// Sharing a platform name with the desktop app would merge two products
-    /// into one breakdown.
+    /// The quit path calls this from a runtime thread — `q` is handled on the
+    /// main one — where a bare `block_on` panics. It has to wait there rather
+    /// than give up: giving up is what dropped the last page of every session,
+    /// and panicking would crash the process on its way out.
+    ///
+    /// Asserted from inside a runtime, which is the case that used to fail.
+    #[tokio::test]
+    async fn the_blocking_flush_waits_from_a_runtime_thread() {
+        let _ = RUNTIME.set(tokio::runtime::Handle::current());
+        flush_blocking();
+    }
+
+    /// Re-entering the page already open is ignored, and the clock is not
+    /// restarted. A view that re-renders, or a state written twice, would
+    /// otherwise emit a view per frame and reset the duration each time — every
+    /// page would read as heavily visited and instantly abandoned.
+    ///
+    /// Nothing is sent here: `track` is a no-op before `init`, which is what
+    /// makes the state machine testable without reaching the network.
     #[test]
-    fn the_platform_is_not_the_desktop_apps() {
-        assert!(platform_type().starts_with("cli-"));
-        assert!(!platform_type().starts_with("desktop-"));
+    fn a_page_already_open_is_not_reentered() {
+        enter_page("tlb_test_first", serde_json::json!({}));
+        let opened_at = PAGE
+            .lock()
+            .expect("the page lock")
+            .as_ref()
+            .map(|page| page.since);
+        assert!(opened_at.is_some(), "the first page was not recorded");
+
+        enter_page("tlb_test_first", serde_json::json!({}));
+        let after = PAGE.lock().expect("the page lock").as_ref().map(|page| {
+            assert_eq!(page.name, "tlb_test_first");
+            page.since
+        });
+        assert_eq!(opened_at, after, "re-entering restarted the clock");
+
+        enter_page("tlb_test_second", serde_json::json!({}));
+        assert_eq!(
+            PAGE.lock()
+                .expect("the page lock")
+                .as_ref()
+                .map(|page| page.name.clone()),
+            Some("tlb_test_second".to_owned()),
+            "a different page did not replace the open one"
+        );
+
+        leave_page();
+        assert!(
+            PAGE.lock().expect("the page lock").is_none(),
+            "leaving did not close the page, so its successor would report no view"
+        );
+    }
+
+    /// `platform_type` names the kind of client and nothing else. It used to
+    /// carry the OS as well (`cli-mac`), which folded two dimensions into one
+    /// field and matched no value in the group's enumeration.
+    #[test]
+    fn the_platform_is_a_client_kind_not_an_operating_system() {
+        assert_eq!(platform_type(), "Terminal");
+        for os in ["mac", "win", "linux", "macOS", "Windows", "Linux"] {
+            assert!(
+                !platform_type().contains(os),
+                "the OS belongs in $os, not in platform_type"
+            );
+        }
+    }
+
+    /// The OS is still reported, under the name the group's other clients use, so
+    /// the field joins across products instead of being terminal-only.
+    #[test]
+    fn the_operating_system_is_reported_separately() {
+        let properties = base_properties(Shape::Command);
+        let os = properties.get("$os").expect("an $os").as_str();
+        assert!(
+            matches!(os, Some("macOS" | "Windows" | "Linux")),
+            "unexpected $os: {os:?}"
+        );
     }
 
     /// These events come from Rust, not from a browser SDK. Claiming `js` would

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -1,0 +1,319 @@
+//! Sensors Analytics for the terminal.
+//!
+//! The client lives in [`core`], copied verbatim from the desktop app so fixes
+//! can be moved across by replacing the file. This module holds what cannot be
+//! shared: the endpoint, what this product calls itself, where the device id
+//! lives, and the process-wide instance.
+//!
+//! ```text
+//!   core.rs   wire format · HTTP · retry · identity · heartbeat · crash
+//!   mod.rs    endpoint · product properties · device id · singleton
+//! ```
+//!
+//! # The two process shapes
+//!
+//! This binary is both a short-lived CLI and a long-running TUI, and analytics
+//! works differently for each:
+//!
+//! * **A command** (`longbridge static TSLA.US`) outlives none of its own
+//!   requests. Reports run on background tasks, and `#[tokio::main]` cancels
+//!   those when `main` returns — so a command **must** call [`flush`] before
+//!   exiting, or its events are simply never sent. There is nothing in the log
+//!   to indicate this: the failure is a request that was never made.
+//! * **The TUI** runs long enough to report normally, and is the only shape
+//!   where a heartbeat means anything.
+//!
+//! Both are configured from [`init`], which takes the shape as an argument
+//! rather than guessing.
+
+// Shared verbatim with the desktop app, so its lints are waived here rather
+// than fixed in place: editing the file would cost the ability to sync a fix by
+// replacing it wholesale, which is the only reason it is a copy at all.
+#[allow(
+    clippy::doc_markdown,
+    clippy::duration_suboptimal_units,
+    clippy::format_push_string,
+    clippy::map_unwrap_or,
+    clippy::match_same_arms,
+    clippy::needless_raw_string_hashes,
+    clippy::single_match_else
+)]
+pub mod core;
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use self::core::{Config, Crash, Heartbeat, Sensors};
+
+/// Production ingest. The terminal has no staging environment of its own, so
+/// unlike the desktop app there is no environment table here.
+const SERVER_URL: &str = "https://event-tracking.lbctrl.com/sa?project=production";
+
+/// Product identifier, telling this client apart from the desktop app (`LBAI`)
+/// and the mobile clients in the same project.
+///
+/// TODO(data): confirm before this ships. Getting it wrong is cheap in code and
+/// expensive in the warehouse, where dashboards are keyed on it.
+const TERMINAL_TYPE: &str = "LBTERM";
+
+/// How long to wait for reports to drain before a command exits. Long enough
+/// for one request on a normal connection, short enough that a user on a bad
+/// one does not notice the CLI hesitating.
+const FLUSH_TIMEOUT: Duration = Duration::from_secs(3);
+
+static SENSORS: OnceLock<Sensors> = OnceLock::new();
+
+/// Which shape the process is running as. Decides whether a heartbeat is armed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Shape {
+    /// A single command that will exit shortly. No heartbeat — the process will
+    /// not live to send a second one — and [`flush`] is required before exit.
+    Command,
+    /// The full-screen TUI. Runs long enough for liveness to mean something.
+    Tui,
+}
+
+/// Event names this binary reports under.
+pub mod event {
+    /// A CLI command ran. `command` names it — the subcommand only, never its
+    /// arguments, which carry symbols, account numbers and order details.
+    pub const COMMAND: &str = "terminal_command_run";
+    /// The TUI was opened.
+    pub const TUI_LAUNCH: &str = "terminal_tui_launch";
+    /// Periodic proof the TUI is still open. Carries `uptime_ms`/`active_ms`.
+    pub const HEARTBEAT: &str = "terminal_heartbeat";
+    /// A panic from the previous run, replayed on this one.
+    pub const CRASH: &str = "terminal_crash";
+
+    /// `longbridge ai` was opened. Carries `agent` and `signed_in`.
+    pub const AI_LAUNCH: &str = "terminal_ai_launch";
+    /// A question was sent to the agent. Carries `agent`, `is_first_turn` and
+    /// `query_len` — the length only, never the text: a question names the
+    /// symbols and positions the reader is asking about.
+    pub const AI_TURN_START: &str = "terminal_ai_turn_start";
+    /// A turn ended. Carries `result` (`ok`/`error`/`cancelled`), `error_kind`,
+    /// `duration_ms`, `answer_len`, the tools it called, and whether the answer
+    /// came with references or follow-up questions.
+    ///
+    /// Reported for abandoned turns too, so `start` and `finish` counts stay
+    /// comparable — a turn aborted by `/new` or Esc would otherwise hang in the
+    /// warehouse as a start with no end, and no completion rate could be derived.
+    pub const AI_TURN_FINISH: &str = "terminal_ai_turn_finish";
+    /// A fresh conversation was started.
+    pub const AI_SESSION_NEW: &str = "terminal_ai_session_new";
+    /// A conversation was reopened from history.
+    pub const AI_SESSION_RESUME: &str = "terminal_ai_session_resume";
+    /// The agent was switched. Carries `from` and `to`.
+    pub const AI_AGENT_SWITCH: &str = "terminal_ai_agent_switch";
+    /// The agent asked the reader something before it could carry on. Carries
+    /// `question_count`.
+    pub const AI_INTERRUPT: &str = "terminal_ai_interrupt";
+    /// How that question ended: `answered`, or `abandoned` when the reader walked
+    /// away from it instead.
+    pub const AI_INTERRUPT_ANSWERED: &str = "terminal_ai_interrupt_answered";
+}
+
+/// Arms analytics. Safe to call more than once; only the first call wins.
+///
+/// Never fails: a terminal that cannot report is a terminal that still works.
+pub fn init(shape: Shape) {
+    if SENSORS.get().is_some() {
+        return;
+    }
+
+    let Some(device_id) = device_id() else {
+        // Without a stable id every run would look like a new user, which is
+        // worse than no data at all — it would quietly inflate every count.
+        tracing::debug!("analytics disabled: no device id");
+        return;
+    };
+
+    let Some(sensors) = Sensors::new(Config {
+        server_url: SERVER_URL.into(),
+        device_id,
+        lib_name: "Rust".into(),
+        lib_version: env!("CARGO_PKG_VERSION").into(),
+        base_properties: base_properties(shape),
+        // Only the TUI lives long enough to beat. A command would arm a timer
+        // it never reaches.
+        heartbeat: match shape {
+            Shape::Tui => Some(Heartbeat {
+                event: event::HEARTBEAT.into(),
+                ..Default::default()
+            }),
+            Shape::Command => None,
+        },
+        crash: crash_path().map(|path| Crash {
+            path,
+            event: event::CRASH.into(),
+        }),
+        ..Default::default()
+    }) else {
+        return;
+    };
+
+    // The access token carries the member id, so binding costs no network call
+    // and no OpenAPI context — which matters for a command that would otherwise
+    // pay for a context it does not need. `None` is normal here: plenty of
+    // commands run signed out.
+    sensors.set_member(crate::auth::member_id());
+
+    let _ = SENSORS.set(sensors);
+}
+
+/// Reports one event. No-op before [`init`].
+pub fn track(event: &str, properties: serde_json::Value) {
+    if let Some(sensors) = SENSORS.get() {
+        sensors.track(event, properties);
+    }
+}
+
+/// Waits for reports to drain. **Every command path must call this before
+/// returning**, or its events die with the runtime.
+pub async fn flush() {
+    if let Some(sensors) = SENSORS.get() {
+        sensors.flush(FLUSH_TIMEOUT).await;
+    }
+}
+
+/// Records a panic for the next run to report. Called from the panic hook.
+pub fn note_crash(info: &str) {
+    if let Some(sensors) = SENSORS.get() {
+        sensors.note_crash(info);
+    }
+}
+
+/// Installs the crash hook, chaining whatever was there before.
+///
+/// Chained rather than replaced: the TUI's own hook restores the terminal out
+/// of full-screen mode, and losing that would leave a panicking user staring at
+/// a garbled shell.
+pub fn install_crash_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        note_crash(&info.to_string());
+        previous(info);
+    }));
+}
+
+/// Properties every event from this binary carries.
+fn base_properties(shape: Shape) -> serde_json::Map<String, serde_json::Value> {
+    let mut base = serde_json::Map::new();
+    base.insert("platform_type".into(), platform_type().into());
+    base.insert("terminal_type".into(), TERMINAL_TYPE.into());
+    // Which shape produced the event. A command and the TUI have very different
+    // usage patterns, and mixing them would make both unreadable.
+    base.insert(
+        "surface".into(),
+        match shape {
+            Shape::Command => "cli",
+            Shape::Tui => "tui",
+        }
+        .into(),
+    );
+    base.insert("version".into(), env!("CARGO_PKG_VERSION").into());
+    base.insert("report_source".into(), "terminal".into());
+    // The SDK puts these in `properties` as well as in the `lib` object; other
+    // clients in this project do the same, so shell events stay the same shape.
+    base.insert("$lib".into(), "Rust".into());
+    base.insert("$lib_version".into(), env!("CARGO_PKG_VERSION").into());
+    base
+}
+
+/// Platform, kept distinct from the desktop app's `desktop-*` so the two
+/// products do not merge into one breakdown.
+const fn platform_type() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "cli-mac"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "cli-win"
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        "cli-linux"
+    }
+}
+
+/// A stable per-machine id, created on first use.
+///
+/// Kept beside the `OpenAPI` token rather than in a cache directory: a cache that
+/// gets cleared would turn one user into many, and the count would climb with
+/// no indication of why.
+fn device_id() -> Option<String> {
+    let path = analytics_dir()?.join("device-id");
+    if let Ok(existing) = std::fs::read_to_string(&path) {
+        let trimmed = existing.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_owned());
+        }
+    }
+
+    let generated = uuid::Uuid::new_v4().to_string();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    // A failed write is not fatal: this run reports under an id that will not
+    // be reused, which is worse than a stable one but better than silence.
+    if let Err(error) = std::fs::write(&path, &generated) {
+        tracing::debug!("could not persist the analytics device id: {error}");
+    }
+    Some(generated)
+}
+
+/// Where a crash from this run is left for the next one to find.
+fn crash_path() -> Option<PathBuf> {
+    Some(analytics_dir()?.join("last-crash.json"))
+}
+
+/// `~/.longbridge/openapi/`, alongside the token and the invite code.
+fn analytics_dir() -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(".longbridge").join("openapi"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A command must not arm a heartbeat: it would schedule a timer the
+    /// process never lives to reach.
+    #[test]
+    fn only_the_tui_beats() {
+        assert_eq!(
+            base_properties(Shape::Command).get("surface").unwrap(),
+            "cli"
+        );
+        assert_eq!(base_properties(Shape::Tui).get("surface").unwrap(), "tui");
+    }
+
+    /// Sharing a platform name with the desktop app would merge two products
+    /// into one breakdown.
+    #[test]
+    fn the_platform_is_not_the_desktop_apps() {
+        assert!(platform_type().starts_with("cli-"));
+        assert!(!platform_type().starts_with("desktop-"));
+    }
+
+    /// These events come from Rust, not from a browser SDK. Claiming `js` would
+    /// produce a payload carrying none of the properties a JS SDK event always
+    /// has, sent from a non-browser agent.
+    #[test]
+    fn the_library_is_named_honestly() {
+        let base = base_properties(Shape::Command);
+        assert_eq!(base.get("$lib").unwrap(), "Rust");
+        assert_eq!(base.get("report_source").unwrap(), "terminal");
+    }
+
+    /// The device id has to survive between runs, or every invocation looks
+    /// like a new user.
+    #[test]
+    fn the_device_id_is_stable_across_calls() {
+        let Some(first) = device_id() else {
+            return; // No home directory in this environment.
+        };
+        assert_eq!(Some(first), device_id());
+    }
+}

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -19,10 +19,10 @@
 //! The switch is the build profile, not a flag: nothing to discover, nothing to
 //! keep working across two states.
 //!
-//! # The two process shapes
+//! # The three process shapes
 //!
-//! This binary is both a short-lived CLI and a long-running TUI, and analytics
-//! works differently for each:
+//! This binary is a short-lived CLI, a full-screen TUI, and a set of servers
+//! that stay open, and analytics works differently for each:
 //!
 //! * **A command** (`longbridge static TSLA.US`) outlives none of its own
 //!   requests. Reports run on background tasks, and `#[tokio::main]` cancels
@@ -30,11 +30,16 @@
 //!   (or [`flush`]) before exiting, or its events are simply never sent. There
 //!   is nothing in the log to indicate this: the failure is a request that was
 //!   never made.
-//! * **The TUI** runs long enough to report normally, and is the only shape
-//!   where a heartbeat means anything.
+//! * **The TUI** runs long enough to report normally, and beats.
+//! * **A session** (`ai`, `serve`, `acp`) also stays open and beats, but is
+//!   routinely killed rather than exited, which is why its run event goes out on
+//!   the way in. Counted as a command it would have looked like the fastest
+//!   thing in the product while actually being the longest.
 //!
-//! Both are configured from [`init`], which takes the shape as an argument
-//! rather than guessing.
+//! All three are configured from [`init`], which takes the shape as an argument
+//! rather than guessing. [`Shape`] owns every consequence of the distinction —
+//! whether it beats, when the run event fires, which crash file it claims — so
+//! adding a shape does not mean finding the places that switch on it.
 //!
 //! # When the run event is sent
 //!
@@ -134,17 +139,46 @@ pub enum Shape {
     Command,
     /// The full-screen TUI. Runs long enough for liveness to mean something.
     Tui,
+    /// A session that stays open without owning the screen: `ai`, `serve`,
+    /// `acp`. Beats like the TUI, because the question "how long was it open"
+    /// is the same question — and answering it for `ai` is the whole point of
+    /// telling this shape apart from a command that happens to run long.
+    Session,
 }
 
 impl Shape {
-    /// The `surface` property, and the suffix that keeps the two shapes' crash
-    /// files apart.
+    /// The `surface` property, and the suffix that keeps each shape's crash file
+    /// apart from the others'.
     const fn as_str(self) -> &'static str {
         match self {
             Self::Command => "cli",
             Self::Tui => "tui",
+            Self::Session => "session",
         }
     }
+
+    /// Whether this shape lives long enough for a heartbeat to mean anything.
+    /// A command would arm a timer it never reaches.
+    const fn beats(self) -> bool {
+        matches!(self, Self::Tui | Self::Session)
+    }
+
+    /// Whether the run event goes out on the way in rather than on the way out.
+    ///
+    /// Sessions are killed far more often than they exit, so an exit-time event
+    /// never arrives. Kept here rather than as a second list of subcommands at
+    /// the call site: that list and this one have to agree, and the way to
+    /// guarantee they do is for there to be only one.
+    pub const fn reports_on_entry(self) -> bool {
+        matches!(self, Self::Session)
+    }
+
+    /// Every shape. Declared with its length so that adding a variant without
+    /// listing it here fails to compile — the tests below check properties that
+    /// must hold for *all* shapes, and one that quietly skips the new one is
+    /// worse than no test, since it reads as coverage.
+    #[cfg(test)]
+    const ALL: [Self; 3] = [Self::Command, Self::Tui, Self::Session];
 }
 
 /// How a run ended.
@@ -216,9 +250,15 @@ pub mod event {
 ///
 /// Never fails: a terminal that cannot report is a terminal that still works.
 ///
-/// Does nothing in a debug build — see the module docs.
+/// Does nothing in a debug build, or when the reader has opted out — see the
+/// module docs.
 pub fn init(shape: Shape) {
     if cfg!(debug_assertions) {
+        return;
+    }
+
+    if opted_out() {
+        tracing::debug!("analytics disabled by the environment");
         return;
     }
 
@@ -241,13 +281,10 @@ pub fn init(shape: Shape) {
         base_properties: base_properties(shape),
         // Only the TUI lives long enough to beat. A command would arm a timer
         // it never reaches.
-        heartbeat: match shape {
-            Shape::Tui => Some(Heartbeat {
-                event: event::HEARTBEAT.into(),
-                ..Default::default()
-            }),
-            Shape::Command => None,
-        },
+        heartbeat: shape.beats().then(|| Heartbeat {
+            event: event::HEARTBEAT.into(),
+            ..Default::default()
+        }),
         crash: crash_path(shape).map(|path| Crash {
             path,
             event: event::CRASH.into(),
@@ -445,6 +482,23 @@ const fn platform_type() -> &'static str {
     }
 }
 
+/// Whether the reader has asked not to be measured.
+///
+/// `DO_NOT_TRACK` is the cross-vendor convention (consoledonottrack.com), so a
+/// reader who already sets it for their other tools gets the same answer here
+/// without having to learn a Longbridge-specific name. The second name exists
+/// because the first is broad — someone may want telemetry from everything else
+/// and not from this — and because a release build has no other way to be told:
+/// `cfg!(debug_assertions)` covers contributors, not users.
+///
+/// Any value counts as opting out except an empty one and `0`, matching how the
+/// convention is implemented elsewhere.
+fn opted_out() -> bool {
+    ["DO_NOT_TRACK", "LONGBRIDGE_NO_ANALYTICS"]
+        .iter()
+        .any(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty() && value != "0"))
+}
+
 /// A stable per-machine id, created on first use.
 ///
 /// Kept beside the `OpenAPI` token rather than in a cache directory: a cache that
@@ -494,24 +548,61 @@ fn analytics_dir() -> Option<PathBuf> {
 mod tests {
     use super::*;
 
-    /// Mixing the two shapes into one breakdown would make both unreadable.
+    /// Mixing the shapes into one breakdown would make each of them unreadable,
+    /// so every shape reports a `surface` and no two report the same one.
     #[test]
     fn each_shape_names_itself() {
-        assert_eq!(
-            base_properties(Shape::Command).get("surface").unwrap(),
-            "cli"
-        );
-        assert_eq!(base_properties(Shape::Tui).get("surface").unwrap(), "tui");
+        let names: Vec<&str> = Shape::ALL
+            .iter()
+            .map(|shape| {
+                let properties = base_properties(*shape);
+                let surface = properties.get("surface").expect("a surface").as_str();
+                assert_eq!(surface, Some(shape.as_str()));
+                shape.as_str()
+            })
+            .collect();
+        let mut unique = names.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), names.len(), "two shapes share a surface");
     }
 
     /// A crash is reported by the next process of the *same* shape, because the
-    /// properties around it come from that process.
+    /// properties around it come from that process. Two shapes sharing a file
+    /// would file each other's panics under the wrong surface.
     #[test]
     fn the_shapes_do_not_share_a_crash_file() {
-        let Some((cli, tui)) = crash_path(Shape::Command).zip(crash_path(Shape::Tui)) else {
-            return; // No home directory in this environment.
-        };
-        assert_ne!(cli, tui);
+        let mut paths: Vec<PathBuf> = Vec::new();
+        for shape in Shape::ALL {
+            let Some(path) = crash_path(shape) else {
+                return; // No home directory in this environment.
+            };
+            paths.push(path);
+        }
+        let count = paths.len();
+        paths.sort_unstable();
+        paths.dedup();
+        assert_eq!(paths.len(), count, "two shapes share a crash file");
+    }
+
+    /// A command would arm a timer it never lives to reach; the shapes that stay
+    /// open are the reason the heartbeat exists. `ai` reporting no heartbeat is
+    /// what made its sessions immeasurable in the first place.
+    #[test]
+    fn the_open_shapes_beat_and_a_command_does_not() {
+        assert!(!Shape::Command.beats());
+        assert!(Shape::Tui.beats());
+        assert!(Shape::Session.beats());
+    }
+
+    /// Only a session reports on entry. A command reporting there could not say
+    /// how it went, and the TUI would be counted twice — it has a launch event
+    /// of its own.
+    #[test]
+    fn only_a_session_reports_on_entry() {
+        assert!(Shape::Session.reports_on_entry());
+        assert!(!Shape::Command.reports_on_entry());
+        assert!(!Shape::Tui.reports_on_entry());
     }
 
     /// Every dashboard for this product is keyed on this value; it is pinned

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -335,10 +335,23 @@ pub fn member_id() -> Option<String> {
     let claims = decode_jwt_payload(full["access_token"].as_str()?)?;
     let sub_str = claims["sub"].as_str()?;
     let sub: serde_json::Value = serde_json::from_str(sub_str).ok()?;
-    ["member_id", "memberId", "uid", "user_id"]
+    member_id_from_sub(&sub)
+}
+
+/// Pulls the member id out of a decoded `sub` claim.
+///
+/// Takes numbers as well as strings. A member id is a number in every system
+/// that produces one, and whether it arrives JSON-quoted is a detail of whoever
+/// minted the token — reading only strings is how this returned `None` for a
+/// signed-in user, which pins every event to an anonymous id.
+fn member_id_from_sub(sub: &serde_json::Value) -> Option<String> {
+    ["member_id", "memberId", "uid", "user_id", "account_id"]
         .iter()
-        .find_map(|key| sub[*key].as_str().filter(|value| !value.is_empty()))
-        .map(str::to_owned)
+        .find_map(|key| match &sub[*key] {
+            serde_json::Value::String(value) if !value.is_empty() => Some(value.clone()),
+            serde_json::Value::Number(value) => Some(value.to_string()),
+            _ => None,
+        })
 }
 
 /// [`account_channel`] with a fallback to [`DEFAULT_ACCOUNT_CHANNEL`].
@@ -1233,5 +1246,26 @@ mod auth_code_tests {
         // Legacy base58 display form (no version byte) and empty input → None.
         assert!(unpack_agent_code(BASE58_FORM).is_none());
         assert!(unpack_agent_code("").is_none());
+    }
+
+    /// A member id that arrives as a JSON number is still a member id. Reading
+    /// only strings reported every signed-in run under an anonymous id.
+    #[test]
+    fn a_numeric_member_id_is_read() {
+        let sub = serde_json::json!({ "account_channel": "lb", "member_id": 1_234_567 });
+        assert_eq!(super::member_id_from_sub(&sub), Some("1234567".to_owned()));
+    }
+
+    #[test]
+    fn a_quoted_member_id_is_read() {
+        let sub = serde_json::json!({ "member_id": "1234567" });
+        assert_eq!(super::member_id_from_sub(&sub), Some("1234567".to_owned()));
+    }
+
+    /// Signed out, or a token that simply carries no member id: both ordinary.
+    #[test]
+    fn a_sub_without_a_member_id_yields_none() {
+        let sub = serde_json::json!({ "account_channel": "lb", "member_id": "" });
+        assert_eq!(super::member_id_from_sub(&sub), None);
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -321,6 +321,26 @@ pub fn account_channel() -> Option<String> {
         .map(str::to_owned)
 }
 
+/// Read the logged-in user's member id from the local access token.
+///
+/// Decoded from the token rather than fetched, so callers pay no network round
+/// trip and need no initialised `OpenAPI` context — which is what makes it usable
+/// from a one-shot command.
+///
+/// The claim's spelling is not guaranteed across token versions, so several are
+/// tried. `None` means signed out, or a token that carries no member id; both
+/// are ordinary, and callers are expected to carry on without one.
+pub fn member_id() -> Option<String> {
+    let full = crate::secure_storage::EncryptedFileTokenStorage::load_full(&effective_client_id())?;
+    let claims = decode_jwt_payload(full["access_token"].as_str()?)?;
+    let sub_str = claims["sub"].as_str()?;
+    let sub: serde_json::Value = serde_json::from_str(sub_str).ok()?;
+    ["member_id", "memberId", "uid", "user_id"]
+        .iter()
+        .find_map(|key| sub[*key].as_str().filter(|value| !value.is_empty()))
+        .map(str::to_owned)
+}
+
 /// [`account_channel`] with a fallback to [`DEFAULT_ACCOUNT_CHANNEL`].
 pub fn account_channel_or_default() -> String {
     account_channel().unwrap_or_else(|| DEFAULT_ACCOUNT_CHANNEL.to_owned())

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,11 +254,18 @@ async fn main() {
     // in the product by a wide margin, and would put a network round trip in
     // front of every prompt.
     let reports = !matches!(cli.command, Some(cli::Commands::Completion { .. }));
+    // Worked out once and used for both decisions below. `ai`, `serve` and `acp`
+    // stay open, so they beat and report on entry; deciding that from a second
+    // list of subcommands further down is how the two lists drift apart.
+    let shape = match &cli.command {
+        Some(cli::Commands::Tui) => analytics::Shape::Tui,
+        Some(cli::Commands::Ai { .. } | cli::Commands::Serve | cli::Commands::Acp { .. }) => {
+            analytics::Shape::Session
+        }
+        _ => analytics::Shape::Command,
+    };
     if reports {
-        analytics::init(match &cli.command {
-            Some(cli::Commands::Tui) => analytics::Shape::Tui,
-            _ => analytics::Shape::Command,
-        });
+        analytics::init(shape);
         analytics::install_crash_hook();
     }
     // `tui` is left out here as well: it reports its own launch event, and
@@ -268,10 +275,7 @@ async fn main() {
         // A session is killed far more often than it exits, so its run event
         // goes out now; a one-shot command reports on the way out instead, where
         // it can say how it went. See `analytics`.
-        if matches!(
-            cli.command,
-            Some(cli::Commands::Ai { .. } | cli::Commands::Serve | cli::Commands::Acp { .. })
-        ) {
+        if shape.reports_on_entry() {
             analytics::report_started();
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@ use std::io::Write;
 use std::time::Instant;
 
 pub mod ai;
+/// Sensors Analytics. `analytics::core` is shared verbatim with the desktop
+/// app; everything terminal-specific lives beside it in `analytics/mod.rs`.
+pub mod analytics;
 pub mod auth;
 pub mod cli;
 pub mod data;
@@ -144,6 +147,24 @@ fn option_quote_permission_guidance(
     )
 }
 
+/// The subcommand the user typed, matched against the names clap declares.
+///
+/// Checked against that list rather than taken as "the first bare argument":
+/// a global option's value (`--lang zh`) is also bare, and would otherwise be
+/// reported as a command that does not exist. Anything unrecognised — a typo,
+/// an alias — reports as `unknown` rather than leaking whatever was typed.
+fn invoked_subcommand() -> String {
+    use clap::CommandFactory;
+    let known: Vec<String> = cli::Cli::command()
+        .get_subcommands()
+        .map(|sub| sub.get_name().to_owned())
+        .collect();
+    std::env::args()
+        .skip(1)
+        .find(|arg| known.contains(arg))
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
 #[tokio::main]
 async fn main() {
     match cli::schema::handle_schema_args(std::env::args_os()) {
@@ -212,6 +233,27 @@ async fn main() {
     // Show release notes URL once after a version change (e.g. brew upgrade, manual install).
     update::check_and_show_release_notes();
 
+    // Armed before the dispatch, not inside it: several commands (auth, tui, ai,
+    // completion, acp) have match arms of their own, so anything wired into the
+    // catch-all arm would silently miss them — which it did, until a run of
+    // `auth status` produced no event at all.
+    //
+    // Before the OpenAPI context too: a command that fails to authenticate is
+    // exactly the kind worth recording.
+    analytics::init(match &cli.command {
+        Some(cli::Commands::Tui) => analytics::Shape::Tui,
+        _ => analytics::Shape::Command,
+    });
+    analytics::install_crash_hook();
+    if cli.command.is_some() {
+        // The subcommand name only. Arguments carry symbols, account numbers
+        // and order details, none of which belong in analytics.
+        analytics::track(
+            analytics::event::COMMAND,
+            serde_json::json!({ "command": invoked_subcommand() }),
+        );
+    }
+
     match cli.command {
         None => {
             // No subcommand: print help and exit
@@ -222,6 +264,7 @@ async fn main() {
 
         Some(cli::Commands::Tui) => {
             tracing::info!("App started");
+            analytics::track(analytics::event::TUI_LAUNCH, serde_json::json!({}));
             let (quote_receiver, using_api_key, _) = match openapi::init_contexts().await {
                 Ok(r) => r,
                 Err(e) => {
@@ -237,6 +280,9 @@ async fn main() {
 
             let hook = std::panic::take_hook();
             std::panic::set_hook(Box::new(move |info| {
+                // Recorded before the terminal is restored, so a panic during
+                // the restore itself still leaves a report for the next run.
+                analytics::note_crash(&info.to_string());
                 Terminal::exit_full_screen();
                 hook(info);
             }));
@@ -247,6 +293,10 @@ async fn main() {
             Terminal::enter_full_screen();
             tui::app::run(Args { logout: false }, quote_receiver).await;
             Terminal::exit_full_screen();
+            // The TUI outlives its own requests while running, but its last
+            // ones are raised on the way out — after this point the runtime
+            // goes away and anything unsent goes with it.
+            analytics::flush().await;
             return;
         }
 
@@ -267,6 +317,12 @@ async fn main() {
                 Ok((rx, _, _)) => Some(Box::pin(rx)),
                 Err(_) => None,
             };
+
+            // Reported after the contexts are built, because whether the chat
+            // opened signed in is the interesting half: it opens either way, and
+            // a reader who arrives without a token behaves nothing like one who
+            // arrives with one.
+            ai::analytics::launch(&agent, quote_receiver.is_some());
 
             let hook = std::panic::take_hook();
             std::panic::set_hook(Box::new(move |info| {
@@ -294,6 +350,11 @@ async fn main() {
                 Ok(None) => {}
                 Err(e) => eprintln!("Error: {e}"),
             }
+            // This arm returns rather than falling through to the flush at the
+            // end of `main`, so it has to flush for itself. Without this the
+            // chat's own events — including the last turn of the session — were
+            // cancelled with the runtime and never sent.
+            analytics::flush().await;
             return;
         }
 
@@ -463,6 +524,10 @@ async fn main() {
                 Ok((_, using_api_key, http_url)) => (using_api_key, http_url),
                 Err(e) => {
                     eprintln!("Authentication failed: {e}");
+                    // Flushed before exiting: a failure to authenticate is
+                    // exactly the kind of run worth knowing about, and
+                    // `process::exit` gives background tasks no chance to run.
+                    analytics::flush().await;
                     std::process::exit(1);
                 }
             };
@@ -471,6 +536,7 @@ async fn main() {
             }
             if let Err(e) = cli::dispatch(cmd, &cli.format, cli.verbose).await {
                 print_cli_error(&e, using_api_key);
+                analytics::flush().await;
                 std::process::exit(1);
             }
             if let Some(t) = start {
@@ -481,6 +547,11 @@ async fn main() {
     }
 
     update::notify_if_update_available();
+
+    // Every path that reaches here is about to return from `main`, which drops
+    // the runtime and cancels anything still sending. The exits above flush on
+    // their own; this covers the rest.
+    analytics::flush().await;
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,9 @@ async fn main() {
             Terminal::enter_full_screen();
             tui::app::run(Args { logout: false }, quote_receiver).await;
             Terminal::exit_full_screen();
+            // The page on screen at exit is left here, or its time is missing
+            // from every total — a view with no matching leave.
+            analytics::leave_page();
             // The TUI outlives its own requests while running, but its last
             // ones are raised on the way out — after this point the runtime
             // goes away and anything unsent goes with it.
@@ -375,6 +378,9 @@ async fn main() {
                 Ok(None) => {}
                 Err(e) => eprintln!("Error: {e}"),
             }
+            // Same as the market TUI: the view open at exit needs its leave, or
+            // its time is missing from every total.
+            analytics::leave_page();
             // This arm returns rather than falling through to the flush at the
             // end of `main`, so it has to flush for itself. Without this the
             // chat's own events — including the last turn of the session — were

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use crate::tui::widgets::Terminal;
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches};
 use std::io::Write;
 use std::time::Instant;
 
@@ -147,22 +147,25 @@ fn option_quote_permission_guidance(
     )
 }
 
-/// The subcommand the user typed, matched against the names clap declares.
+/// The subcommand the user ran, as clap resolved it: `"kline"`, `"alert add"`.
 ///
-/// Checked against that list rather than taken as "the first bare argument":
-/// a global option's value (`--lang zh`) is also bare, and would otherwise be
-/// reported as a command that does not exist. Anything unrecognised — a typo,
-/// an alias — reports as `unknown` rather than leaking whatever was typed.
-fn invoked_subcommand() -> String {
-    use clap::CommandFactory;
-    let known: Vec<String> = cli::Cli::command()
-        .get_subcommands()
-        .map(|sub| sub.get_name().to_owned())
-        .collect();
-    std::env::args()
-        .skip(1)
-        .find(|arg| known.contains(arg))
-        .unwrap_or_else(|| "unknown".to_owned())
+/// Taken from the parse rather than from a rescan of `argv`, which is the only
+/// way to get this right. Scanning cannot tell a subcommand from a global
+/// option's value (`--lang zh`), loses the second level entirely (`alert add`
+/// reads as `alert`), and needs an `unknown` bucket for anything it fails to
+/// recognise. clap already knows the answer; this asks it.
+///
+/// Names only — never argument values, which carry symbols, account numbers and
+/// order details.
+fn command_path(matches: &clap::ArgMatches) -> String {
+    let mut path = Vec::new();
+    let mut current = matches;
+    // Two levels is every group this CLI has (`alert add`, `auth login`).
+    while let Some((name, sub)) = current.subcommand() {
+        path.push(name.to_owned());
+        current = sub;
+    }
+    path.join(" ")
 }
 
 #[tokio::main]
@@ -182,7 +185,11 @@ async fn main() {
     // Clean up leftover .old binary from a previous Windows update.
     update::cleanup_old_binary();
 
-    let cli = cli::Cli::parse();
+    // Parsed through `ArgMatches` rather than `Cli::parse()` so the resolved
+    // subcommand path is available for reporting; the typed value is the same
+    // one `parse` would have produced.
+    let matches = cli::Cli::command().get_matches();
+    let cli = cli::Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
     let verbose = cli.verbose;
 
     locale::init(cli.lang.as_deref());
@@ -240,24 +247,38 @@ async fn main() {
     //
     // Before the OpenAPI context too: a command that fails to authenticate is
     // exactly the kind worth recording.
-    analytics::init(match &cli.command {
-        Some(cli::Commands::Tui) => analytics::Shape::Tui,
-        _ => analytics::Shape::Command,
-    });
-    analytics::install_crash_hook();
-    if cli.command.is_some() {
-        // The subcommand name only. Arguments carry symbols, account numbers
-        // and order details, none of which belong in analytics.
-        analytics::track(
-            analytics::event::COMMAND,
-            serde_json::json!({ "command": invoked_subcommand() }),
-        );
+    //
+    // `completion` is the one command left out. The README has users put
+    // `source <(longbridge completion zsh)` in their shell profile, so it runs
+    // on every new shell — reporting there would make it the most-used command
+    // in the product by a wide margin, and would put a network round trip in
+    // front of every prompt.
+    let reports = !matches!(cli.command, Some(cli::Commands::Completion { .. }));
+    if reports {
+        analytics::init(match &cli.command {
+            Some(cli::Commands::Tui) => analytics::Shape::Tui,
+            _ => analytics::Shape::Command,
+        });
+        analytics::install_crash_hook();
+    }
+    // `tui` is left out here as well: it reports its own launch event, and
+    // counting it as a command too would double every total.
+    if reports && cli.command.is_some() && !matches!(cli.command, Some(cli::Commands::Tui)) {
+        analytics::arm_command(command_path(&matches));
+        // A session is killed far more often than it exits, so its run event
+        // goes out now; a one-shot command reports on the way out instead, where
+        // it can say how it went. See `analytics`.
+        if matches!(
+            cli.command,
+            Some(cli::Commands::Ai { .. } | cli::Commands::Serve | cli::Commands::Acp { .. })
+        ) {
+            analytics::report_started();
+        }
     }
 
     match cli.command {
         None => {
             // No subcommand: print help and exit
-            use clap::CommandFactory;
             cli::Cli::command().print_help().unwrap();
             println!();
         }
@@ -353,7 +374,8 @@ async fn main() {
             // This arm returns rather than falling through to the flush at the
             // end of `main`, so it has to flush for itself. Without this the
             // chat's own events — including the last turn of the session — were
-            // cancelled with the runtime and never sent.
+            // cancelled with the runtime and never sent. The run event itself
+            // has already gone out: a session reports on the way in.
             analytics::flush().await;
             return;
         }
@@ -365,23 +387,28 @@ async fn main() {
                 Ok(r) => r,
                 Err(e) => {
                     eprintln!("Authentication failed: {e}");
+                    analytics::flush().await;
                     std::process::exit(1);
                 }
             };
             if let Err(e) = openapi::quote().member_id().await {
                 print_cli_error(&anyhow::anyhow!(e), using_api_key);
+                analytics::flush().await;
                 std::process::exit(1);
             }
             if let Err(e) = cli::serve::run(quote_receiver).await {
                 eprintln!("Error: {e}");
+                analytics::flush().await;
                 std::process::exit(1);
             }
+            analytics::flush().await;
             return;
         }
 
         Some(cli::Commands::Init { invite_code }) => {
             if let Err(e) = cli::init::cmd_init(&invite_code) {
                 eprintln!("Error: {e}");
+                analytics::finish_command(analytics::Outcome::Error).await;
                 std::process::exit(1);
             }
         }
@@ -389,6 +416,7 @@ async fn main() {
         Some(cli::Commands::Check) => {
             if let Err(e) = cli::check::cmd_check(&cli.format).await {
                 print_cli_error(&e, false);
+                analytics::finish_command(analytics::Outcome::Error).await;
                 std::process::exit(1);
             }
         }
@@ -400,12 +428,15 @@ async fn main() {
             if release_notes {
                 if let Err(e) = update::cmd_release_notes().await {
                     eprintln!("Error: {e}");
+                    analytics::finish_command(analytics::Outcome::Error).await;
                     std::process::exit(1);
                 }
             } else if let Err(e) = update::cmd_update(verbose, force).await {
                 eprintln!("Error: {e}");
+                analytics::finish_command(analytics::Outcome::Error).await;
                 std::process::exit(1);
             }
+            analytics::finish_command(analytics::Outcome::Ok).await;
             return;
         }
 
@@ -427,6 +458,7 @@ async fn main() {
             };
             if let Err(e) = result {
                 eprintln!("Authentication failed: {e:#}");
+                analytics::finish_command(analytics::Outcome::AuthFailed).await;
                 std::process::exit(1);
             }
         }
@@ -455,6 +487,7 @@ async fn main() {
         ) => {
             if let Err(e) = auth::device_login(verbose, client_name).await {
                 eprintln!("Authentication failed: {e:#}");
+                analytics::finish_command(analytics::Outcome::AuthFailed).await;
                 std::process::exit(1);
             }
         }
@@ -475,6 +508,7 @@ async fn main() {
             Ok(()) => println!("Successfully logged out."),
             Err(e) => {
                 eprintln!("Failed to clear credentials: {e}");
+                analytics::finish_command(analytics::Outcome::Error).await;
                 std::process::exit(1);
             }
         },
@@ -484,6 +518,7 @@ async fn main() {
         }) => {
             if let Err(e) = cli::auth::cmd_auth_status(&cli.format, &market).await {
                 eprintln!("Error: {e}");
+                analytics::finish_command(analytics::Outcome::Error).await;
                 std::process::exit(1);
             }
         }
@@ -511,6 +546,7 @@ async fn main() {
             .await;
             if let Err(e) = result {
                 print_cli_error(&anyhow::anyhow!(e), false);
+                analytics::flush().await;
                 std::process::exit(1);
             }
         }
@@ -524,10 +560,10 @@ async fn main() {
                 Ok((_, using_api_key, http_url)) => (using_api_key, http_url),
                 Err(e) => {
                     eprintln!("Authentication failed: {e}");
-                    // Flushed before exiting: a failure to authenticate is
+                    // Reported before exiting: a failure to authenticate is
                     // exactly the kind of run worth knowing about, and
                     // `process::exit` gives background tasks no chance to run.
-                    analytics::flush().await;
+                    analytics::finish_command(analytics::Outcome::AuthFailed).await;
                     std::process::exit(1);
                 }
             };
@@ -536,7 +572,7 @@ async fn main() {
             }
             if let Err(e) = cli::dispatch(cmd, &cli.format, cli.verbose).await {
                 print_cli_error(&e, using_api_key);
-                analytics::flush().await;
+                analytics::finish_command(analytics::Outcome::Error).await;
                 std::process::exit(1);
             }
             if let Some(t) = start {
@@ -549,9 +585,70 @@ async fn main() {
     update::notify_if_update_available();
 
     // Every path that reaches here is about to return from `main`, which drops
-    // the runtime and cancels anything still sending. The exits above flush on
+    // the runtime and cancels anything still sending. The exits above report on
     // their own; this covers the rest.
-    analytics::flush().await;
+    analytics::finish_command(analytics::Outcome::Ok).await;
+}
+
+#[cfg(test)]
+mod command_path_tests {
+    use super::command_path;
+    use clap::CommandFactory;
+
+    /// Built on a thread of its own because this CLI's clap tree is deep enough
+    /// to overflow a test thread's default stack while it is being constructed —
+    /// a property of the tree's size in a debug build, not of the parse.
+    fn path_of<const N: usize>(args: [&str; N]) -> String {
+        let args: Vec<String> = args.iter().map(|arg| (*arg).to_owned()).collect();
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(move || command_path(&crate::cli::Cli::command().get_matches_from(args)))
+            .expect("spawn")
+            .join()
+            .expect("parse")
+    }
+
+    /// The plain case, and the reason the name is worth reporting at all.
+    #[test]
+    fn names_the_command() {
+        assert_eq!(path_of(["longbridge", "quote", "700.HK"]), "quote");
+    }
+
+    /// A group's second level is where the interesting distinction lives:
+    /// listing alerts and creating one are not the same activity.
+    #[test]
+    fn names_the_second_level_too() {
+        assert_eq!(
+            path_of(["longbridge", "alert", "add", "TSLA.US", "--price", "200"]),
+            "alert add"
+        );
+        assert_eq!(
+            path_of(["longbridge", "profit-analysis", "detail", "700.HK"]),
+            "profit-analysis detail"
+        );
+    }
+
+    /// A group used without a subcommand is its own case, not a missing name.
+    #[test]
+    fn a_bare_group_is_just_the_group() {
+        assert_eq!(path_of(["longbridge", "alert"]), "alert");
+    }
+
+    /// A global option's value is a bare argument too. Scanning `argv` for the
+    /// first bare word would report `zh` as the command.
+    #[test]
+    fn a_global_options_value_is_not_the_command() {
+        assert_eq!(
+            path_of(["longbridge", "--lang", "zh", "quote", "700.HK"]),
+            "quote"
+        );
+    }
+
+    /// Nothing to report when nothing was run: `longbridge` alone prints help.
+    #[test]
+    fn no_subcommand_is_empty() {
+        assert_eq!(path_of(["longbridge"]), "");
+    }
 }
 
 #[cfg(test)]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -237,6 +237,16 @@ pub async fn run(
                         mouse_input::handle_mouse_event(&mut app, mouse_event, state, popup, update_tx.clone(), &mut render_state);
                         continue;
                     }
+                    // Time spent with the terminal in the background is not
+                    // time in use; `active_ms` is what tells the two apart.
+                    Ok(crossterm::event::Event::FocusGained) => {
+                        crate::analytics::set_active(true);
+                        continue;
+                    }
+                    Ok(crossterm::event::Event::FocusLost) => {
+                        crate::analytics::set_active(false);
+                        continue;
+                    }
                     Ok(_) => continue,
                     Err(err) => {
                         tracing::error!("fail to receive event: {err}");

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -30,6 +30,48 @@ pub static USER: std::sync::LazyLock<RwLock<User>> = std::sync::LazyLock::new(De
 pub static ACCOUNT_CHANNEL: std::sync::LazyLock<RwLock<Option<String>>> =
     std::sync::LazyLock::new(|| RwLock::new(None));
 
+/// The group's registered `page_name` for a state, or `None` for a state that is
+/// not a page.
+///
+/// These follow the vocabulary in the group's `page_name` document —
+/// `应用_业务关键字_页面功能_页面特征` — so a terminal page totals in the same
+/// report as the app's equivalent: `tlb_stock_select_home` sits beside
+/// `lb_stock_select_home` rather than in a breakdown of its own. `tlb` extends
+/// the existing prefixes (`lb` app, `dlb` desktop) the way they were built:
+/// `t`(erminal) + `lb`.
+///
+/// `Loading` and `Error` are deliberately absent. They are states the reader
+/// passes through, not pages they visit, and counting them would put a page view
+/// in front of every real one.
+const fn page_name(state: AppState) -> Option<&'static str> {
+    match state {
+        AppState::Watchlist => Some("tlb_stock_select_home"),
+        AppState::WatchlistStock => Some("tlb_stock_select_detail"),
+        AppState::Stock => Some("tlb_stock_quote_detail"),
+        AppState::Portfolio => Some("tlb_account_asset_home"),
+        AppState::Orders => Some("tlb_trade_order_home"),
+        AppState::TradeToken => Some("tlb_trade_token_entry"),
+        AppState::Loading | AppState::Error => None,
+    }
+}
+
+/// Reports a page view whenever the state changes.
+///
+/// One system watching transitions rather than a line in each `OnEnter`: the
+/// eight states share four enter systems (`Watchlist` and `WatchlistStock` both
+/// run `enter_watchlist_common`), so per-system reporting could not tell those
+/// two apart, and a state added later would silently report nothing.
+fn report_page_view(state: Res<State<AppState>>, mut reported: Local<Option<AppState>>) {
+    let current = *state.get();
+    if *reported == Some(current) {
+        return;
+    }
+    *reported = Some(current);
+    if let Some(page) = page_name(current) {
+        crate::analytics::enter_page(page, serde_json::json!({}));
+    }
+}
+
 #[derive(
     Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States, strum::EnumIter, bytemuck::NoUninit,
 )]
@@ -114,6 +156,7 @@ pub async fn run(
         .insert_resource(systems::Command(update_tx.clone()))
         .insert_resource(Carousel::new(indexes, Duration::from_secs(5)))
         .insert_resource(systems::WsState(crate::data::ReadyState::Open))
+        .add_systems(Update, report_page_view)
         .add_systems(Update, systems::loading.run_if(in_state(AppState::Loading)))
         .add_systems(Update, systems::error.run_if(in_state(AppState::Error)))
         .add_systems(OnExit(AppState::Watchlist), systems::exit_watchlist)
@@ -328,4 +371,70 @@ pub async fn run(
 fn send_evt<T: Event>(evt: T, world: &mut World) {
     let mut state = SystemState::<EventWriter<T>>::new(world);
     state.get_mut(world).send(evt);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{page_name, AppState};
+    use strum::IntoEnumIterator;
+
+    /// One page, one name. The `match` is exhaustive so a new state cannot be
+    /// forgotten, but nothing stops two states from being given the same string —
+    /// and that would silently merge two pages in every report.
+    #[test]
+    fn no_two_states_share_a_page_name() {
+        let mut names: Vec<&str> = AppState::iter().filter_map(page_name).collect();
+        let total = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), total, "two states report the same page_name");
+    }
+
+    /// Every page follows the group's vocabulary: this client's prefix, then at
+    /// least a business keyword and what the page is.
+    #[test]
+    fn every_page_name_follows_the_convention() {
+        for state in AppState::iter() {
+            let Some(name) = page_name(state) else {
+                continue;
+            };
+            assert!(
+                name.starts_with("tlb_"),
+                "{state:?} → {name} is missing this client's prefix"
+            );
+            assert!(
+                name.split('_').count() >= 3,
+                "{state:?} → {name} needs at least prefix_business_page"
+            );
+            assert_eq!(
+                name,
+                name.to_lowercase(),
+                "{state:?} → {name} should be lower snake_case"
+            );
+        }
+    }
+
+    /// The states the reader passes through are not pages. Counting them would
+    /// put a page view in front of every real one, since every session starts in
+    /// `Loading`.
+    #[test]
+    fn the_transient_states_are_not_pages() {
+        assert_eq!(page_name(AppState::Loading), None);
+        assert_eq!(page_name(AppState::Error), None);
+    }
+
+    /// Three pages exist to match the app's, so they must keep the app's names
+    /// with only the prefix swapped — that is the entire reason to use this
+    /// vocabulary rather than inventing one.
+    #[test]
+    fn the_shared_pages_match_the_apps_names() {
+        for (state, app) in [
+            (AppState::Watchlist, "lb_stock_select_home"),
+            (AppState::Portfolio, "lb_account_asset_home"),
+            (AppState::Orders, "lb_trade_order_home"),
+        ] {
+            let ours = page_name(state).expect("a page name");
+            assert_eq!(ours, app.replacen("lb_", "tlb_", 1), "{state:?} drifted");
+        }
+    }
 }

--- a/src/tui/widgets/terminal.rs
+++ b/src/tui/widgets/terminal.rs
@@ -58,6 +58,10 @@ impl Terminal {
             cursor::MoveTo(0, 0),
             cursor::Hide,
             event::EnableMouseCapture,
+            // Focus reporting: without it a TUI left open in a background pane
+            // reports the same time-in-use as one somebody is watching.
+            // Terminals that do not support it simply send nothing.
+            event::EnableFocusChange,
         );
     }
 
@@ -67,6 +71,7 @@ impl Terminal {
         _ = crossterm::execute!(
             std::io::stdout(),
             event::DisableMouseCapture,
+            event::DisableFocusChange,
             cursor::Show,
             terminal::LeaveAlternateScreen,
         );

--- a/src/tui/widgets/terminal.rs
+++ b/src/tui/widgets/terminal.rs
@@ -79,8 +79,19 @@ impl Terminal {
     }
 
     /// Graceful exit - cleanup terminal and exit program
+    ///
+    /// Analytics is settled here rather than after the TUI returns, because it
+    /// never does: this is `q` and Ctrl-C, and `process::exit` below ends the
+    /// process without unwinding. Anything still queued — the page on screen,
+    /// which has no leave yet, and whatever was reported on the way out — would
+    /// go with it, silently, since a cancelled request logs nothing.
+    ///
+    /// The terminal is restored first so the wait happens against a normal
+    /// prompt instead of a frozen full-screen frame.
     pub fn graceful_exit(code: i32) -> ! {
         Self::exit_full_screen();
+        crate::analytics::leave_page();
+        crate::analytics::flush_blocking();
         std::process::exit(code);
     }
 }


### PR DESCRIPTION
Usage reporting for the terminal: a self-contained Sensors Analytics client, the events this binary sends, and the scope rules that decide when it stays quiet.

> 4 commits · 15 files · ~+3200 · `analytics` `ai` `tui` `main` `auth`

## What changed

**`5f7a2a1` — the client and the AI events.** `analytics/core.rs` is a copy of the desktop app's client: wire format, HTTP, retry, identity, heartbeat, crash. It has no dependencies on the rest of this repository, and everything project-specific arrives through `Config`. Beside it, `analytics/mod.rs` holds the endpoint, the product properties, the device id and the process-wide instance; `ai/analytics.rs` holds the chat's business events, gathered in one file so the whole surface reads in one screen rather than being scattered through a 9000-line view.

**`78a556e` — identity, scope, and honesty about the numbers.** Reporting went out anonymously for every signed-in user: the `member_id` claim was read with `as_str()` while the token carries it as a JSON number, so it was always `None`. Beyond that fix, this narrows what reports at all and sharpens what the numbers mean — debug builds report nothing, `completion` reports nothing, the run event carries an outcome, the command name comes from clap's parse, crashes are per-surface and scrubbed, and `set_active` is wired to terminal focus. The README gained a *Usage Data* section stating what is collected.

**`ff4e3f1` — sessions, opt-out, and a warning for what is lost.** `ai`, `serve` and `acp` took the `Command` shape, so they armed no heartbeat and labelled themselves `cli` — the longest-lived things in the product reading as the shortest, with session duration not derivable at all. They get a `Session` shape. `DO_NOT_TRACK` / `LONGBRIDGE_NO_ANALYTICS` disable reporting for a user holding a release binary, which the build profile cannot reach. And the client now warns when it is dropped with events still queued.

**`9417a4f` — page views, and the platform named the group's way.** `platform_type` reported `cli-mac` / `cli-win` / `cli-linux`, folding client kind and OS into one field and matching no value in the group's spec — whose own values (`iOS`, `Desktop`, `Web`) never carry an OS. It now reports `Terminal`, with the OS moved to `$os`. Both TUIs report `$AppViewScreen` / `$AppPageLeave` under the group's `page_name` vocabulary. Three separate defects had to be fixed for any of it to arrive — see *Three silent failures* below.

## Events

| Event | When | Properties |
|---|---|---|
| `terminal_command_run` | Every invocation except `completion` and `tui` | `command` (subcommand path), `outcome`, `duration_ms` |
| `terminal_tui_launch` | `longbridge tui` | — |
| `terminal_heartbeat` | Every 60s while a TUI or session is open | `active`, `interval_ms`, `uptime_ms`, `active_ms` |
| `terminal_crash` | Next run of the same shape, after a panic | `recovered`, `crashed_at`, `crashed_after_ms`, `info` (scrubbed) |
| `$AppViewScreen` / `$AppPageLeave` | A page was opened / left | `page_name`, `$screen_name`, `$event_duration` |
| `terminal_ai_launch` | Chat opened | `agent`, `signed_in` |
| `terminal_ai_turn_start` | Question sent | `agent`, `is_first_turn`, `query_len` |
| `terminal_ai_turn_finish` | Turn ended, cancelled or abandoned included | `result`, `error_kind`, `duration_ms`, `tools[]`, `tool_calls`, `tools_failed[]`, `answer_len`, `has_references`, `has_further_questions` |
| `terminal_ai_session_new` / `_resume` | `/new` / reopened from history | — |
| `terminal_ai_agent_switch` | `/agent` | `from`, `to` |
| `terminal_ai_interrupt` / `_answered` | Agent asked something / how it ended | `question_count` / `answered`\|`abandoned` |

Every event also carries `platform_type`, `$os`, `terminal_type`, `surface`, `version`, `report_source`, `is_ci`, `is_tty`.

Three accounting decisions are deliberate. `turn_finish` is reported for cancelled and abandoned turns too, so `start` and `finish` stay comparable — a turn aborted by `/new` or Esc would otherwise hang in the warehouse as a start with no end. Tool use is aggregated into `turn_finish` rather than sent per call: one event per turn instead of one per tool, while still answering "which tools get used" and "which fail". And re-entering the page already open is ignored — without that a re-render emits a view per frame and resets the duration, so every page reads as heavily visited and instantly abandoned, a number that looks entirely plausible.

## page_name vocabulary

Built from the group's `page_name` document — `应用_业务关键字_页面功能_页面特征` — so a terminal page totals in the same report as the app's equivalent rather than in a breakdown of its own.

| Page | page_name | App's |
|---|---|---|
| Watchlist | `tlb_stock_select_home` | `lb_stock_select_home` |
| Portfolio | `tlb_account_asset_home` | `lb_account_asset_home` |
| Orders | `tlb_trade_order_home` | `lb_trade_order_home` |
| Stock detail | `tlb_stock_quote_detail` | spec's own example form |
| Watchlist detail | `tlb_stock_select_detail` | — |
| Trade token | `tlb_trade_token_entry` | — |
| AI chat | `tlb_ai_chat_home` | — |
| AI conversations | `tlb_ai_chat_list` | — |
| AI settings | `tlb_ai_setting_entry` | — |
| AI interrupt | `tlb_ai_interrupt_drawer` | drawer has precedent |

`Loading` and `Error` report nothing: they are states the reader passes through, and every session starts in `Loading`, so counting them would put a page view in front of every real one.

`tlb` extends the existing prefixes the way they were built — `dlb` is `d`(esktop)+`lb`, so this is `t`(erminal)+`lb`. `ai` is a new business keyword; the chat is its own product line rather than "content".

## Process shapes

`Shape` owns every consequence of the distinction — whether it beats, when the run event fires, which crash file it claims — so adding a shape does not mean hunting for the places that switch on it.

| Shape | `surface` | Beats | Run event |
|---|---|---|---|
| `Command` | `cli` | no | on the way **out**, carrying the outcome |
| `Tui` | `tui` | yes | none — it has `terminal_tui_launch` |
| `Session` (`ai`, `serve`, `acp`) | `session` | yes | on the way **in** |

Sessions report on entry because they are killed far more often than they exit. Commands report on exit because reporting on entry cannot say whether the user got an answer.

## Three silent failures

None of these fail visibly; each was found by running the thing and reading the log.

1. **Events reported from Bevy's executor threads were dropped.** `core` sends on a background task and finds the runtime through `Handle::try_current()`, which only works on a thread already inside one. The market TUI logged ten paired page events and sent none — caught only because `core` warns loudly rather than returning quietly, exactly as its own notes say it must. `track` now enters the runtime captured at `init`.
2. **The quit path never reached the flush.** `q` and Ctrl-C end in `process::exit`, so the page on screen had no leave and anything queued died with the process. The loss was biased, not random: it is always the page the reader was on when they quit, which is usually the one they spent longest on. `graceful_exit` now settles analytics first.
3. **That flush skipped the wait in the one case that needed it.** `q` is handled on the runtime's main thread, where `block_on` panics; guarding on `try_current()` avoided the panic and silently skipped the wait, still losing the last page of every session. It now waits on a thread of its own, which is never inside a runtime and therefore correct from either kind of caller.

## What is not collected

No command arguments, so no symbols, account numbers or order details. No question or answer text — a question to the agent names the positions the reader is asking about, so only lengths and counts go out. No market data, positions or orders. Panic messages have the home directory and account name removed before they are stored.

Three things keep it quiet entirely: a debug build reports nothing (this repository is public, and a contributor running `cargo run` would otherwise be indistinguishable from a user in production dashboards); `completion` reports nothing (the README has users source it from their shell profile, so it runs on every new shell); and `DO_NOT_TRACK` / `LONGBRIDGE_NO_ANALYTICS` turn it off.

## Known gaps

Documented in `analytics`, not discovered later:

- **The retry queue is in memory.** A report that fails while a one-shot command exits is gone. Offline runs report nothing, so the numbers read as "runs that reached the ingest", not "runs". The client warns on drop when something was still queued.
- **A failed device-id write is not fatal**: the run reports under an id that will not be reused. On a read-only directory every run counts as a new user, and the only trace is a `debug` line. Deliberate — silence was judged worse — but it is the one path that can inflate user counts.
- **`seed_script` has no consumer here.** It injects a cookie for a WebView; a terminal has no `document`. Kept for parity with the desktop copy.
- **Clap usage errors exit before analytics is armed.**

## Verification

✅ `cargo clippy --bins` clean · ✅ `cargo fmt --check` clean · ✅ `cargo test --all` — **753 passed, 0 failed**

**Verified on real runs**, both TUIs driven end to end against the live ingest:

- Signed-in reporting: 8 AI event types sent, every `reporting` paired with a delivery, `identity bound`, and the payloads confirmed present in the warehouse under the member id — `turn_finish` carrying real `duration_ms` (9907, 12327) and `answer_len` (142, 85). `is_first_turn` came back both `true` and `false`, which is what confirms it is read before the prompt is applied; read after, every turn would report `false`.
- Page views: 7 events reported, 7 delivered, `$AppViewScreen` and `$AppPageLeave` equal at 3 each, and the closing leave delivered 98ms after the quit keystroke. The previous build sent 7 and delivered 6 — the missing one was that closing leave.
- `Session` heartbeat: `serve` held open past the interval beat at 60.0005s and was accepted.

**Tests were checked against reverted source.** Restricting `beats()` to `Tui` fails `the_open_shapes_beat_and_a_command_does_not`; measuring tools over the whole conversation fails `a_turn_is_measured_without_its_predecessors` with the previous turn's tool leaking in; dropping the numeric branch of the id claim fails both `claim_id` tests with `left: None`; giving two states the same page_name fails both the uniqueness and the parity tests; removing the page-reentry guard fails `a_page_already_open_is_not_reentered`; removing the `block_on` guard panics with `Cannot start a runtime from within a runtime`. `Shape::ALL` and `AppState::iter()` drive the all-shapes and all-pages assertions, so a variant added without a name fails to compile or fails a test rather than silently escaping coverage.

**Not verified on a real run:** the tool aggregation (`tools` / `tools_failed`) — the turns exercised so far called no tools.

## Open for review

- **`tlb` and `ai` need a row in the group's `page_name` document.** That document is the only registry: the configuration backend for it was abandoned (SP-6553), so new names are added by editing the wiki.
- **`Terminal` needs adding to the `platform_type` enumeration**, which currently lists only `iOS / Android / Desktop / Web / H5 / Golang`.
- **`$event_duration` is reported in seconds**, per the vendor's definition. The group's spec names the property but not its unit, and the code carries a `TODO(data)` saying so. Worth confirming against one real page before a dashboard is built on it — milliseconds would overstate every page by a factor of a thousand and look plausible.
- **This binary reports to `event-tracking.lbctrl.com?project=production`**, not the `ai-event-forward…?project=production_ai` the LBAI spec names. That spec's scope covers iOS / Android / Desktop / Web / H5 / Golang and does not mention a CLI, so which project a terminal belongs in has never been decided.
- `core.rs` is shared with the desktop app but is not byte-identical: this project mandates `cargo fmt`, so syncing is "copy the file, run `cargo fmt`". The `impl Drop` warning added here is worth carrying back.
- `LONGBRIDGE_NO_ANALYTICS` is a new environment variable, which this project's conventions discourage. It is here because `DO_NOT_TRACK` is broad — a user may want telemetry from everything else but not this — and because a release build has no other way to be told.
