### PR TITLE
tui: Sort watchlist by market trading session

### DIFF
--- a/src/data/watchlist.rs
+++ b/src/data/watchlist.rs
@@ -1,6 +1,7 @@
-use super::{Counter, TradeSessionExt};
+use super::{Counter, TradeSession};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Watchlist group
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -78,6 +79,13 @@ impl Watchlist {
 
     /// Refresh (re-apply sorting, etc.)
     pub fn refresh(&mut self) {
+        fn market_key(market: &str) -> &str {
+            match market {
+                "SH" | "SZ" => "CN",
+                market => market,
+            }
+        }
+
         fn market_priority(market: &str) -> u8 {
             match market {
                 "US" => 0,
@@ -88,17 +96,62 @@ impl Watchlist {
             }
         }
 
+        fn session_priority(session: TradeSession) -> u8 {
+            match session {
+                TradeSession::Intraday => 0,
+                TradeSession::Pre => 1,
+                TradeSession::Post | TradeSession::Overnight => 2,
+            }
+        }
+
+        // Session is a market-level property for sorting. A few indices or
+        // synthetic counters can report Intraday while most securities in the
+        // same market are Pre, so use the market's most common session class.
+        let mut session_counts: HashMap<&str, [usize; 3]> = HashMap::new();
+        for counter in &self.counters {
+            let Some(stock) = super::STOCKS.get(counter) else {
+                continue;
+            };
+            if stock
+                .quote
+                .last_done
+                .is_none_or(|price| price <= Decimal::ZERO)
+            {
+                continue;
+            }
+            session_counts
+                .entry(market_key(counter.market()))
+                .or_default()[usize::from(session_priority(stock.trade_session))] += 1;
+        }
+        let market_sessions: HashMap<&str, u8> = session_counts
+            .into_iter()
+            .map(|(market, counts)| {
+                let mut best_rank = 0;
+                let mut best_count = counts[0];
+                for (rank, count) in counts.into_iter().enumerate().skip(1) {
+                    if count > best_count {
+                        best_rank = rank as u8;
+                        best_count = count;
+                    }
+                }
+                (market, best_rank)
+            })
+            .collect();
+
         // Snapshot sort keys before sorting. STOCKS is updated concurrently,
         // so reading it inside sort_by can yield different results for the same
         // pair on successive calls, violating total order and causing a panic.
-        let keys: Vec<(bool, u8)> = self
+        let keys: Vec<(u8, u8)> = self
             .counters
             .iter()
-            .map(|c| {
-                let not_trading = !super::STOCKS
-                    .get(c)
-                    .is_some_and(|s| s.trade_session.is_normal_trading());
-                (not_trading, market_priority(c.market()))
+            .map(|counter| {
+                (
+                    market_sessions
+                        .get(market_key(counter.market()))
+                        .copied()
+                        .unwrap_or(2),
+                    market_priority(counter.market()),
+                )
             })
             .collect();
 
@@ -127,5 +180,60 @@ impl Watchlist {
     pub fn group(&self) -> Option<&WatchlistGroup> {
         let group_id = self.group_id?;
         self.groups.iter().find(|g| g.id == group_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::{Stock, TradeSession, STOCKS};
+    use rust_decimal::Decimal;
+
+    fn counter_with_session(symbol: &str, session: TradeSession, has_quote: bool) -> Counter {
+        let counter = Counter::new(symbol);
+        let mut stock = Stock::new(counter.clone());
+        stock.trade_session = session;
+        stock.quote.last_done = has_quote.then_some(Decimal::ONE);
+        STOCKS.insert(stock);
+        counter
+    }
+
+    #[test]
+    fn refresh_sorts_by_market_session_before_market_priority() {
+        let counters = vec![
+            counter_with_session(".SPX_SORT_TEST.US", TradeSession::Intraday, true),
+            counter_with_session("AAPL_SORT_TEST.US", TradeSession::Pre, true),
+            counter_with_session("MSFT_SORT_TEST.US", TradeSession::Pre, true),
+            counter_with_session("AMD_SORT_TEST.US", TradeSession::Pre, true),
+            counter_with_session("700_SORT_TEST.HK", TradeSession::Intraday, true),
+            counter_with_session("300001_SORT_TEST.SZ", TradeSession::Intraday, true),
+            counter_with_session("600000_SORT_TEST.SH", TradeSession::Intraday, true),
+            counter_with_session("300002_SORT_TEST.SZ", TradeSession::Intraday, true),
+            counter_with_session("D05_SORT_TEST.SG", TradeSession::Intraday, false),
+        ];
+        let mut watchlist = Watchlist::new();
+        watchlist.set_counters(counters.clone());
+
+        watchlist.refresh();
+
+        let symbols: Vec<_> = watchlist.counters().iter().map(Counter::as_str).collect();
+        assert_eq!(
+            symbols,
+            [
+                "700_SORT_TEST.HK",
+                "300001_SORT_TEST.SZ",
+                "600000_SORT_TEST.SH",
+                "300002_SORT_TEST.SZ",
+                ".SPX_SORT_TEST.US",
+                "AAPL_SORT_TEST.US",
+                "MSFT_SORT_TEST.US",
+                "AMD_SORT_TEST.US",
+                "D05_SORT_TEST.SG",
+            ]
+        );
+
+        for counter in counters {
+            STOCKS.remove(&counter);
+        }
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -247,6 +247,7 @@ pub async fn run(
                         crate::data::STOCKS.modify(counter.clone(), |stock| {
                             stock.update_from_push_quote(&quote);
                         });
+                        systems::refresh_watchlist_order();
                         render_state.mark_dirty(DirtyFlags::NONE.mark_quote_update());
                     }
                     PushEventDetail::Depth(depth) => {

--- a/src/tui/systems/watchlist.rs
+++ b/src/tui/systems/watchlist.rs
@@ -26,6 +26,30 @@ use crate::{
 
 use super::{Command, Key, NavFooter, PopUp, StockDetail, LAST_DONE, WATCHLIST_TABLE};
 
+pub(crate) fn refresh_watchlist_order() {
+    let selected_ix = WATCHLIST_TABLE.lock().expect("poison").selected();
+    let selected = selected_ix.and_then(|ix| {
+        WATCHLIST
+            .read()
+            .expect("poison")
+            .counters()
+            .get(ix)
+            .cloned()
+    });
+
+    let next_ix = {
+        let mut watchlist = WATCHLIST.write().expect("poison");
+        watchlist.refresh();
+        selected.and_then(|counter| {
+            watchlist
+                .counters()
+                .iter()
+                .position(|candidate| candidate == &counter)
+        })
+    };
+    WATCHLIST_TABLE.lock().expect("poison").select(next_ix);
+}
+
 pub fn render_watchlist(
     mut terminal: ResMut<crate::tui::widgets::Terminal>,
     mut events: EventReader<Key>,


### PR DESCRIPTION
## Summary

The watchlist sorted each counter by its own `trade_session`, so a market's securities could split apart in the list: an index reporting `Intraday` while the rest of its market is still in `Pre` would jump to the top on its own, and rows shuffled around as quote pushes arrived.

Session is really a market-level property for sorting purposes, so this derives it per market:

- Group SH/SZ into a single `CN` key.
- For each market, take the most common session class (Intraday / Pre / Post+Overnight) among counters that have a real quote (`last_done > 0`), ignoring counters with no price so stale or unsubscribed entries don't skew the group.
- Sort every counter in a market by that shared class, then by the existing market priority. A market with no priced counters falls back to the lowest priority.

Also re-sorts on quote pushes (`refresh_watchlist_order`) so the order follows session changes as they happen, restoring the current table selection to the same counter after the re-sort.

## Test plan

- New unit test `refresh_sorts_by_market_session_before_market_priority` covers the majority-vote grouping: a `.SPX`-style index reporting `Intraday` stays with its `Pre` US market instead of jumping ahead of HK/CN, and an unpriced SG counter sinks to the bottom.
- `cargo fmt && cargo clippy` clean for the changed code.
- `cargo test --bin longbridge` — 793 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)