### PR TITLE
cli: Add `signals`, `signal` and `facts` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,7 +2705,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "dotenv",
  "eventsource-stream",
@@ -2801,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2818,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#32cb424b58745bdfd832d4196cbbe2842c9ea9c0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3757,7 +3757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,7 +2705,6 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2758,7 +2757,6 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2770,7 +2768,6 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2778,7 +2775,6 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "dotenv",
  "eventsource-stream",
@@ -2801,7 +2797,6 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2818,7 +2813,6 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2900,7 +2894,6 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.5.0"
-source = "git+https://github.com/longbridge/openapi.git?branch=main#7aa17e3127150f8fd96feb23bad27d6195357203"
 dependencies = [
  "byteorder",
  "flate2",
@@ -3757,7 +3750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,6 +2705,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "longbridge"
 version = "4.5.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#59294104c48a3812049158ee52124f32e5046008"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -2757,6 +2758,7 @@ dependencies = [
 [[package]]
 name = "longbridge-candlesticks"
 version = "4.5.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#59294104c48a3812049158ee52124f32e5046008"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
@@ -2768,6 +2770,7 @@ dependencies = [
 [[package]]
 name = "longbridge-geo"
 version = "4.5.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#59294104c48a3812049158ee52124f32e5046008"
 dependencies = [
  "reqwest 0.12.28",
 ]
@@ -2775,6 +2778,7 @@ dependencies = [
 [[package]]
 name = "longbridge-httpcli"
 version = "4.5.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#59294104c48a3812049158ee52124f32e5046008"
 dependencies = [
  "dotenv",
  "eventsource-stream",
@@ -2797,6 +2801,7 @@ dependencies = [
 [[package]]
 name = "longbridge-oauth"
 version = "4.5.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#59294104c48a3812049158ee52124f32e5046008"
 dependencies = [
  "dirs 6.0.0",
  "futures-util",
@@ -2813,6 +2818,7 @@ dependencies = [
 [[package]]
 name = "longbridge-proto"
 version = "4.5.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#59294104c48a3812049158ee52124f32e5046008"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2894,6 +2900,7 @@ dependencies = [
 [[package]]
 name = "longbridge-wscli"
 version = "4.5.0"
+source = "git+https://github.com/longbridge/openapi.git?branch=main#59294104c48a3812049158ee52124f32e5046008"
 dependencies = [
  "byteorder",
  "flate2",

--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ longbridge participants                             # Market maker (participant)
 longbridge subscriptions                            # Active real-time WebSocket subscriptions for this session
 ```
 
+### Signals & Catalysts
+
+```bash
+longbridge signals [--limit 20]                  # Strategy signals: headline, outlook, target prices, triggering catalyst
+longbridge signals --symbol 700.HK               # Filter by symbol, --strategy-id, --strategy, --catalyst, --catalyst-type, --start/--end, --offset
+longbridge signal <signal_id>                    # One signal; --format json adds the full strategy analysis
+longbridge facts AAPL.US [--limit 20]            # Fact (catalyst) events behind signals; --begin/--end for a time window
+```
+
 ### News
 
 ```bash

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -735,10 +735,11 @@ pub enum Commands {
         /// Filter by strategy name
         #[arg(long, value_name = "NAME")]
         strategy: Option<String>,
-        /// Filter by the catalyst name that triggered the signal
+        /// Filter by the name of the factor that triggered the signal
         ///
-        /// Matched against the triggering fact's catalyst name, falling back to
-        /// the factor name.
+        /// Takes a factor name such as `EARNINGS_RELEASED` or `macd_12_26_9` —
+        /// not the prose shown in the catalyst column, which will match
+        /// nothing.
         #[arg(long, value_name = "NAME")]
         catalyst: Option<String>,
         /// Filter by the triggering fact's type: News, Fundamental or Technical

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,6 +27,7 @@ pub mod search;
 pub mod sec_edgar;
 pub mod serve;
 pub mod sharelist;
+pub mod signal;
 pub mod statement;
 pub mod topic;
 pub mod trade;
@@ -713,6 +714,79 @@ pub enum Commands {
         /// Historical range in years (history mode, default: 1): 1 | 3 | 5 | 10
         #[arg(long)]
         range: Option<String>,
+    },
+
+    // ── Signals & Catalysts ─────────────────────────────────────────────────────
+    /// List strategy signals
+    ///
+    /// A signal is a strategy's take on a security, triggered by a catalyst: it
+    /// carries a headline, a summary, an outlook and conservative / benchmark /
+    /// optimistic target prices.
+    /// Example: longbridge signals --limit 10
+    /// Example: longbridge signals --symbol 700.HK
+    /// Example: longbridge signals --catalyst-type News --start 2026-08-01
+    Signals {
+        /// Filter by symbol in <CODE>.<MARKET> format
+        #[arg(long, value_name = "SYMBOL")]
+        symbol: Option<String>,
+        /// Filter by strategy id, e.g. buffett-value
+        #[arg(long, value_name = "ID")]
+        strategy_id: Option<String>,
+        /// Filter by strategy name
+        #[arg(long, value_name = "NAME")]
+        strategy: Option<String>,
+        /// Filter by the catalyst name that triggered the signal
+        ///
+        /// Matched against the triggering fact's catalyst name, falling back to
+        /// the factor name.
+        #[arg(long, value_name = "NAME")]
+        catalyst: Option<String>,
+        /// Filter by the triggering fact's type: News, Fundamental or Technical
+        #[arg(long, value_name = "TYPE")]
+        catalyst_type: Option<String>,
+        /// Only signals created at or after this date/time
+        #[arg(long, value_name = "DATE")]
+        start: Option<String>,
+        /// Only signals created at or before this date/time
+        #[arg(long, value_name = "DATE")]
+        end: Option<String>,
+        /// Maximum number of signals to return (default 20)
+        #[arg(long)]
+        limit: Option<i32>,
+        /// Number of signals to skip, for paging
+        #[arg(long)]
+        offset: Option<i32>,
+    },
+
+    /// Show one signal, including the strategy analysis behind it
+    ///
+    /// Get the id from `longbridge signals`. Use `--format json` for the full
+    /// analysis: fit scores, valuation scenarios and evidence sources.
+    /// Example: longbridge signal `sign_992_1a00c9425c3_48ab`
+    Signal {
+        /// Signal id, e.g. `sign_992_1a00c9425c3_48ab`
+        signal_id: String,
+    },
+
+    /// List the fact (catalyst) events for a security
+    ///
+    /// Facts are what strategies react to — anomaly detections, factor readings,
+    /// data sources and a plain-language summary. A signal names the fact that
+    /// triggered it in `key_fact_id`.
+    /// Example: longbridge facts AAPL.US
+    /// Example: longbridge facts 700.HK --begin 2026-07-01 --limit 20
+    Facts {
+        /// Symbol in <CODE>.<MARKET> format
+        symbol: String,
+        /// Only facts occurring at or after this date/time
+        #[arg(long, value_name = "DATE")]
+        begin: Option<String>,
+        /// Only facts occurring at or before this date/time
+        #[arg(long, value_name = "DATE")]
+        end: Option<String>,
+        /// Maximum number of facts to return (default 100)
+        #[arg(long)]
+        limit: Option<i32>,
     },
 
     // ── News ────────────────────────────────────────────────────────────────────
@@ -4485,6 +4559,39 @@ IpoCmd::ProfitLoss { period, page, count } => {
                 ipo::cmd_ipo_us_listed(page, count, format, verbose).await
             }
         },
+
+        Commands::Signals {
+            symbol,
+            strategy_id,
+            strategy,
+            catalyst,
+            catalyst_type,
+            start,
+            end,
+            limit,
+            offset,
+        } => {
+            signal::cmd_signals(
+                symbol,
+                strategy_id,
+                strategy,
+                catalyst,
+                catalyst_type,
+                start,
+                end,
+                limit,
+                offset,
+                format,
+            )
+            .await
+        }
+        Commands::Signal { signal_id } => signal::cmd_signal_detail(signal_id, format).await,
+        Commands::Facts {
+            symbol,
+            begin,
+            end,
+            limit,
+        } => signal::cmd_security_facts(symbol, begin, end, limit, format).await,
 
         Commands::Agent { cmd, skill } => agent::cmd_agent(cmd, skill, format, verbose).await,
 

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -5,7 +5,7 @@ use std::ffi::OsString;
 
 use super::{
     agent, asset, atm, auth, check, completion, dca, fundamental, grid, init, insider_trades,
-    investors, ipo, news, quote, run_script, screener, sharelist, statement, topic, trade,
+    investors, ipo, news, quote, run_script, screener, sharelist, signal, statement, topic, trade,
     watchlist, Cli,
 };
 
@@ -394,6 +394,7 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<ResponseSchema> {
         | "macrodata"
         | "etf-docs" => fundamental::schema_for_path(path),
         "news" | "filing" => news::schema_for_path(path),
+        "signals" | "signal" | "facts" => signal::schema_for_path(path),
         "topic" => topic::schema_for_path(path),
         "watchlist" => watchlist::schema_for_path(path),
         "statement" => statement::schema_for_path(path),
@@ -622,7 +623,7 @@ mod tests {
             let paths = real_leaf_paths(&root);
             assert_eq!(
                 paths.len(),
-                160,
+                163,
                 "real command count changed; review schema coverage"
             );
 
@@ -634,5 +635,16 @@ mod tests {
 
             assert!(missing.is_empty(), "missing schema coverage: {missing:#?}");
         });
+    }
+
+    #[test]
+    fn signal_commands_describe_their_json_roots() {
+        let signals = schema_for_path(&["signals".to_string()]).expect("signals schema");
+        let signal = schema_for_path(&["signal".to_string()]).expect("signal schema");
+        let facts = schema_for_path(&["facts".to_string()]).expect("facts schema");
+
+        assert_eq!(signals.root, RootKind::Object);
+        assert_eq!(signal.root, RootKind::Object);
+        assert_eq!(facts.root, RootKind::Array);
     }
 }

--- a/src/cli/signal.rs
+++ b/src/cli/signal.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use longbridge::signal::{SecurityFact, SecurityFactsOptions, Signal, SignalsOptions};
+use longbridge::signal::{
+    SecurityFact, SecurityFactsOptions, Signal, SignalsOptions, SignalsResponse,
+};
 
 use super::{
     output::{parse_datetime_end, parse_datetime_start, print_table},
@@ -37,6 +39,13 @@ fn signal_to_json(s: &Signal) -> serde_json::Value {
     })
 }
 
+fn signals_to_json(resp: &SignalsResponse) -> serde_json::Value {
+    serde_json::json!({
+        "signals": resp.signals.iter().map(signal_to_json).collect::<Vec<_>>(),
+        "total": resp.total,
+    })
+}
+
 /// List strategy signals.
 pub async fn cmd_signals(
     symbol: Option<String>,
@@ -63,21 +72,16 @@ pub async fn cmd_signals(
     };
     let resp = crate::openapi::signal().signals(opts).await?;
 
-    if resp.signals.is_empty() {
-        println!("No signals found.");
+    if matches!(format, OutputFormat::Json) {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&signals_to_json(&resp)).unwrap_or_default()
+        );
         return Ok(());
     }
 
-    if matches!(format, OutputFormat::Json) {
-        let records: Vec<_> = resp.signals.iter().map(signal_to_json).collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
-                "signals": records,
-                "total": resp.total,
-            }))
-            .unwrap_or_default()
-        );
+    if resp.signals.is_empty() {
+        println!("No signals found.");
         return Ok(());
     }
 
@@ -201,6 +205,10 @@ fn fact_to_json(f: &SecurityFact) -> serde_json::Value {
     })
 }
 
+fn facts_to_json(facts: &[SecurityFact]) -> serde_json::Value {
+    serde_json::Value::Array(facts.iter().map(fact_to_json).collect())
+}
+
 /// List the fact (catalyst) events for one security.
 pub async fn cmd_security_facts(
     symbol: String,
@@ -217,17 +225,16 @@ pub async fn cmd_security_facts(
     };
     let facts = crate::openapi::signal().security_facts(opts).await?;
 
-    if facts.is_empty() {
-        println!("No facts found.");
+    if matches!(format, OutputFormat::Json) {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&facts_to_json(&facts)).unwrap_or_default()
+        );
         return Ok(());
     }
 
-    if matches!(format, OutputFormat::Json) {
-        let records: Vec<_> = facts.iter().map(fact_to_json).collect();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&records).unwrap_or_default()
-        );
+    if facts.is_empty() {
+        println!("No facts found.");
         return Ok(());
     }
 
@@ -253,4 +260,90 @@ pub async fn cmd_security_facts(
 
     print_table(headers, rows, format);
     Ok(())
+}
+
+pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {
+    use super::schema::{field, schema, RootKind};
+
+    match path.join(" ").as_str() {
+        "signals" => Some(schema(
+            "Strategy signal list",
+            RootKind::Object,
+            vec![
+                field("signals", "object[]", "Signals on this page"),
+                field("total", "number", "Total signals matching the filters"),
+            ],
+        )),
+        "signal" => Some(schema(
+            "Strategy signal detail",
+            RootKind::Object,
+            vec![
+                field("id", "string", "Signal ID"),
+                field("symbol", "string", "Security symbol"),
+                field("company_name", "string", "Company name"),
+                field("market", "string", "Trading market"),
+                field("title", "string", "Signal headline"),
+                field("summary", "string", "Signal summary in Markdown"),
+                field("strategy_id", "string", "Strategy ID"),
+                field("strategy_name", "string", "Strategy name"),
+                field("recommend_by", "string", "Signal recommender"),
+                field("expression", "string", "Strategy expression"),
+                field("key_fact_id", "string", "Triggering fact ID"),
+                field("key_catalyst", "string", "Triggering catalyst label"),
+                field("analysis_price", "number", "Analysis price"),
+                field("conservative_price", "number", "Conservative target price"),
+                field("benchmark_price", "number", "Benchmark target price"),
+                field("optimistic_price", "number", "Optimistic target price"),
+                field("outlook", "string", "Strategy outlook"),
+                field("outlook_desc", "string", "Localized outlook description"),
+                field("status", "string", "Signal lifecycle status"),
+                field("created_at", "string", "Creation time (RFC3339)"),
+                field("updated_at", "string", "Last update time (RFC3339)"),
+                field(
+                    "analysis",
+                    "object | string",
+                    "Full strategy-specific analysis",
+                ),
+            ],
+        )),
+        "facts" => Some(schema(
+            "Security catalyst facts",
+            RootKind::Array,
+            vec![
+                field("fact_id", "string", "Fact ID"),
+                field("fact_type", "string", "Fact type"),
+                field("direction", "string", "Fact direction"),
+                field("occur_time", "string", "Occurrence time (RFC3339)"),
+                field("symbols", "object[]", "Related securities"),
+                field("factors", "object[]", "Contributing factors"),
+                field("data_source", "object[]", "Fact data sources"),
+                field("nl_info", "object", "Natural-language fact details"),
+            ],
+        )),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn empty_signals_remain_valid_json_with_total() {
+        let response = SignalsResponse {
+            signals: Vec::new(),
+            total: 0,
+        };
+
+        assert_eq!(
+            signals_to_json(&response),
+            json!({ "signals": [], "total": 0 })
+        );
+    }
+
+    #[test]
+    fn empty_facts_remain_a_valid_json_array() {
+        assert_eq!(facts_to_json(&[]), json!([]));
+    }
 }

--- a/src/cli/signal.rs
+++ b/src/cli/signal.rs
@@ -1,0 +1,256 @@
+use anyhow::Result;
+use longbridge::signal::{SecurityFact, SecurityFactsOptions, Signal, SignalsOptions};
+
+use super::{
+    output::{parse_datetime_end, parse_datetime_start, print_table},
+    OutputFormat,
+};
+use crate::utils::{datetime::fmt_rfc3339, text::truncate_width};
+
+/// Width the signal title is trimmed to in the table view, so a row stays on
+/// one terminal line next to the other columns.
+const TITLE_WIDTH: usize = 60;
+
+fn signal_to_json(s: &Signal) -> serde_json::Value {
+    serde_json::json!({
+        "id": s.id,
+        "symbol": s.symbol,
+        "company_name": s.company_name,
+        "market": s.market,
+        "title": s.title,
+        "summary": s.summary,
+        "strategy_id": s.strategy_id,
+        "strategy_name": s.strategy_name,
+        "recommend_by": s.recommend_by,
+        "expression": s.expression,
+        "key_fact_id": s.key_fact_id,
+        "key_catalyst": s.key_catalyst,
+        "analysis_price": s.analysis_price,
+        "conservative_price": s.conservative_price,
+        "benchmark_price": s.benchmark_price,
+        "optimistic_price": s.optimistic_price,
+        "outlook": s.outlook.to_string(),
+        "outlook_desc": s.outlook_desc,
+        "risk_level": s.risk_level,
+        "status": s.status,
+        "created_at": fmt_rfc3339(s.created_at),
+        "updated_at": fmt_rfc3339(s.updated_at),
+    })
+}
+
+/// List strategy signals.
+pub async fn cmd_signals(
+    symbol: Option<String>,
+    strategy_id: Option<String>,
+    strategy_name: Option<String>,
+    catalyst: Option<String>,
+    catalyst_type: Option<String>,
+    start: Option<String>,
+    end: Option<String>,
+    limit: Option<i32>,
+    offset: Option<i32>,
+    format: &OutputFormat,
+) -> Result<()> {
+    let opts = SignalsOptions {
+        symbol_name: symbol,
+        strategy_id,
+        strategy_name,
+        catalyst_name: catalyst,
+        catalyst_type,
+        start_time: start.map(|s| parse_datetime_start(&s)).transpose()?,
+        end_time: end.map(|s| parse_datetime_end(&s)).transpose()?,
+        limit,
+        offset,
+    };
+    let resp = crate::openapi::signal().signals(opts).await?;
+
+    if resp.signals.is_empty() {
+        println!("No signals found.");
+        return Ok(());
+    }
+
+    if matches!(format, OutputFormat::Json) {
+        let records: Vec<_> = resp.signals.iter().map(signal_to_json).collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "signals": records,
+                "total": resp.total,
+            }))
+            .unwrap_or_default()
+        );
+        return Ok(());
+    }
+
+    let headers = &[
+        "id",
+        "symbol",
+        "title",
+        "strategy",
+        "outlook",
+        "catalyst",
+        "created_at",
+    ];
+    let rows = resp
+        .signals
+        .iter()
+        .map(|s| {
+            vec![
+                s.id.clone(),
+                s.symbol.clone(),
+                truncate_width(&s.title, TITLE_WIDTH),
+                s.strategy_name.clone(),
+                s.outlook_desc.clone(),
+                s.key_catalyst.clone(),
+                fmt_rfc3339(s.created_at),
+            ]
+        })
+        .collect();
+
+    print_table(headers, rows, format);
+    println!(
+        "\nShowing {} of {} signals.",
+        resp.signals.len(),
+        resp.total
+    );
+    Ok(())
+}
+
+/// Show one signal, including the strategy analysis behind it.
+pub async fn cmd_signal_detail(signal_id: String, format: &OutputFormat) -> Result<()> {
+    let s = crate::openapi::signal().signal(signal_id).await?;
+
+    if matches!(format, OutputFormat::Json) {
+        let mut json = signal_to_json(&s);
+        // The analysis travels as a JSON document inside a string; hand it over
+        // as real JSON so `jq` can reach into it. Anything that does not parse
+        // is passed through as the original string rather than dropped.
+        json["analysis"] = serde_json::from_str(&s.json_data)
+            .unwrap_or_else(|_| serde_json::Value::String(s.json_data.clone()));
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json).unwrap_or_default()
+        );
+        return Ok(());
+    }
+
+    println!("{}", s.title);
+    println!();
+    println!("{:<14}{} {}", "Symbol", s.symbol, s.company_name);
+    println!("{:<14}{} ({})", "Strategy", s.strategy_name, s.strategy_id);
+    println!("{:<14}{}", "Catalyst", s.key_catalyst);
+    println!("{:<14}{}", "Outlook", s.outlook_desc);
+    if !s.risk_level.is_empty() {
+        println!("{:<14}{}", "Risk", s.risk_level);
+    }
+    println!(
+        "{:<14}{} (conservative {} / benchmark {} / optimistic {})",
+        "Price", s.analysis_price, s.conservative_price, s.benchmark_price, s.optimistic_price
+    );
+    println!("{:<14}{}", "Created", fmt_rfc3339(s.created_at));
+    if !s.summary.is_empty() {
+        println!();
+        println!("{}", s.summary);
+    }
+    Ok(())
+}
+
+fn fact_to_json(f: &SecurityFact) -> serde_json::Value {
+    serde_json::json!({
+        "fact_id": f.fact_id,
+        "fact_type": f.fact_type.to_string(),
+        "direction": f.direction.to_string(),
+        "occur_time": fmt_rfc3339(f.occur_time),
+        "symbols": f.symbols_info.iter().map(|s| serde_json::json!({
+            "symbol": s.symbol,
+            "security_name": s.security_name,
+        })).collect::<Vec<_>>(),
+        "factors": f.factors.iter().map(|factor| serde_json::json!({
+            "name": factor.name,
+            "factor_groups": factor.factor_groups,
+            "long_short_direction": factor.long_short_direction.to_string(),
+            "trigger_condition": factor.trigger_condition,
+            "anomaly_detection": {
+                "anomaly_result": factor.anomaly_detection.anomaly_result,
+                "significance_level": factor.anomaly_detection.significance_level,
+                "test_method": factor.anomaly_detection.test_method,
+                "thresholds": {
+                    "low": factor.anomaly_detection.thresholds.low,
+                    "medium": factor.anomaly_detection.thresholds.medium,
+                    "high": factor.anomaly_detection.thresholds.high,
+                },
+            },
+        })).collect::<Vec<_>>(),
+        "data_source": f.data_source.iter().map(|d| serde_json::json!({
+            "source_name": d.source_name,
+            "type": d.source_type.to_string(),
+            "url": d.url,
+        })).collect::<Vec<_>>(),
+        "nl_info": {
+            "title": f.nl_info.title,
+            "sub_title": f.nl_info.sub_title,
+            "summary": f.nl_info.summary_tags().iter().map(|t| serde_json::json!({
+                "tag": t.tag,
+                "value": t.value,
+            })).collect::<Vec<_>>(),
+            "invest_anal": f.nl_info.invest_anal_tags().iter().map(|t| serde_json::json!({
+                "tag": t.tag,
+                "value": t.value,
+            })).collect::<Vec<_>>(),
+        },
+    })
+}
+
+/// List the fact (catalyst) events for one security.
+pub async fn cmd_security_facts(
+    symbol: String,
+    begin: Option<String>,
+    end: Option<String>,
+    limit: Option<i32>,
+    format: &OutputFormat,
+) -> Result<()> {
+    let opts = SecurityFactsOptions {
+        symbol,
+        begin_time: begin.map(|s| parse_datetime_start(&s)).transpose()?,
+        end_time: end.map(|s| parse_datetime_end(&s)).transpose()?,
+        limit,
+    };
+    let facts = crate::openapi::signal().security_facts(opts).await?;
+
+    if facts.is_empty() {
+        println!("No facts found.");
+        return Ok(());
+    }
+
+    if matches!(format, OutputFormat::Json) {
+        let records: Vec<_> = facts.iter().map(fact_to_json).collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&records).unwrap_or_default()
+        );
+        return Ok(());
+    }
+
+    let headers = &["occur_time", "type", "dir", "factors", "title"];
+    let rows = facts
+        .iter()
+        .map(|f| {
+            let factors = f
+                .factors
+                .iter()
+                .map(|factor| factor.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            vec![
+                fmt_rfc3339(f.occur_time),
+                f.fact_type.to_string(),
+                f.direction.to_string(),
+                factors,
+                truncate_width(&f.nl_info.title, TITLE_WIDTH),
+            ]
+        })
+        .collect();
+
+    print_table(headers, rows, format);
+    Ok(())
+}

--- a/src/cli/signal.rs
+++ b/src/cli/signal.rs
@@ -31,8 +31,7 @@ fn signal_to_json(s: &Signal) -> serde_json::Value {
         "optimistic_price": s.optimistic_price,
         "outlook": s.outlook.to_string(),
         "outlook_desc": s.outlook_desc,
-        "risk_level": s.risk_level,
-        "status": s.status,
+        "status": format!("{:?}", s.status),
         "created_at": fmt_rfc3339(s.created_at),
         "updated_at": fmt_rfc3339(s.updated_at),
     })
@@ -140,9 +139,6 @@ pub async fn cmd_signal_detail(signal_id: String, format: &OutputFormat) -> Resu
     println!("{:<14}{} ({})", "Strategy", s.strategy_name, s.strategy_id);
     println!("{:<14}{}", "Catalyst", s.key_catalyst);
     println!("{:<14}{}", "Outlook", s.outlook_desc);
-    if !s.risk_level.is_empty() {
-        println!("{:<14}{}", "Risk", s.risk_level);
-    }
     println!(
         "{:<14}{} (conservative {} / benchmark {} / optimistic {})",
         "Price", s.analysis_price, s.conservative_price, s.benchmark_price, s.optimistic_price
@@ -194,6 +190,10 @@ fn fact_to_json(f: &SecurityFact) -> serde_json::Value {
                 "value": t.value,
             })).collect::<Vec<_>>(),
             "invest_anal": f.nl_info.invest_anal_tags().iter().map(|t| serde_json::json!({
+                "tag": t.tag,
+                "value": t.value,
+            })).collect::<Vec<_>>(),
+            "eli_explain": f.nl_info.eli_explain_tags().iter().map(|t| serde_json::json!({
                 "tag": t.tag,
                 "value": t.value,
             })).collect::<Vec<_>>(),

--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -49,6 +49,8 @@ pub(crate) static CONTENT_CTX: Slot<longbridge::ContentContext> = Slot::new();
 
 /// Global `FundamentalContext` for fundamental data (ratings, dividends, ETF allocation, etc.)
 pub(crate) static FUNDAMENTAL_CTX: Slot<longbridge::FundamentalContext> = Slot::new();
+/// Global `SignalContext` for strategy signals and catalyst facts
+pub(crate) static SIGNAL_CTX: Slot<longbridge::signal::SignalContext> = Slot::new();
 
 /// Global `AgentContext` for AI agent discovery and conversations
 pub(crate) static AGENT_CTX: Slot<longbridge::agent::AgentContext> = Slot::new();
@@ -334,6 +336,9 @@ async fn init_contexts_with_auth(
     let fundamental_ctx = longbridge::FundamentalContext::new(Arc::clone(&config));
     FUNDAMENTAL_CTX.set(fundamental_ctx);
 
+    let signal_ctx = longbridge::signal::SignalContext::new(Arc::clone(&config));
+    SIGNAL_CTX.set(signal_ctx);
+
     let agent_ctx = longbridge::agent::AgentContext::new(Arc::clone(&config));
     AGENT_CTX.set(agent_ctx);
 
@@ -488,6 +493,13 @@ pub fn fundamental() -> &'static longbridge::FundamentalContext {
     FUNDAMENTAL_CTX
         .get()
         .expect("FundamentalContext not initialized, please call init_contexts() first")
+}
+
+/// Get global `SignalContext` for strategy signals and catalyst facts
+pub fn signal() -> &'static longbridge::signal::SignalContext {
+    SIGNAL_CTX
+        .get()
+        .expect("SignalContext not initialized, please call init_contexts() first")
 }
 
 /// Whether the session authenticated with API-key env vars rather than

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -14,6 +14,6 @@ pub use agent::{AuthenticationRequiredAgent, OpenApiAgent};
 pub use context::{
     agent, content, fundamental, grid, http_client, init_contexts, init_oauth_contexts, is_ready,
     is_us_account, mark_signed_out, oauth_credentials_available, quote, quote_cmd, quote_limited,
-    statement, track_quote_cmd, trade, trade_limited, using_api_key,
+    signal, statement, track_quote_cmd, trade, trade_limited, using_api_key,
 };
 pub use rate_limiter::global_rate_limiter;


### PR DESCRIPTION
Three commands over the SDK's `SignalContext`.

```bash
longbridge signals --symbol 700.HK        # strategy signals for a security
longbridge signal sign_700_1a014ee18ae_4bfe --format json
longbridge facts AAPL.US                  # the catalyst events signals react to
```

A **signal** is a strategy's take on a security triggered by a **catalyst**; a **fact** is the catalyst event itself, named in the signal's `key_fact_id`.

- `signals` filters on `--symbol` / `--strategy-id` / `--strategy` / `--catalyst` / `--catalyst-type` / `--start` / `--end` and pages with `--limit` / `--offset`. The table shows headline, strategy, outlook and catalyst, and closes with `Showing N of M signals.`
- `signal <id>` prints a readable card. `--format json` adds `analysis` — the strategy analysis unwrapped from the JSON-in-a-string the API carries it in, so `jq` can reach into it; anything that fails to parse is passed through as the original string rather than dropped.
- `facts <symbol>` lists the catalyst events with their factors, sources and plain-language title; `--format json` includes all three `nl_info` documents (`summary`, `invest_anal`, `eli_explain`) already parsed.
- Date flags take the same formats as the rest of the CLI (RFC 3339, `YYYY-MM-DD`, `YYYY-MM-DD HH:MM`).

`--catalyst` matches the **triggering factor's name** (`EARNINGS_RELEASED`, `macd_12_26_9`), not the prose shown in the catalyst column — the help text says so, because filtering by the displayed value returns nothing.

## Verification

Run against production:

```
| id                        | symbol | title                                | strategy       | outlook        | catalyst                    |
| sign_700_1a014ee18ae_4bfe | 700.HK | Tencent WorkBuddy enters Guangdong…  | HK Tech Giants | Strong bullish | WorkBuddy Government Launch |
```

- `signals` (3467), `--symbol 700.HK` (102), `--strategy-id 26` (171), `--strategy "HK Tech Giants"` (171 — same set, cross-checked), `--catalyst-type News/Technical/Fundamental` (2516/325/626, summing to 3467), `--catalyst EARNINGS_RELEASED` (892), `--start` / `--end` — all work.
- `signal <id> --format json` returns the full analysis; `facts 700.HK` returns 100 facts, and the signal's `key_fact_id` resolves to a fact in that list, so the signal → catalyst link works end to end.

**One upstream failure, not caused by this change:** `?limit=` / `?offset=` return `500 code 13` on both access points, so `--limit` / `--offset` currently fail while the default page of 20 works. Reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)