### PR TITLE
ai: Show the running turn's token usage in the chat TUI

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -403,6 +403,7 @@ Agent:
   ContinueWith: "Resume with:"
   FollowUpWith: "Follow up with:"
   Elapsed: "elapsed %{secs}s"
+  Tokens: "%{total} tokens"
   PartialAnswer: "Warning: stream dropped; showing partial answer"
   Reconnecting: "Connection lost; reconnecting to the run…"
   RunFailed: "The agent run did not complete successfully"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -403,6 +403,7 @@ Agent:
   ContinueWith: "续答命令："
   FollowUpWith: "续聊命令："
   Elapsed: "耗时 %{secs}s"
+  Tokens: "%{total} tokens"
   PartialAnswer: "警告：流中断，以下为已接收的部分回答"
   Reconnecting: "连接中断，正在重新连接…"
   RunFailed: "本次运行未能成功完成"

--- a/locales/zh-HK.yml
+++ b/locales/zh-HK.yml
@@ -403,6 +403,7 @@ Agent:
   ContinueWith: "續答命令："
   FollowUpWith: "續聊命令："
   Elapsed: "耗時 %{secs}s"
+  Tokens: "%{total} tokens"
   PartialAnswer: "警告：流中斷，以下為已接收的部分回答"
   Reconnecting: "連線中斷，正在重新連線…"
   RunFailed: "本次執行未能成功完成"

--- a/src/ai/runtime.rs
+++ b/src/ai/runtime.rs
@@ -115,6 +115,7 @@ fn map_agent_event(ev: &AgentEvent) -> Vec<ChatEvent> {
             vec![ChatEvent::Status(strip_control_chars(title))]
         }
         AgentEvent::ThinkingFinished => vec![ChatEvent::ThinkingFinished],
+        AgentEvent::TokenUsage(usage) => vec![ChatEvent::TokenUsage(*usage)],
         // A tool call goes to the transcript as well as the status line: the
         // status line is overwritten by the next event, and which data an answer
         // was built from is worth keeping.

--- a/src/ai/session_store.rs
+++ b/src/ai/session_store.rs
@@ -176,6 +176,10 @@ fn continuable_parent(messages: &[crate::openapi::chats::ChatMessage]) -> Option
 
 /// Restore a loaded conversation into `state`, ready for follow-ups.
 pub fn restore(loaded: LoadedChat, state: &mut ChatState) {
+    // Like `reset`: the conversation identity changes, so events a turn of the
+    // previous conversation already queued must not apply to this one —
+    // aborting its task cannot retract them, only the generation gate can.
+    state.generation = state.generation.wrapping_add(1);
     if !loaded.agent_uid.is_empty() {
         state.agent_uid = loaded.agent_uid;
     }
@@ -197,6 +201,7 @@ pub fn restore(loaded: LoadedChat, state: &mut ChatState) {
     state.busy = false;
     state.queued.clear();
     state.tool_failures.clear();
+    state.token_usage = None;
     state.messages = loaded.messages;
 }
 
@@ -211,6 +216,39 @@ mod tests {
             status,
             ..ChatMessage::default()
         }
+    }
+
+    /// Restoring changes which conversation the state describes, so a turn of
+    /// the previous conversation must lose its claim on it: the generation gate
+    /// is what discards events an aborted task had already queued, and the live
+    /// token count belongs to the turn that was just abandoned.
+    #[test]
+    fn restore_bumps_the_generation_and_drops_live_turn_state() {
+        use crate::ai::state::{ChatEvent, ChatState};
+        let mut state = ChatState::new("chatbot".into(), "welcome".into());
+        state.apply(ChatEvent::UserPrompt("still running".into()));
+        state.apply(ChatEvent::TokenUsage(crate::openapi::chats::TokenUsage {
+            prompt_tokens: 1200,
+            completion_tokens: 80,
+            total_tokens: 1280,
+        }));
+        let generation = state.generation;
+        let loaded = LoadedChat {
+            agent_uid: "chatbot".into(),
+            chat_uid: "c2".into(),
+            message_id: None,
+            parent_message_id: None,
+            title: None,
+            messages: Vec::new(),
+            pending_interrupt: None,
+        };
+        restore(loaded, &mut state);
+        assert_ne!(state.generation, generation, "stale events must be gated");
+        assert!(
+            state.token_usage.is_none(),
+            "the old turn's count is dropped"
+        );
+        assert!(!state.busy);
     }
 
     /// The bug this exists for: a conversation the reader quit while the agent was

--- a/src/ai/session_store.rs
+++ b/src/ai/session_store.rs
@@ -176,10 +176,12 @@ fn continuable_parent(messages: &[crate::openapi::chats::ChatMessage]) -> Option
 
 /// Restore a loaded conversation into `state`, ready for follow-ups.
 pub fn restore(loaded: LoadedChat, state: &mut ChatState) {
-    // Like `reset`: the conversation identity changes, so events a turn of the
-    // previous conversation already queued must not apply to this one —
-    // aborting its task cannot retract them, only the generation gate can.
-    state.generation = state.generation.wrapping_add(1);
+    // Drop the previous conversation's in-flight turn and bump the generation:
+    // a turn of the conversation being left cannot be retracted by aborting its
+    // task, only gated out by the generation. This clears the live answer,
+    // reasoning block, status, queue, and token count in one place shared with
+    // `reset`, so the two can't drift.
+    state.clear_turn_state();
     if !loaded.agent_uid.is_empty() {
         state.agent_uid = loaded.agent_uid;
     }
@@ -190,18 +192,7 @@ pub fn restore(loaded: LoadedChat, state: &mut ChatState) {
     // and neither is something the server will build on.
     state.parent_message_id = loaded.parent_message_id;
     state.pending_interrupt = loaded.pending_interrupt;
-    state.turn_error = None;
     state.scroll = 0;
-    state.references.clear();
-    state.further.clear();
-    // Drop any transient turn state so a restored conversation never inherits a
-    // half-streamed answer, a stale status/spinner, or queued prompts.
-    state.streaming = None;
-    state.status.clear();
-    state.busy = false;
-    state.queued.clear();
-    state.tool_failures.clear();
-    state.token_usage = None;
     state.messages = loaded.messages;
 }
 
@@ -220,18 +211,22 @@ mod tests {
 
     /// Restoring changes which conversation the state describes, so a turn of
     /// the previous conversation must lose its claim on it: the generation gate
-    /// is what discards events an aborted task had already queued, and the live
-    /// token count belongs to the turn that was just abandoned.
+    /// discards events an aborted task had already queued, and every piece of
+    /// live turn state (the running answer, the reasoning block, the token
+    /// count, the turn's start) belongs to the conversation just abandoned — not
+    /// the one being opened.
     #[test]
     fn restore_bumps_the_generation_and_drops_live_turn_state() {
         use crate::ai::state::{ChatEvent, ChatState};
         let mut state = ChatState::new("chatbot".into(), "welcome".into());
         state.apply(ChatEvent::UserPrompt("still running".into()));
+        state.apply(ChatEvent::ThinkingDelta("mid-reasoning".into()));
         state.apply(ChatEvent::TokenUsage(crate::openapi::chats::TokenUsage {
             prompt_tokens: 1200,
             completion_tokens: 80,
             total_tokens: 1280,
         }));
+        assert!(state.thinking.is_some() && state.turn_started.is_some());
         let generation = state.generation;
         let loaded = LoadedChat {
             agent_uid: "chatbot".into(),
@@ -247,6 +242,14 @@ mod tests {
         assert!(
             state.token_usage.is_none(),
             "the old turn's count is dropped"
+        );
+        assert!(
+            state.thinking.is_none(),
+            "the old turn's reasoning block must not leak into the restored chat"
+        );
+        assert!(
+            state.turn_started.is_none(),
+            "no turn is in flight after restore"
         );
         assert!(!state.busy);
     }

--- a/src/ai/session_store.rs
+++ b/src/ai/session_store.rs
@@ -176,11 +176,12 @@ fn continuable_parent(messages: &[crate::openapi::chats::ChatMessage]) -> Option
 
 /// Restore a loaded conversation into `state`, ready for follow-ups.
 pub fn restore(loaded: LoadedChat, state: &mut ChatState) {
-    // Drop the previous conversation's in-flight turn and bump the generation:
-    // a turn of the conversation being left cannot be retracted by aborting its
-    // task, only gated out by the generation. This clears the live answer,
-    // reasoning block, status, queue, and token count in one place shared with
-    // `reset`, so the two can't drift.
+    // Drop the previous conversation's in-flight turn and invalidate its
+    // generation: a turn of the conversation being left cannot be retracted by
+    // aborting its task, only gated out. Clearing the live answer, reasoning
+    // block, status, queue, and token count runs through the same helper `reset`
+    // uses, so the two can't drift.
+    state.bump_generation();
     state.clear_turn_state();
     if !loaded.agent_uid.is_empty() {
         state.agent_uid = loaded.agent_uid;

--- a/src/ai/session_store.rs
+++ b/src/ai/session_store.rs
@@ -106,7 +106,9 @@ pub async fn load_detail(uid: &str) -> Option<LoadedChat> {
                 } else {
                     Role::Assistant
                 };
-                out.push(Message::new(role, text));
+                // Only assistant answers carry usage; a user line never does.
+                let usage = (role == Role::Assistant).then_some(m.token_usage).flatten();
+                out.push(Message::new(role, text).with_token_usage(usage));
             }
             out
         })

--- a/src/ai/state.rs
+++ b/src/ai/state.rs
@@ -483,28 +483,41 @@ impl ChatState {
         self.messages.push(Message::thinking(thinking.text, secs));
     }
 
-    /// Reset to a fresh conversation, keeping the agent but dropping all
-    /// messages and conversation identity. Used by the "new chat" action.
-    pub fn reset(&mut self, welcome: String) {
+    /// Drop everything tied to the turn in flight and bump the generation so
+    /// events a turn task already queued (it may still be running) are discarded
+    /// by the generation gate rather than applied to whatever comes next.
+    ///
+    /// Shared by [`Self::reset`] (new chat) and `session_store::restore` (switch
+    /// conversation): both abandon the running turn, so the field list lives in
+    /// one place instead of drifting between two hand-kept copies. Conversation
+    /// identity (title, ids, pending interrupt) is *not* cleared here — `reset`
+    /// blanks it, `restore` overwrites it with the loaded chat's.
+    pub fn clear_turn_state(&mut self) {
         self.generation = self.generation.wrapping_add(1);
-        self.messages = vec![Message::new(Role::System, welcome)];
         self.streaming = None;
         self.thinking = None;
         self.status.clear();
         self.busy = false;
+        self.queued.clear();
+        self.tool_failures.clear();
+        self.references.clear();
+        self.further.clear();
+        self.turn_error = None;
+        self.turn_started = None;
+        self.token_usage = None;
+    }
+
+    /// Reset to a fresh conversation, keeping the agent but dropping all
+    /// messages and conversation identity. Used by the "new chat" action.
+    pub fn reset(&mut self, welcome: String) {
+        self.clear_turn_state();
+        self.messages = vec![Message::new(Role::System, welcome)];
         self.scroll = 0;
         self.title = None;
         self.chat_uid = None;
         self.message_id = None;
         self.parent_message_id = None;
         self.pending_interrupt = None;
-        self.turn_error = None;
-        self.queued.clear();
-        self.tool_failures.clear();
-        self.references.clear();
-        self.further.clear();
-        self.turn_started = None;
-        self.token_usage = None;
     }
 
     /// Take everything queued as a single prompt, or `None` if nothing waits.

--- a/src/ai/state.rs
+++ b/src/ai/state.rs
@@ -483,17 +483,25 @@ impl ChatState {
         self.messages.push(Message::thinking(thinking.text, secs));
     }
 
-    /// Drop everything tied to the turn in flight and bump the generation so
-    /// events a turn task already queued (it may still be running) are discarded
-    /// by the generation gate rather than applied to whatever comes next.
+    /// Invalidate the current turn generation so events a turn task already
+    /// queued — it may still be running after an abort, which cannot retract
+    /// them — are dropped by the generation gate instead of applied to whatever
+    /// conversation comes next. Kept separate from [`Self::clear_turn_state`]:
+    /// clearing fields is local bookkeeping, this is the concurrency gate, and
+    /// fusing them would hide a load-bearing side effect behind a tidy name.
+    pub fn bump_generation(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+    }
+
+    /// Drop every field tied to the turn in flight. Pure field-clearing — it does
+    /// **not** touch the generation gate (call [`Self::bump_generation`] for that
+    /// when abandoning a running turn) or conversation identity (title, ids,
+    /// pending interrupt), which `reset` blanks and `restore` overwrites.
     ///
     /// Shared by [`Self::reset`] (new chat) and `session_store::restore` (switch
-    /// conversation): both abandon the running turn, so the field list lives in
-    /// one place instead of drifting between two hand-kept copies. Conversation
-    /// identity (title, ids, pending interrupt) is *not* cleared here — `reset`
-    /// blanks it, `restore` overwrites it with the loaded chat's.
+    /// conversation) so the field list lives in one place instead of drifting
+    /// between two hand-kept copies.
     pub fn clear_turn_state(&mut self) {
-        self.generation = self.generation.wrapping_add(1);
         self.streaming = None;
         self.thinking = None;
         self.status.clear();
@@ -510,6 +518,7 @@ impl ChatState {
     /// Reset to a fresh conversation, keeping the agent but dropping all
     /// messages and conversation identity. Used by the "new chat" action.
     pub fn reset(&mut self, welcome: String) {
+        self.bump_generation();
         self.clear_turn_state();
         self.messages = vec![Message::new(Role::System, welcome)];
         self.scroll = 0;

--- a/src/ai/state.rs
+++ b/src/ai/state.rs
@@ -9,6 +9,8 @@
 use longbridge::agent::Reference;
 use serde_json::Value;
 
+use crate::openapi::chats::TokenUsage;
+
 /// Who authored a transcript line.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Role {
@@ -51,6 +53,10 @@ pub struct Message {
     pub tool: Option<ToolStatus>,
     /// Set only on [`Role::Thinking`] lines.
     pub thinking: Option<ThinkingBlock>,
+    /// The round's token usage, on the [`Role::Assistant`] line that answered
+    /// it. Absent for every other line, and for answers that consumed no
+    /// tokens — see [`TokenUsage`].
+    pub token_usage: Option<TokenUsage>,
 }
 
 impl Message {
@@ -61,6 +67,7 @@ impl Message {
             text,
             tool: None,
             thinking: None,
+            token_usage: None,
         }
     }
 
@@ -71,6 +78,7 @@ impl Message {
             text: name,
             tool: Some(status),
             thinking: None,
+            token_usage: None,
         }
     }
 
@@ -84,7 +92,16 @@ impl Message {
                 secs,
                 expanded: false,
             }),
+            token_usage: None,
         }
+    }
+
+    /// Attach a round's token usage to an assistant line, dropping an empty
+    /// one so it never shows as a "0 tokens" placeholder.
+    #[must_use]
+    pub fn with_token_usage(mut self, usage: Option<TokenUsage>) -> Self {
+        self.token_usage = usage.filter(|u| !u.is_empty());
+        self
     }
 }
 
@@ -107,6 +124,10 @@ pub enum ChatEvent {
     ThinkingDelta(String),
     /// The reasoning phase ended; the live block collapses to a summary line.
     ThinkingFinished,
+    /// The turn's cumulative token usage so far. Overwrites the last value
+    /// (never accumulates), so a dropped or replayed frame keeps the count
+    /// correct.
+    TokenUsage(TokenUsage),
     /// The agent started calling a tool; appends a running tool line.
     ToolStarted(String),
     /// A tool finished; resolves its line and records failures so an empty turn
@@ -225,6 +246,10 @@ pub struct ChatState {
     pub further: Vec<String>,
     /// Where the turn in flight began, for analytics. See [`TurnStart`].
     pub turn_started: Option<TurnStart>,
+    /// The active turn's cumulative token usage, carried until the answer is
+    /// finalized and then attached to that assistant message. Overwritten by
+    /// each frame, so the value is always the round's running total.
+    pub token_usage: Option<TokenUsage>,
 }
 
 impl ChatState {
@@ -257,6 +282,7 @@ impl ChatState {
                 self.references.clear();
                 self.further.clear();
                 self.turn_error = None;
+                self.token_usage = None;
             }
             ChatEvent::TurnStarted {
                 chat_uid,
@@ -282,6 +308,8 @@ impl ChatState {
                 self.thinking.get_or_insert_with(Thinking::default).text += &text;
             }
             ChatEvent::ThinkingFinished => self.collapse_thinking(),
+            // Cumulative for the round, so replace rather than add.
+            ChatEvent::TokenUsage(usage) => self.token_usage = Some(usage),
             // A tool call is committed to the transcript rather than only
             // flashing through the status line: for a finance agent, which data
             // an answer was built from is part of the answer.
@@ -359,6 +387,8 @@ impl ChatState {
                 self.references.clear();
                 self.further.clear();
                 self.turn_error = None;
+                // The replay re-emits this round's cumulative token frames.
+                self.token_usage = None;
             }
             ChatEvent::TurnFinished { error } => {
                 // A transport error takes precedence, but a server-reported one is
@@ -377,12 +407,16 @@ impl ChatState {
         self.collapse_thinking();
         self.settle_running_tools();
         let error_free = error.is_none();
+        // Taken whether or not an answer was produced, so a turn that streamed
+        // no text never carries its usage into the next turn.
+        let usage = self.token_usage.take();
         let produced = self
             .streaming
             .take()
             .filter(|t| !t.trim().is_empty())
             .map(|text| {
-                self.messages.push(Message::new(Role::Assistant, text));
+                self.messages
+                    .push(Message::new(Role::Assistant, text).with_token_usage(usage));
             })
             .is_some();
         if let Some(err) = error {
@@ -470,6 +504,7 @@ impl ChatState {
         self.references.clear();
         self.further.clear();
         self.turn_started = None;
+        self.token_usage = None;
     }
 
     /// Take everything queued as a single prompt, or `None` if nothing waits.
@@ -492,6 +527,7 @@ impl ChatState {
         // nothing left to finish it.
         self.collapse_thinking();
         self.settle_running_tools();
+        let usage = self.token_usage.take();
         if let Some(mut text) = self.streaming.take() {
             if text.trim().is_empty() {
                 text = cancelled_label.to_string();
@@ -499,7 +535,8 @@ impl ChatState {
                 text.push('\n');
                 text.push_str(cancelled_label);
             }
-            self.messages.push(Message::new(Role::Assistant, text));
+            self.messages
+                .push(Message::new(Role::Assistant, text).with_token_usage(usage));
         }
         self.busy = false;
         self.status.clear();
@@ -740,6 +777,44 @@ mod tests {
         // A blank title does not overwrite a real one.
         s.apply(ChatEvent::Title("   ".into()));
         assert_eq!(s.title.as_deref(), Some("Tesla outlook"));
+    }
+
+    /// The round's token total lands on the assistant message it belongs to,
+    /// and a fresh prompt starts the next round's count from nothing.
+    #[test]
+    fn token_usage_attaches_to_the_answer_and_resets_next_turn() {
+        use crate::openapi::chats::TokenUsage;
+        let mut s = state();
+        s.apply(ChatEvent::UserPrompt("how is TSLA?".into()));
+        s.apply(ChatEvent::TokenUsage(TokenUsage {
+            prompt_tokens: 1200,
+            completion_tokens: 80,
+            total_tokens: 1280,
+        }));
+        // A later cumulative frame overwrites the earlier one.
+        s.apply(ChatEvent::TokenUsage(TokenUsage {
+            prompt_tokens: 2600,
+            completion_tokens: 210,
+            total_tokens: 2810,
+        }));
+        s.apply(ChatEvent::Delta("TSLA is up.".into()));
+        s.apply(ChatEvent::TurnFinished { error: None });
+        let answer = s.messages.last().unwrap();
+        assert_eq!(answer.role, Role::Assistant);
+        assert_eq!(answer.token_usage.unwrap().total_tokens, 2810);
+        // The next turn does not inherit the previous round's total.
+        s.apply(ChatEvent::UserPrompt("and NVDA?".into()));
+        assert!(s.token_usage.is_none());
+    }
+
+    /// A round that consumed no tokens (a cache hit) leaves no footer to render.
+    #[test]
+    fn an_answer_without_usage_carries_none() {
+        let mut s = state();
+        s.apply(ChatEvent::UserPrompt("hi".into()));
+        s.apply(ChatEvent::Delta("hello".into()));
+        s.apply(ChatEvent::TurnFinished { error: None });
+        assert!(s.messages.last().unwrap().token_usage.is_none());
     }
 
     #[test]

--- a/src/ai/tui.rs
+++ b/src/ai/tui.rs
@@ -1164,6 +1164,17 @@ pub async fn run(agent_uid: String, quotes: Option<QuoteStream>) -> Result<Optio
             }
             Some(loaded) = load_rx.recv() => {
                 if let Some(loaded) = loaded {
+                    // A turn still streaming belongs to the conversation being
+                    // left. Abort it before the switch — without this its
+                    // remaining events kept applying to the restored state,
+                    // committing the old conversation's answer into the new
+                    // one's transcript.
+                    if let Some(task) = turn.take() {
+                        task.abort();
+                        // An aborted turn sends no finishing event, so its end
+                        // is reported here or not at all.
+                        analytics::turn_finish(&state, analytics::Outcome::Cancelled);
+                    }
                     analytics::session_resume();
                     session_store::restore(loaded, &mut state);
                     ui.reset_render();
@@ -3373,7 +3384,7 @@ fn view(f: &mut ratatui::Frame, ui: &mut Ui, state: &mut ChatState, editor: &Edi
     // floats over the status row and any chrome between the transcript and the
     // prompt rather than being anchored to the transcript's foot with a gap.
     if ui.view == View::Chat {
-        render_slash_dropdown(f, body, footer, ui, state, editor);
+        render_slash_dropdown(f, body, footer, ui, state, editor, hug);
     } else {
         ui.slash_rows.clear();
     }
@@ -4518,6 +4529,7 @@ fn render_slash_dropdown(
     ui: &mut Ui,
     state: &ChatState,
     editor: &Editor,
+    hug: bool,
 ) {
     ui.slash_rows.clear();
     if !slash_active(editor) {
@@ -4535,12 +4547,16 @@ fn render_slash_dropdown(
         .unwrap_or(0);
     let box_h = matches.len() as u16 + 2;
     let box_w = area.width.clamp(24, 56);
-    // The prompt box's top border sits one row into the footer (a blank row above
-    // it). Hang the palette's bottom edge off that border so the two are flush,
-    // instead of anchoring to the transcript's foot with the status row between.
+    // Hang the palette's bottom edge off the prompt box's top border so the two
+    // are flush, instead of anchoring to the transcript's foot with the status
+    // row between. Where that border sits depends on the footer's layout: one
+    // row into the footer normally (a blank row above the box), or on its first
+    // row when the box hugs a populated status row — anchoring past the real
+    // border would draw the palette over it.
+    let box_top = prompt.y + u16::from(!hug);
     let box_area = Rect {
         x: area.x,
-        y: (prompt.y + 1).saturating_sub(box_h),
+        y: box_top.saturating_sub(box_h),
         width: box_w,
         height: box_h,
     };
@@ -7050,6 +7066,48 @@ mod tests {
                     .to_string()
             })
             .collect()
+    }
+
+    /// The command palette must hang off the prompt box's real top border in
+    /// the hugged layout too. Anchored one row too low, its bottom border
+    /// overwrote the box's top border whenever the palette was opened while
+    /// scrolled up (or during a turn).
+    #[test]
+    fn the_command_palette_respects_a_hugged_prompt_box() {
+        let mut ui = super::Ui::new();
+        let mut state = super::ChatState::new("chatbot".into(), "welcome".into());
+        let mut editor = super::Editor::new();
+        editor.set_text("/");
+        for i in 0..20 {
+            state.apply(super::ChatEvent::UserPrompt(format!("q{i}")));
+            state.apply(super::ChatEvent::Delta(format!("a{i}")));
+            state.apply(super::ChatEvent::TurnFinished { error: None });
+        }
+        state.scroll = 5; // hug active: the scrolled-up hint occupies the status row
+        let backend = ratatui::backend::TestBackend::new(60, 24);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|f| super::view(f, &mut ui, &mut state, &editor))
+            .expect("draw");
+        let buf = terminal.backend().buffer().clone();
+        let rows: Vec<String> = (0..buf.area.height)
+            .map(|y| {
+                (0..buf.area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect();
+        // The box's top border survives intact (its row starts with ╭, not with
+        // the palette's bottom border), and the palette sits flush above it.
+        let box_top = rows
+            .iter()
+            .rposition(|r| r.trim_start().starts_with('╭'))
+            .expect("the prompt box's top border must survive the palette");
+        assert!(
+            rows[box_top - 1].contains('╰'),
+            "the palette should sit flush above the box:\n{}",
+            rows.join("\n")
+        );
     }
 
     /// When the status row carries a hint (here, the scrolled-up notice), the

--- a/src/ai/tui.rs
+++ b/src/ai/tui.rs
@@ -1165,16 +1165,12 @@ pub async fn run(agent_uid: String, quotes: Option<QuoteStream>) -> Result<Optio
             Some(loaded) = load_rx.recv() => {
                 if let Some(loaded) = loaded {
                     // A turn still streaming belongs to the conversation being
-                    // left. Abort it before the switch — without this its
-                    // remaining events kept applying to the restored state,
-                    // committing the old conversation's answer into the new
-                    // one's transcript.
-                    if let Some(task) = turn.take() {
-                        task.abort();
-                        // An aborted turn sends no finishing event, so its end
-                        // is reported here or not at all.
-                        analytics::turn_finish(&state, analytics::Outcome::Cancelled);
-                    }
+                    // left. Abandon it before the switch (and report the turn /
+                    // any pending question) — without the abort its remaining
+                    // events kept applying to the restored state, committing the
+                    // old conversation's answer into the new one's transcript.
+                    // Read before `restore` clears the turn state.
+                    abandon_turn(&state, &mut turn);
                     analytics::session_resume();
                     session_store::restore(loaded, &mut state);
                     ui.reset_render();
@@ -1518,21 +1514,30 @@ fn on_ctrl_c(
     }
 }
 
-/// Abort the active turn and fold any partial answer into the transcript.
-fn cancel_turn(state: &mut ChatState, turn: &mut Option<JoinHandle<()>>) {
-    if let Some(turn) = turn.take() {
-        turn.abort();
-        // Aborting stops the producer, so no finishing event is coming. Reported
-        // before `cancel`, which clears the turn's start along with the rest of
-        // the in-flight state. `turn_finish` ignores an idle chat on its own, but
-        // gating on the handle keeps a bare Esc from reaching it at all.
+/// Abandon whatever turn is in flight, reporting it to analytics: the aborted
+/// producer sends no finishing event, so the turn is recorded as cancelled here
+/// or never, and a question it left pending counts as walked away from.
+///
+/// Shared by every path that drops the running turn — cancel (Esc), new chat,
+/// resuming another conversation — so none of them can forget the reporting the
+/// others do (a start with no end hangs in the warehouse forever). Reads the
+/// turn state, so callers must invoke it *before* clearing that state. The
+/// transcript is left untouched; callers that fold a partial answer (Esc) or
+/// replace it (new chat / resume) do so afterward.
+fn abandon_turn(state: &ChatState, turn: &mut Option<JoinHandle<()>>) {
+    if let Some(task) = turn.take() {
+        task.abort();
         analytics::turn_finish(state, analytics::Outcome::Cancelled);
     }
-    // `cancel` drops a pending question as unanswerable, so it counts as walked
-    // away from — reported before that happens.
     if state.pending_interrupt.is_some() {
         analytics::interrupt_answered(false);
     }
+}
+
+/// Abort the active turn and fold any partial answer into the transcript.
+fn cancel_turn(state: &mut ChatState, turn: &mut Option<JoinHandle<()>>) {
+    // Before `cancel`, which clears the turn state `abandon_turn` reads.
+    abandon_turn(state, turn);
     state.cancel(&t!("Ai.Cancelled"));
 }
 
@@ -1932,21 +1937,9 @@ fn start_turn(
 }
 
 fn new_session(ui: &mut Ui, state: &mut ChatState, turn: &mut Option<JoinHandle<()>>) {
-    if let Some(task) = turn.take() {
-        task.abort();
-        // An aborted turn sends no finishing event, so its end is reported here
-        // or not at all — and a start with no end is a turn the warehouse counts
-        // forever as still running.
-        analytics::turn_finish(state, analytics::Outcome::Cancelled);
-    }
-    // Checked apart from the turn: a question left over from a turn that already
-    // finished is the most common way one goes unanswered — the reader reads it
-    // and starts over instead of replying.
-    if state.pending_interrupt.is_some() {
-        analytics::interrupt_answered(false);
-    }
+    // Reported before the reset, which clears the turn state these read.
+    abandon_turn(state, turn);
     analytics::session_new();
-    // Reported before the reset, which clears the turn's start.
     state.reset(t!("Ai.Welcome").to_string());
     ui.reset_render();
     ui.switch(View::Chat);
@@ -5349,17 +5342,6 @@ fn render_turn_status(f: &mut ratatui::Frame, area: Rect, ui: &mut Ui, state: &C
             Style::default().fg(Color::DarkGray),
         ));
     }
-    // The round's token count, rolling up as the server reports it — the same
-    // place Claude Code keeps it, inline with the timer while the turn runs.
-    if let Some(usage) = state.token_usage.filter(|u| !u.is_empty()) {
-        spans.push(Span::styled(
-            format!(
-                "   · ↑ {}",
-                t!("Agent.Tokens", total = group_thousands(usage.total_tokens))
-            ),
-            Style::default().fg(Color::DarkGray),
-        ));
-    }
     // A spinner spins the same whether the agent is working or the stream has
     // gone quiet, which is the whole of "it looks stuck". Once the silence is
     // long enough to be worth naming, say how long it has lasted — during a slow
@@ -5374,10 +5356,31 @@ fn render_turn_status(f: &mut ratatui::Frame, area: Rect, ui: &mut Ui, state: &C
     // The button is right-aligned, so its rect is derived from the label width.
     let label = format!("[{}]", t!("Ai.Stop"));
     let label_w = UnicodeWidthStr::width(label.as_str()) as u16;
-    let used: u16 = spans
-        .iter()
-        .map(|s| UnicodeWidthStr::width(s.content.as_ref()) as u16)
-        .sum();
+    let span_width = |spans: &[Span]| -> u16 {
+        spans
+            .iter()
+            .map(|s| UnicodeWidthStr::width(s.content.as_ref()) as u16)
+            .sum()
+    };
+    // The token count, rolling up as the server reports it — the same place
+    // Claude Code keeps it. It yields to the [stop] button: on a narrow row a
+    // long count would otherwise push the cancel affordance off the edge, and
+    // being able to stop the turn matters more than watching its cost. So it is
+    // added only when it *and* the reserved stop label still fit.
+    if let Some(usage) = state.token_usage.filter(|u| !u.is_empty()) {
+        let token = format!(
+            "   · ↑ {}",
+            t!("Agent.Tokens", total = group_thousands(usage.total_tokens))
+        );
+        let token_w = UnicodeWidthStr::width(token.as_str()) as u16;
+        // Mirror the stop-button placement below (`width > used + label_w + 1`)
+        // with the token span counted into `used`, so the count is added only
+        // when the row still clears the bar that keeps `[stop]` on screen.
+        if span_width(&spans) + token_w + label_w + 1 < area.width {
+            spans.push(Span::styled(token, Style::default().fg(Color::DarkGray)));
+        }
+    }
+    let used: u16 = span_width(&spans);
     let rect = (area.width > used + label_w + 1).then(|| Rect {
         x: area.x + area.width - label_w,
         y: area.y,
@@ -7040,6 +7043,50 @@ mod tests {
         assert!(
             screen.contains("11,975"),
             "the running token count should be visible on screen:\n{screen}"
+        );
+    }
+
+    /// The cancel affordance outranks the token count: on a row too narrow for
+    /// both, the token span is dropped and `[stop]` stays. Renders the turn row
+    /// directly and checks the stop button was placed and the count omitted.
+    #[test]
+    fn the_stop_button_wins_the_row_over_the_token_count() {
+        use crate::openapi::chats::TokenUsage;
+        let mut ui = super::Ui::new();
+        let mut state = super::ChatState::new("chatbot".into(), "welcome".into());
+        state.apply(super::ChatEvent::UserPrompt("q".into()));
+        ui.turn_started = Some(std::time::Instant::now());
+        // Sized so the base row + `[stop]` fit a 60-col row, but adding the
+        // ~21-col token span would push `[stop]` off the edge.
+        state.status = "Reading market data for TSLA".into();
+        state.apply(super::ChatEvent::TokenUsage(TokenUsage {
+            prompt_tokens: 123_400,
+            completion_tokens: 56,
+            total_tokens: 123_456,
+        }));
+        // A narrow row: the base status + timer + stop label already nearly fill
+        // it, so the token span cannot also fit.
+        let area = super::Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 1,
+        };
+        let backend = ratatui::backend::TestBackend::new(60, 1);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|f| super::render_turn_status(f, area, &mut ui, &state))
+            .expect("draw");
+        let row: String = (0..60)
+            .map(|x| terminal.backend().buffer()[(x, 0)].symbol())
+            .collect();
+        assert!(
+            ui.stop_button.is_some() && row.contains("stop"),
+            "the stop button must survive a narrow row:\n{row}"
+        );
+        assert!(
+            !row.contains("123,456"),
+            "the token count yields when it would push [stop] off:\n{row}"
         );
     }
 

--- a/src/ai/tui.rs
+++ b/src/ai/tui.rs
@@ -1219,11 +1219,10 @@ pub async fn run(agent_uid: String, quotes: Option<QuoteStream>) -> Result<Optio
         // Signing out is the only action left to run here; signing in is handled
         // above, where the panel can stay open while the browser round trip runs.
         if ui.pending.take() == Some(Pending::SignOut) {
-            // A turn in flight belongs to the credentials being revoked.
-            if let Some(task) = turn.take() {
-                task.abort();
-                state.cancel(&t!("Ai.Cancelled"));
-            }
+            // A turn in flight belongs to the credentials being revoked. Abandon
+            // it through the shared path so its end (and any pending question) is
+            // reported to analytics, not just aborted.
+            cancel_turn(&mut state, &mut turn);
             match crate::auth::clear_token().await {
                 Ok(()) => {
                     // Signing out stays in the chat. The contexts cannot be torn
@@ -1260,9 +1259,9 @@ pub async fn run(agent_uid: String, quotes: Option<QuoteStream>) -> Result<Optio
         crossterm::event::DisableBracketedPaste,
         crossterm::event::DisableFocusChange,
     );
-    if let Some(turn) = turn.take() {
-        turn.abort();
-    }
+    // Quitting mid-turn abandons it like any other teardown, so its end is
+    // reported rather than left as an open turn_start in the warehouse.
+    abandon_turn(&state, &mut turn);
     if let Some(task) = login_task.take() {
         task.abort();
     }
@@ -1839,6 +1838,10 @@ fn submit(
                     retry_last(ui, state, turn, tx);
                 } else if key == "new" {
                     new_session(ui, state, turn);
+                } else if key == "agent" {
+                    // Switching agents abandons the running turn, so it needs
+                    // the turn handle `exec_slash` does not carry.
+                    switch_agent(args, ui, state, turn);
                 } else {
                     exec_slash(key, args, ui, state);
                 }
@@ -2019,7 +2022,8 @@ fn exec_slash(name: &str, args: &str, ui: &mut Ui, state: &mut ChatState) {
         }
         "resume" => open_sessions(ui),
         "settings" => ui.switch(View::Settings),
-        "agent" => switch_agent(args, ui, state),
+        // `agent` (like `new`) abandons the running turn, so it is dispatched
+        // where the turn handle lives (`submit` / `run_slash`) rather than here.
         // A panel, not a message: help is something you consult and dismiss, and as
         // a transcript entry it could not be dismissed at all.
         "help" => ui.help = Some(0),
@@ -2034,7 +2038,7 @@ fn exec_slash(name: &str, args: &str, ui: &mut Ui, state: &mut ChatState) {
 ///
 /// The uid is not validated here: only the server knows which agents the
 /// account may drive, so a bad one surfaces as that agent's first-turn error.
-fn switch_agent(args: &str, ui: &mut Ui, state: &mut ChatState) {
+fn switch_agent(args: &str, ui: &mut Ui, state: &mut ChatState, turn: &mut Option<JoinHandle<()>>) {
     if args.is_empty() {
         ui.notice = Some(t!("Ai.AgentUsage").to_string());
         return;
@@ -2060,6 +2064,10 @@ fn switch_agent(args: &str, ui: &mut Ui, state: &mut ChatState) {
     analytics::agent_switch(&state.agent_uid, &uid);
     // A conversation belongs to its agent server-side, so switching starts a
     // fresh one rather than continuing this thread under a different agent.
+    // Abandon the turn in flight first (reset only gates its events; the task
+    // still runs and would go unreported): `/agent` can be typed mid-turn, the
+    // slash dispatch running before the busy guard.
+    abandon_turn(state, turn);
     state.reset(t!("Ai.Welcome").to_string());
     state.agent_uid = uid;
     ui.reset_render();
@@ -3238,6 +3246,9 @@ fn run_slash(
     editor.clear();
     if key == "new" {
         new_session(ui, state, turn);
+    } else if key == "agent" {
+        // No argument from the palette; switch_agent notices the missing uid.
+        switch_agent("", ui, state, turn);
     } else {
         exec_slash(key, "", ui, state);
     }
@@ -5362,26 +5373,27 @@ fn render_turn_status(f: &mut ratatui::Frame, area: Rect, ui: &mut Ui, state: &C
             .map(|s| UnicodeWidthStr::width(s.content.as_ref()) as u16)
             .sum()
     };
+    // The one bar both the token span and the [stop] button clear: content of
+    // width `used`, plus the label and a one-column gap, must fit the row. Kept
+    // in one place so the gate and the placement can't drift to different bars.
+    let fits_with_stop = |used: u16| area.width > used + label_w + 1;
     // The token count, rolling up as the server reports it — the same place
     // Claude Code keeps it. It yields to the [stop] button: on a narrow row a
     // long count would otherwise push the cancel affordance off the edge, and
     // being able to stop the turn matters more than watching its cost. So it is
-    // added only when it *and* the reserved stop label still fit.
+    // added only when it and the reserved stop label both still fit.
     if let Some(usage) = state.token_usage.filter(|u| !u.is_empty()) {
         let token = format!(
-            "   · ↑ {}",
+            "   · {}",
             t!("Agent.Tokens", total = group_thousands(usage.total_tokens))
         );
         let token_w = UnicodeWidthStr::width(token.as_str()) as u16;
-        // Mirror the stop-button placement below (`width > used + label_w + 1`)
-        // with the token span counted into `used`, so the count is added only
-        // when the row still clears the bar that keeps `[stop]` on screen.
-        if span_width(&spans) + token_w + label_w + 1 < area.width {
+        if fits_with_stop(span_width(&spans) + token_w) {
             spans.push(Span::styled(token, Style::default().fg(Color::DarkGray)));
         }
     }
     let used: u16 = span_width(&spans);
-    let rect = (area.width > used + label_w + 1).then(|| Rect {
+    let rect = fits_with_stop(used).then(|| Rect {
         x: area.x + area.width - label_w,
         y: area.y,
         width: label_w,
@@ -5417,16 +5429,10 @@ fn tools_this_turn(state: &ChatState) -> usize {
 /// in [`render_status`]; the idle Chat case (a committed transcript, not
 /// scrolled, no notice) is the only one that leaves the row blank.
 fn status_row_populated(ui: &Ui, state: &ChatState, editor: &Editor) -> bool {
-    if !editor.attachments().is_empty() && ui.find.is_none() {
-        return true;
-    }
-    if ui.find.is_some() {
-        return true;
-    }
-    if state.scroll > 0 {
-        return true;
-    }
-    ui.notice.is_some()
+    // A folded-paste chip, the find bar, the scrolled-up hint, or a notice —
+    // any one fills the row. (Attachments and the find bar don't interact for
+    // this decision: whichever is present, the row is populated.)
+    !editor.attachments().is_empty() || ui.find.is_some() || state.scroll > 0 || ui.notice.is_some()
 }
 
 fn render_status(f: &mut ratatui::Frame, area: Rect, ui: &Ui, state: &ChatState, editor: &Editor) {
@@ -7043,6 +7049,11 @@ mod tests {
         assert!(
             screen.contains("11,975"),
             "the running token count should be visible on screen:\n{screen}"
+        );
+        // The total is not input-only, so it must not carry the ↑ (sent) marker.
+        assert!(
+            !screen.contains('↑'),
+            "the total must not be labelled with the input-only ↑ marker:\n{screen}"
         );
     }
 

--- a/src/ai/tui.rs
+++ b/src/ai/tui.rs
@@ -3274,13 +3274,15 @@ fn view(f: &mut ratatui::Frame, ui: &mut Ui, state: &mut ChatState, editor: &Edi
     // button cannot be hidden by a notice — and the notice cannot be hidden by
     // it. Only while busy, so idle chrome stays one row on a short terminal.
     let has_turn = is_chat && state.busy;
-    // Idle, a blank row sits above the boxed prompt to lift it off the
-    // transcript's last line. While a turn runs, the status row already separates
-    // them, so the box drops that blank and hugs the status — the extra gap read
-    // as too much empty space between the spinner and the prompt.
+    // A blank row normally sits above the boxed prompt to lift it off the
+    // transcript's last line. But whenever the status row itself draws something
+    // — a running turn's spinner, the scrolled-up hint, a notice — that row is
+    // already the separator, so the box hugs it and drops the blank; the second
+    // gap otherwise read as too much empty space between the two.
+    let hug = has_turn || (is_chat && status_row_populated(ui, state, editor));
     let footer_h = if is_chat {
-        let extra = if has_turn { 2 } else { 3 };
-        (editor.lines().len() as u16 + extra).clamp(if has_turn { 3 } else { 4 }, 9)
+        let extra = if hug { 2 } else { 3 };
+        (editor.lines().len() as u16 + extra).clamp(if hug { 3 } else { 4 }, 9)
     } else {
         4
     };
@@ -3366,7 +3368,7 @@ fn view(f: &mut ratatui::Frame, ui: &mut Ui, state: &mut ChatState, editor: &Edi
         ui.stop_button = None;
     }
     render_status(f, status, ui, state, editor);
-    render_footer(f, footer, ui, editor, has_turn);
+    render_footer(f, footer, ui, editor, hug);
     // The command palette hangs directly off the prompt box, drawn last so it
     // floats over the status row and any chrome between the transcript and the
     // prompt rather than being anchored to the transcript's foot with a gap.
@@ -5390,6 +5392,24 @@ fn tools_this_turn(state: &ChatState) -> usize {
         .count()
 }
 
+/// Whether the status row (between the transcript and the prompt box) will draw
+/// anything. When it does, it is itself the separator, so the prompt box hugs it
+/// rather than adding a second blank row above. Kept in sync with the branches
+/// in [`render_status`]; the idle Chat case (a committed transcript, not
+/// scrolled, no notice) is the only one that leaves the row blank.
+fn status_row_populated(ui: &Ui, state: &ChatState, editor: &Editor) -> bool {
+    if !editor.attachments().is_empty() && ui.find.is_none() {
+        return true;
+    }
+    if ui.find.is_some() {
+        return true;
+    }
+    if state.scroll > 0 {
+        return true;
+    }
+    ui.notice.is_some()
+}
+
 fn render_status(f: &mut ratatui::Frame, area: Rect, ui: &Ui, state: &ChatState, editor: &Editor) {
     // Folded pastes are announced here, above the input, so a big paste is a
     // compact chip instead of a wall of text filling the box.
@@ -7004,6 +7024,78 @@ mod tests {
         assert!(
             screen.contains("11,975"),
             "the running token count should be visible on screen:\n{screen}"
+        );
+    }
+
+    /// Render the chat and return one string per row (trailing blanks trimmed).
+    fn render_rows(
+        ui: &mut super::Ui,
+        state: &mut super::ChatState,
+        w: u16,
+        h: u16,
+    ) -> Vec<String> {
+        let editor = super::Editor::new();
+        let backend = ratatui::backend::TestBackend::new(w, h);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|f| super::view(f, ui, state, &editor))
+            .expect("draw");
+        let buf = terminal.backend().buffer().clone();
+        (0..buf.area.height)
+            .map(|y| {
+                (0..buf.area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    /// When the status row carries a hint (here, the scrolled-up notice), the
+    /// prompt box hugs it — the box's top border sits on the very next row, with
+    /// no blank gap between the two. Regression for a too-tall gap under the
+    /// "Scrolled up" line.
+    #[test]
+    fn the_prompt_box_hugs_a_populated_status_row() {
+        let mut ui = super::Ui::new();
+        let mut state = super::ChatState::new("chatbot".into(), "welcome".into());
+        for i in 0..20 {
+            state.apply(super::ChatEvent::UserPrompt(format!("q{i}")));
+            state.apply(super::ChatEvent::Delta(format!("a{i}")));
+            state.apply(super::ChatEvent::TurnFinished { error: None });
+        }
+        state.scroll = 5;
+        let rows = render_rows(&mut ui, &mut state, 60, 14);
+        let hint = rows
+            .iter()
+            .position(|r| r.contains("Scrolled up"))
+            .expect("the scrolled-up hint should show");
+        assert!(
+            rows[hint + 1].contains('╭'),
+            "the prompt box should hug the status row, no blank between:\n{}",
+            rows.join("\n")
+        );
+    }
+
+    /// Idle with a committed transcript, the status row is blank, so the box
+    /// keeps its blank row above to lift it off the transcript.
+    #[test]
+    fn the_prompt_box_keeps_a_blank_above_when_idle() {
+        let mut ui = super::Ui::new();
+        let mut state = super::ChatState::new("chatbot".into(), "welcome".into());
+        state.apply(super::ChatEvent::UserPrompt("hi".into()));
+        state.apply(super::ChatEvent::Delta("hello".into()));
+        state.apply(super::ChatEvent::TurnFinished { error: None });
+        let rows = render_rows(&mut ui, &mut state, 60, 14);
+        let top = rows
+            .iter()
+            .position(|r| r.contains('╭'))
+            .expect("the prompt box should render");
+        assert!(
+            rows[top - 1].trim().is_empty(),
+            "a blank row should sit above the box when idle:\n{}",
+            rows.join("\n")
         );
     }
 

--- a/src/ai/tui.rs
+++ b/src/ai/tui.rs
@@ -1219,12 +1219,15 @@ pub async fn run(agent_uid: String, quotes: Option<QuoteStream>) -> Result<Optio
         // Signing out is the only action left to run here; signing in is handled
         // above, where the panel can stay open while the browser round trip runs.
         if ui.pending.take() == Some(Pending::SignOut) {
-            // A turn in flight belongs to the credentials being revoked. Abandon
-            // it through the shared path so its end (and any pending question) is
-            // reported to analytics, not just aborted.
-            cancel_turn(&mut state, &mut turn);
             match crate::auth::clear_token().await {
                 Ok(()) => {
+                    // Only now that sign-out has actually happened: a turn in
+                    // flight belonged to the revoked credentials, so abandon it
+                    // through the shared path (reporting its end and any pending
+                    // question). Done here, not before the await, so a failed
+                    // clear_token leaves the conversation — and a paused
+                    // question's pending_interrupt — untouched.
+                    cancel_turn(&mut state, &mut turn);
                     // Signing out stays in the chat. The contexts cannot be torn
                     // down — they are process-wide singletons — so the process is
                     // marked signed out instead, and the view goes back to what an
@@ -1697,7 +1700,7 @@ fn on_chat_key(
                 return;
             }
             KeyCode::Enter if !newline => {
-                run_slash_selected(ui, state, editor, turn);
+                run_slash_selected(ui, state, editor, turn, tx);
                 return;
             }
             KeyCode::Esc => {
@@ -1960,11 +1963,9 @@ fn split_command(input: &str) -> (&str, &str) {
 /// (possibly empty) rest of the line.
 fn exec_slash(name: &str, args: &str, ui: &mut Ui, state: &mut ChatState) {
     match name {
-        "new" => {
-            state.reset(t!("Ai.Welcome").to_string());
-            ui.reset_render();
-            ui.switch(View::Chat);
-        }
+        // `new`, `retry`, and `agent` all abandon the running turn, so they are
+        // dispatched where the turn handle (and, for retry, the event sender)
+        // lives — `submit` / `run_slash` — never here.
         // Keyboard route to what a click on a symbol does. With no argument it
         // opens the security the answer mentioned last, which is usually the one
         // the reader is looking at.
@@ -2022,8 +2023,6 @@ fn exec_slash(name: &str, args: &str, ui: &mut Ui, state: &mut ChatState) {
         }
         "resume" => open_sessions(ui),
         "settings" => ui.switch(View::Settings),
-        // `agent` (like `new`) abandons the running turn, so it is dispatched
-        // where the turn handle lives (`submit` / `run_slash`) rather than here.
         // A panel, not a message: help is something you consult and dismiss, and as
         // a transcript entry it could not be dismissed at all.
         "help" => ui.help = Some(0),
@@ -2237,7 +2236,7 @@ fn on_mouse(
                     .find(|(_, r)| hit(*r, col, row))
                     .map(|(i, _)| *i)
                 {
-                    run_slash(idx, ui, state, editor, turn);
+                    run_slash(idx, ui, state, editor, turn, tx);
                 } else if hit(ui.title_bar, col, row) {
                     if let Some((chip, rect)) = ui
                         .header_chips
@@ -3226,10 +3225,11 @@ fn run_slash_selected(
     state: &mut ChatState,
     editor: &mut Editor,
     turn: &mut Option<JoinHandle<()>>,
+    tx: &UnboundedSender<runtime::TurnEvent>,
 ) {
     let matches = slash_matches(editor, state);
     if let Some(&idx) = matches.get(ui.slash_sel) {
-        run_slash(idx, ui, state, editor, turn);
+        run_slash(idx, ui, state, editor, turn, tx);
     }
 }
 
@@ -3241,10 +3241,16 @@ fn run_slash(
     state: &mut ChatState,
     editor: &mut Editor,
     turn: &mut Option<JoinHandle<()>>,
+    tx: &UnboundedSender<runtime::TurnEvent>,
 ) {
     let key = SLASH[idx].key();
     editor.clear();
-    if key == "new" {
+    // The turn-owning commands are dispatched here (not `exec_slash`) because
+    // they need the turn handle — and `retry` the event sender — to abandon or
+    // start a turn. Kept in step with the same set in `submit`.
+    if key == "retry" {
+        retry_last(ui, state, turn, tx);
+    } else if key == "new" {
         new_session(ui, state, turn);
     } else if key == "agent" {
         // No argument from the palette; switch_agent notices the missing uid.
@@ -7038,22 +7044,28 @@ mod tests {
             .draw(|f| super::view(f, &mut ui, &mut state, &editor))
             .expect("draw");
         let buf = terminal.backend().buffer().clone();
-        let screen: String = (0..buf.area.height)
+        let rows: Vec<String> = (0..buf.area.height)
             .map(|y| {
                 (0..buf.area.width)
                     .map(|x| buf[(x, y)].symbol())
                     .collect::<String>()
             })
-            .collect::<Vec<_>>()
-            .join("\n");
+            .collect();
+        let token_row = rows
+            .iter()
+            .find(|r| r.contains("11,975"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "the running token count should be visible:\n{}",
+                    rows.join("\n")
+                )
+            });
+        // The figure is the round total, not input-only, so the row that carries
+        // it must not label it with the '↑' (sent) marker. Checked on that row
+        // alone — '↑' legitimately appears in unrelated chrome elsewhere.
         assert!(
-            screen.contains("11,975"),
-            "the running token count should be visible on screen:\n{screen}"
-        );
-        // The total is not input-only, so it must not carry the ↑ (sent) marker.
-        assert!(
-            !screen.contains('↑'),
-            "the total must not be labelled with the input-only ↑ marker:\n{screen}"
+            !token_row.contains('↑'),
+            "the total must not carry the input-only ↑ marker: {token_row}"
         );
     }
 

--- a/src/ai/tui.rs
+++ b/src/ai/tui.rs
@@ -342,6 +342,7 @@ fn event_label(event: &ChatEvent) -> String {
         ChatEvent::Delta(t) => format!("answer_delta ({} chars)", t.chars().count()),
         ChatEvent::ThinkingDelta(t) => format!("thinking_delta ({} chars)", t.chars().count()),
         ChatEvent::ThinkingFinished => "thinking_finished".to_string(),
+        ChatEvent::TokenUsage(usage) => format!("token_usage total={}", usage.total_tokens),
         ChatEvent::Status(s) => format!("status {s}"),
         ChatEvent::ToolStarted(name) => format!("tool_started {name}"),
         ChatEvent::ToolFinished { name, ok } => format!("tool_finished {name} ok={ok}"),
@@ -5330,6 +5331,17 @@ fn render_turn_status(f: &mut ratatui::Frame, area: Rect, ui: &mut Ui, state: &C
             Style::default().fg(Color::DarkGray),
         ));
     }
+    // The round's token count, rolling up as the server reports it — the same
+    // place Claude Code keeps it, inline with the timer while the turn runs.
+    if let Some(usage) = state.token_usage.filter(|u| !u.is_empty()) {
+        spans.push(Span::styled(
+            format!(
+                "   · ↑ {}",
+                t!("Agent.Tokens", total = group_thousands(usage.total_tokens))
+            ),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
     // A spinner spins the same whether the agent is working or the stream has
     // gone quiet, which is the whole of "it looks stuck". Once the silence is
     // long enough to be worth naming, say how long it has lasted — during a slow
@@ -5609,6 +5621,25 @@ fn tool_line(name: &str, status: ToolStatus, width: usize) -> Line<'static> {
         ));
     }
     Line::from(spans)
+}
+
+/// Group an integer with thousands separators, e.g. `2810` → `2,810`. Token
+/// counts read far more easily grouped than as one long run of digits, and B/M/K
+/// scaling would lose the exact figure this is meant to report.
+fn group_thousands(n: u64) -> String {
+    let digits = n.to_string();
+    let len = digits.len();
+    let mut out = String::with_capacity(len + len / 3);
+    for (i, ch) in digits.chars().enumerate() {
+        // A separator falls before a digit when a whole number of groups of
+        // three still follows it. Counting from the right avoids the underflow
+        // a left-anchored offset hits when the leading group is shorter than i.
+        if i != 0 && (len - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out
 }
 
 fn push_message(
@@ -6664,6 +6695,15 @@ mod tests {
     use super::marquee;
     use unicode_width::UnicodeWidthStr;
 
+    #[test]
+    fn thousands_are_grouped() {
+        assert_eq!(super::group_thousands(0), "0");
+        assert_eq!(super::group_thousands(210), "210");
+        assert_eq!(super::group_thousands(2810), "2,810");
+        assert_eq!(super::group_thousands(11975), "11,975");
+        assert_eq!(super::group_thousands(1_000_000), "1,000,000");
+    }
+
     /// One view, one name — see the market TUI's equivalent. A duplicate would
     /// merge two views in every report without failing anywhere.
     #[test]
@@ -6925,6 +6965,45 @@ mod tests {
             flush,
             "the palette should rest on the prompt box:\n{}",
             rows.join("\n")
+        );
+    }
+
+    /// The whole point of the feature: while a turn runs, its rolling token
+    /// count shows inline with the timer on the status row (as Claude Code does).
+    /// Renders a full frame mid-turn and looks for it in the buffer.
+    #[test]
+    fn token_usage_shows_on_the_running_turn_row() {
+        use crate::openapi::chats::TokenUsage;
+        let mut ui = super::Ui::new();
+        let mut state = super::ChatState::new("chatbot".into(), "welcome".into());
+        let editor = super::Editor::new();
+        // A turn in flight (busy), with a token frame already delivered.
+        state.apply(super::ChatEvent::UserPrompt("how is TSLA?".into()));
+        ui.turn_started = Some(std::time::Instant::now());
+        state.apply(super::ChatEvent::TokenUsage(TokenUsage {
+            prompt_tokens: 11939,
+            completion_tokens: 36,
+            total_tokens: 11975,
+        }));
+        state.apply(super::ChatEvent::Delta("TSLA is up.".into()));
+
+        let backend = ratatui::backend::TestBackend::new(80, 20);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|f| super::view(f, &mut ui, &mut state, &editor))
+            .expect("draw");
+        let buf = terminal.backend().buffer().clone();
+        let screen: String = (0..buf.area.height)
+            .map(|y| {
+                (0..buf.area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            screen.contains("11,975"),
+            "the running token count should be visible on screen:\n{screen}"
         );
     }
 

--- a/src/cli/agent/chat.rs
+++ b/src/cli/agent/chat.rs
@@ -888,8 +888,15 @@ fn print_footer(agent_uid: &str, outcome: &ChatOutcome) {
         .elapsed_time
         .map(|s| t!("Agent.Elapsed", secs = format!("{s:.1}")).to_string())
         .unwrap_or_default();
+    // Only when the run actually reported usage; a cache hit or a pre-rollout
+    // message carries none and must not print "0 tokens".
+    let tokens = outcome
+        .token_usage
+        .filter(|usage| !usage.is_empty())
+        .map(|usage| format!(" · {}", t!("Agent.Tokens", total = usage.total_tokens)))
+        .unwrap_or_default();
     println!(
-        "chat_uid: {} · message_id: {} · {elapsed}",
+        "chat_uid: {} · message_id: {} · {elapsed}{tokens}",
         strip_control_chars(&outcome.chat_uid),
         strip_control_chars(&outcome.message_id)
     );

--- a/src/cli/agent/chat.rs
+++ b/src/cli/agent/chat.rs
@@ -884,22 +884,21 @@ fn print_footer(agent_uid: &str, outcome: &ChatOutcome) {
         }
     }
     println!("─────");
-    let elapsed = outcome
-        .elapsed_time
-        .map(|s| t!("Agent.Elapsed", secs = format!("{s:.1}")).to_string())
-        .unwrap_or_default();
-    // Only when the run actually reported usage; a cache hit or a pre-rollout
-    // message carries none and must not print "0 tokens".
-    let tokens = outcome
-        .token_usage
-        .filter(|usage| !usage.is_empty())
-        .map(|usage| format!(" · {}", t!("Agent.Tokens", total = usage.total_tokens)))
-        .unwrap_or_default();
-    println!(
-        "chat_uid: {} · message_id: {} · {elapsed}{tokens}",
-        strip_control_chars(&outcome.chat_uid),
-        strip_control_chars(&outcome.message_id)
-    );
+    // The trailing stats are each optional (a read-back run has no elapsed
+    // time; a cache hit reports no usage — and "0 tokens" must not print), so
+    // they are collected and joined rather than concatenated, which left a
+    // dangling separator whenever an earlier one was absent.
+    let mut parts = vec![
+        format!("chat_uid: {}", strip_control_chars(&outcome.chat_uid)),
+        format!("message_id: {}", strip_control_chars(&outcome.message_id)),
+    ];
+    if let Some(secs) = outcome.elapsed_time {
+        parts.push(t!("Agent.Elapsed", secs = format!("{secs:.1}")).to_string());
+    }
+    if let Some(usage) = outcome.token_usage.filter(|usage| !usage.is_empty()) {
+        parts.push(t!("Agent.Tokens", total = usage.total_tokens).to_string());
+    }
+    println!("{}", parts.join(" · "));
     // Same treatment as `continue_hint`: this line is meant to be pasted into
     // a shell, so every server-supplied argument is stripped and quoted.
     println!(

--- a/src/cli/agent/client.rs
+++ b/src/cli/agent/client.rs
@@ -709,6 +709,12 @@ async fn read_back_answer(
     if !text.is_empty() {
         on_event(AgentEvent::AnswerDelta { text });
     }
+    // The stored usage equals the stream's final frame (the server writes the
+    // round's cumulative total), so history restores what the dead connection
+    // never delivered — and what the restart announcement above cleared.
+    if let Some(usage) = msg.token_usage.filter(|usage| !usage.is_empty()) {
+        on_event(AgentEvent::TokenUsage(usage));
+    }
     let status = recovered_status(msg.status);
     on_event(AgentEvent::WorkflowFinished {
         status: status.to_string(),
@@ -754,6 +760,12 @@ async fn finalize_from_history(
                     ));
                     break;
                 };
+                // The frame that would have carried the round's final total is
+                // exactly what the truncated stream lost; the stored value is
+                // its equal, so supply it alongside the verdict.
+                if let Some(usage) = msg.token_usage.filter(|usage| !usage.is_empty()) {
+                    on_event(AgentEvent::TokenUsage(usage));
+                }
                 on_event(AgentEvent::WorkflowFinished {
                     status: recovered_status(msg.status).to_string(),
                     references: msg.references(),

--- a/src/cli/agent/client.rs
+++ b/src/cli/agent/client.rs
@@ -313,6 +313,14 @@ fn map_event(ev: ConversationStreamEvent) -> Option<AgentEvent> {
         ConversationStreamEvent::ChatTitleUpdated(p) => {
             AgentEvent::ChatTitleUpdated { title: p.title }
         }
+        // The SDK has no typed variant for `token_usage`, so it arrives here as
+        // a raw event carrying the cumulative counts for the round.
+        ConversationStreamEvent::Other { event, data } if event == "token_usage" => {
+            match crate::openapi::chats::TokenUsage::from_data(&data) {
+                Some(usage) => AgentEvent::TokenUsage(usage),
+                None => return None,
+            }
+        }
         ConversationStreamEvent::Other { event, .. } => AgentEvent::Unknown { event },
         // Progress-only events the CLI does not display.
         ConversationStreamEvent::Ping

--- a/src/cli/agent/events.rs
+++ b/src/cli/agent/events.rs
@@ -8,6 +8,8 @@
 use longbridge::agent::Reference;
 use serde_json::Value;
 
+use crate::openapi::chats::TokenUsage;
+
 // `PartialEq` is intentionally not derived: `WorkflowFinished` now carries the
 // SDK's `Reference`, which is not `PartialEq`. Tests match on variants instead.
 #[derive(Debug, Clone)]
@@ -32,6 +34,10 @@ pub enum AgentEvent {
     },
     ThinkingStarted,
     ThinkingFinished,
+    /// The turn's cumulative token consumption so far. Each frame is the running
+    /// total for the round, not an increment — consumers overwrite rather than
+    /// add, so a dropped or replayed frame never skews the count.
+    TokenUsage(TokenUsage),
     ToolUseStarted {
         tool_name: String,
     },
@@ -128,6 +134,9 @@ pub fn parse_data_line(payload: &str) -> Option<AgentEvent> {
         },
         "thinking_started" => AgentEvent::ThinkingStarted,
         "thinking_finished" => AgentEvent::ThinkingFinished,
+        // A frame with no real usage (an all-zero object) carries nothing worth
+        // surfacing, so it is dropped rather than turned into a "0 tokens" event.
+        "token_usage" => return TokenUsage::from_data(&data).map(AgentEvent::TokenUsage),
         "node_tool_use_started" => AgentEvent::ToolUseStarted {
             tool_name: str_field(&data, "tool_name"),
         },
@@ -228,6 +237,9 @@ pub struct ChatOutcome {
     pub further_questions: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub elapsed_time: Option<f64>,
+    /// The round's final cumulative token usage, if the stream reported any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_usage: Option<TokenUsage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interrupt: Option<Value>,
     #[serde(skip_serializing_if = "String::is_empty")]
@@ -251,6 +263,9 @@ impl ChatAggregator {
                 self.outcome.message_id.clone_from(message_id);
             }
             AgentEvent::AnswerDelta { text } => self.outcome.answer.push_str(text),
+            // Cumulative for the round: overwrite, never accumulate, so a replay
+            // on reconnect cannot double the count.
+            AgentEvent::TokenUsage(usage) => self.outcome.token_usage = Some(*usage),
             // The reconnected run replays this message from the beginning, so
             // keeping the interrupted connection's partial answer would double
             // its prefix.
@@ -261,6 +276,10 @@ impl ChatAggregator {
                 self.outcome.error_message.clear();
                 self.outcome.status.clear();
                 self.outcome.interrupt = None;
+                // The replay re-emits this round's cumulative token frames, so
+                // drop the old total rather than letting a stale one linger if
+                // the replay happens not to carry one.
+                self.outcome.token_usage = None;
             }
             AgentEvent::HumanInteractionRequired { interrupt } => {
                 self.outcome.status = "interrupted".to_string();
@@ -515,6 +534,43 @@ mod tests {
     #[test]
     fn unparseable_payload_returns_none() {
         assert!(parse_data_line("not json").is_none());
+    }
+
+    #[test]
+    fn token_usage_is_parsed_from_its_inner_data() {
+        let payload = r#"{"event":"token_usage","workflow_run_id":"7431982450123456","data":{"prompt_tokens":2600,"completion_tokens":210,"total_tokens":2810}}"#;
+        let Some(AgentEvent::TokenUsage(usage)) = parse_data_line(payload) else {
+            panic!("expected TokenUsage");
+        };
+        assert_eq!(usage.prompt_tokens, 2600);
+        assert_eq!(usage.completion_tokens, 210);
+        assert_eq!(usage.total_tokens, 2810);
+    }
+
+    #[test]
+    fn an_all_zero_token_usage_frame_is_dropped() {
+        let payload = r#"{"event":"token_usage","data":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}"#;
+        assert!(parse_data_line(payload).is_none());
+    }
+
+    /// Each frame is the running total, so the aggregate takes the latest value
+    /// rather than summing — a replay on reconnect must not double it.
+    #[test]
+    fn token_usage_overwrites_rather_than_accumulates() {
+        use crate::openapi::chats::TokenUsage;
+        let mut agg = ChatAggregator::default();
+        agg.push(&AgentEvent::TokenUsage(TokenUsage {
+            prompt_tokens: 1200,
+            completion_tokens: 80,
+            total_tokens: 1280,
+        }));
+        agg.push(&AgentEvent::TokenUsage(TokenUsage {
+            prompt_tokens: 2600,
+            completion_tokens: 210,
+            total_tokens: 2810,
+        }));
+        let outcome = agg.finish();
+        assert_eq!(outcome.token_usage.unwrap().total_tokens, 2810);
     }
 
     #[test]

--- a/src/cli/agent/mod.rs
+++ b/src/cli/agent/mod.rs
@@ -512,6 +512,13 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<crate::cli::schema::Res
                     "Run duration in seconds; null when the run did not finish",
                 ),
                 field(
+                    "token_usage",
+                    "object | absent",
+                    "Cumulative token usage for the round: {prompt_tokens, \
+                     completion_tokens, total_tokens}. Absent when the round \
+                     consumed none (cache hit) or the server did not report it",
+                ),
+                field(
                     "interrupt",
                     "object | null",
                     "Present when status=interrupted: {tool_call_id, questions[]}. \

--- a/src/openapi/chats.rs
+++ b/src/openapi/chats.rs
@@ -35,6 +35,40 @@ pub struct ChatsResponse {
     pub chats: Vec<Chat>,
 }
 
+/// Token consumption for one assistant message / conversation round.
+///
+/// Counts are cumulative for the whole round — the main agent's tool loop, any
+/// subagents, and any delegated agents — not per model call, so the last frame
+/// of a stream equals the value read back from history. The key is omitted
+/// entirely (rather than sent as a zeroed object) whenever a round consumed no
+/// tokens — a user message, a cache hit, or a message stored before this field
+/// existed — so it is carried as an `Option` and never rendered as a
+/// "0 tokens" placeholder. See `token-usage-client-integration.md`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct TokenUsage {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    pub total_tokens: u64,
+}
+
+impl TokenUsage {
+    /// Parse from an SSE `token_usage` frame's inner `data` object, dropping a
+    /// frame that carries no real usage. `None` — rather than a zeroed value —
+    /// so callers never render a "0 tokens" placeholder for an empty frame.
+    pub fn from_data(data: &serde_json::Value) -> Option<Self> {
+        serde_json::from_value::<Self>(data.clone())
+            .ok()
+            .filter(|usage| !usage.is_empty())
+    }
+
+    /// Whether this carries a real total worth showing. An all-zero usage is
+    /// treated the same as an absent one.
+    pub fn is_empty(&self) -> bool {
+        self.total_tokens == 0
+    }
+}
+
 /// One content chunk of a [`ChatMessage`].
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
@@ -62,6 +96,12 @@ pub struct ChatMessage {
     pub likes: i32,
     pub parent_message_id: i64,
     pub thinking_seconds: i32,
+    /// Cumulative token usage for this message's round. Absent (`None`) for
+    /// user messages, cache hits, and messages stored before this field
+    /// existed — see [`TokenUsage`]. Omitted from serialized output when absent,
+    /// matching the server's own "omit, don't zero" contract.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_usage: Option<TokenUsage>,
     pub error_code: i32,
     pub workflow_run_id: String,
     pub created_at: i64,
@@ -170,7 +210,45 @@ impl ChatMessage {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChatMessage, ChatMessageChunk};
+    use super::{ChatMessage, ChatMessageChunk, TokenUsage};
+
+    /// A history message carries its round's token usage as an optional
+    /// top-level field, absent (`None`) when the round consumed none.
+    #[test]
+    fn token_usage_is_read_from_a_history_message() {
+        let with: ChatMessage = serde_json::from_value(serde_json::json!({
+            "sender": "assistant",
+            "thinking_seconds": 12,
+            "token_usage": {
+                "prompt_tokens": 2600,
+                "completion_tokens": 210,
+                "total_tokens": 2810,
+            },
+        }))
+        .unwrap();
+        assert_eq!(with.token_usage.unwrap().total_tokens, 2810);
+
+        // The key is omitted entirely when there is nothing to show.
+        let without: ChatMessage = serde_json::from_value(serde_json::json!({
+            "sender": "user",
+        }))
+        .unwrap();
+        assert!(without.token_usage.is_none());
+    }
+
+    /// An SSE frame's inner `data` parses into usage; an all-zero one is treated
+    /// as no usage at all.
+    #[test]
+    fn token_usage_from_data_drops_empty_frames() {
+        let real = TokenUsage::from_data(&serde_json::json!({
+            "prompt_tokens": 1200, "completion_tokens": 80, "total_tokens": 1280,
+        }));
+        assert_eq!(real.unwrap().total_tokens, 1280);
+        assert!(TokenUsage::from_data(&serde_json::json!({
+            "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0,
+        }))
+        .is_none());
+    }
 
     fn chunk(kind: &str, content: &str) -> ChatMessageChunk {
         ChatMessageChunk {


### PR DESCRIPTION
## What

Surfaces the token consumption the LongbridgeAI agent reports for a conversation round, in the `longbridge ai` chat TUI — rendered inline with the timer on the running turn's status row, rolling up as the server reports it (the same place Claude Code keeps it):

```
⠋  Generating…   · ↑ 11,975 tokens                                      [stop]
╭──────────────────────────────────────────────────────────────────────────────╮
│❯ Ask anything — press / for commands                                         │
╰──────────────────────────────────────────────────────────────────────────────╯
```

Follows the backend contract in `token-usage-client-integration.md`.

## How

- **New `token_usage` SSE event** — the SDK has no typed variant, so it arrives as `ConversationStreamEvent::Other`. Map it to a typed `AgentEvent::TokenUsage` in both the live SDK path (`client.rs`) and the reconnect parser (`events.rs`).
- **Overwrite, not accumulate** — each frame is the round's running total, so `ChatAggregator`/`ChatState` replace the value rather than sum it; a replay on reconnect can never double the count. Frames are also cleared on `StreamInterrupted`.
- **No "0 tokens" placeholder** — an all-zero frame is dropped at parse time; a round that consumed no tokens (cache hit, etc.) shows nothing.
- **History** — `ChatMessage` reads the optional top-level `token_usage` field back (omitted from serialized output when absent).
- **CLI** — `agent chat` gains the round total on its footer and in `--format json` (`ChatOutcome.token_usage`).

## Verification

- `cargo fmt` clean; `cargo clippy` delta vs `main` is **zero** new findings.
- `cargo test`: **801 pass**, including new coverage for SSE parsing, overwrite semantics, empty-frame dropping, history read-back, thousands grouping, and a full-frame `TestBackend` render asserting the count appears on the running turn row.
- Confirmed live against the API: a real `agent chat` turn returns `token_usage {prompt: 11939, completion: 36, total: 11975}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)