### PR TITLE
chore: Update longbridge SDK to `32cb424b`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,7 +2705,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "dotenv",
  "eventsource-stream",
@@ -2801,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2818,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#266d9230c05208e2b9b6f0e1ebba7eb34fc7e8a2"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3757,7 +3757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",


### PR DESCRIPTION
Fixes `SPCX.US` returning an internal server error on every counter_id-based command:

```
$ longbridge financial-statement SPCX.US --kind IS --report qf
Error: openapi error: code=2601400: internal server error
```

SPCX used to be the AXS SPAC and New Issue ETF, which has since delisted; the ticker now belongs to SpaceX (a stock). The SDK's embedded counter_id directory still mapped it to `ETF/US/SPCX`, so requests asked the backend for the wrong instrument type. [longbridge/openapi#576](https://github.com/longbridge/openapi/pull/576) removes the stale entry and the symbol falls back to `ST/US/SPCX`.

Verified against the live API — `financial-statement SPCX.US` now returns SpaceX's quarterly income statement.

Lockfile-only change; `cargo clippy` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)