### PR TITLE
ai: Send prompts queued during a turn as one message

### DIFF
--- a/src/ai/state.rs
+++ b/src/ai/state.rs
@@ -148,11 +148,11 @@ pub struct ChatState {
     /// next — the very thing that bricks a conversation. Consumed by
     /// [`Self::finish_turn`].
     pub turn_error: Option<String>,
-    /// Prompts typed while a turn was running, sent one at a time as it frees up.
+    /// Prompts typed while a turn was running, sent together as it frees up.
     ///
     /// A reader who has thought of the next question should not have to hold it in
     /// their head until the answer lands — and typing it used to start a second,
-    /// concurrent turn on the same conversation.
+    /// concurrent turn on the same conversation. Drained by [`Self::take_queued`].
     pub queued: Vec<String>,
     /// Tools that failed during the active turn.
     pub tool_failures: Vec<String>,
@@ -344,6 +344,19 @@ impl ChatState {
         self.turn_started = None;
     }
 
+    /// Take everything queued as a single prompt, or `None` if nothing waits.
+    ///
+    /// Prompts typed while one answer was streaming are one follow-up thought, not
+    /// a backlog of separate turns: sending them together lets the agent plan once
+    /// with the whole picture, instead of answering the first and then discovering
+    /// the rest one turn at a time.
+    pub fn take_queued(&mut self) -> Option<String> {
+        if self.queued.is_empty() {
+            return None;
+        }
+        Some(self.queued.drain(..).collect::<Vec<_>>().join("\n\n"))
+    }
+
     /// Cancel the active turn, folding any partial answer into the transcript.
     pub fn cancel(&mut self, cancelled_label: &str) {
         if let Some(mut text) = self.streaming.take() {
@@ -376,6 +389,24 @@ mod tests {
 
     fn state() -> ChatState {
         ChatState::new("chatbot".into(), "welcome".into())
+    }
+
+    /// Prompts lined up during one answer go out as a single turn: the reader was
+    /// reading one reply when they typed them, so they belong together.
+    #[test]
+    fn everything_queued_goes_out_as_one_prompt() {
+        let mut s = state();
+        assert!(
+            s.take_queued().is_none(),
+            "nothing waiting, nothing to send"
+        );
+        s.queued.push("那 NVDA 呢？".into());
+        s.queued.push("顺便看看 AMD".into());
+        assert_eq!(
+            s.take_queued(),
+            Some("那 NVDA 呢？\n\n顺便看看 AMD".to_string())
+        );
+        assert!(s.queued.is_empty(), "and the queue is drained, not re-sent");
     }
 
     #[test]

--- a/src/ai/tui.rs
+++ b/src/ai/tui.rs
@@ -906,8 +906,12 @@ pub async fn run(agent_uid: String, quotes: Option<QuoteStream>) -> Result<Optio
                         .question
                         .as_ref()
                         .is_some_and(QuestionState::has_confirmation);
-                    if !state.queued.is_empty() && !waiting_for_confirmation {
-                        let next = state.queued.remove(0);
+                    let queued = if waiting_for_confirmation {
+                        None
+                    } else {
+                        state.take_queued()
+                    };
+                    if let Some(next) = queued {
                         // The drawer was asking what this message answers, so it
                         // goes; a reader who has wandered into Settings stays there.
                         if ui.view == View::Question {


### PR DESCRIPTION
## What changed

When you type more than one message while the assistant is still answering, they are now sent together as a single follow-up instead of being replayed one turn at a time.

Before: each queued prompt started its own turn, so the assistant answered the first question and only then discovered the rest.

After: everything queued during one answer goes out as a single prompt (joined by blank lines), so the assistant sees the whole picture at once and can plan a single reply.

Behavior when a confirmation prompt is pending is unchanged — the queue still waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)