### PR TITLE
cli: Make switching stocks in the TUI fast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "longbridge-terminal"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "aes-gcm",
  "ansi-parser",

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -102,8 +102,8 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
                     "repinned_by_latency": repinned.is_some(),
                 },
                 "connectivity": {
-                    "global": { "url": region::HTTP_URL_GLOBAL, "ok": global.ok, "ms": global.ms },
-                    "cn":     { "url": region::HTTP_URL_CN, "ok": cn.ok, "ms": cn.ms },
+                    "global": { "url": region::QUOTE_WS_URL_GLOBAL, "ok": global.ok, "ms": global.ms },
+                    "cn":     { "url": region::QUOTE_WS_URL_CN, "ok": cn.ok, "ms": cn.ms },
                 },
             });
             println!("{}", serde_json::to_string_pretty(&value)?);
@@ -143,8 +143,11 @@ pub async fn cmd_check(format: &OutputFormat) -> Result<()> {
 
             println!();
             println!("Connectivity {DIM}(avg of {PROBE_COUNT}){RESET}");
-            println!("{}", probe_line("global", &global, region::HTTP_URL_GLOBAL));
-            println!("{}", probe_line("cn", &cn, region::HTTP_URL_CN));
+            println!(
+                "{}",
+                probe_line("global", &global, region::QUOTE_WS_URL_GLOBAL)
+            );
+            println!("{}", probe_line("cn", &cn, region::QUOTE_WS_URL_CN));
             if let Some(measured_is_cn) = repinned {
                 let (winner, loser) = if measured_is_cn {
                     ("cn", "global")

--- a/src/region.rs
+++ b/src/region.rs
@@ -3,8 +3,9 @@
 /// On each startup:
 /// 1. `refresh_region_cache()` re-probes geotest.lbkrs.com if the cached
 ///    verdict is older than `CACHE_TTL_SECS`, and persists the result.
-/// 2. `spawn_latency_repin()` measures both access points in the background and
-///    repins to the better one, so a wrong verdict repairs itself.
+/// 2. `spawn_latency_repin()` measures both access points' quote hosts in the
+///    background and repins to the better one, so a wrong verdict repairs
+///    itself.
 /// 3. `is_cn_cached()` reads that verdict from disk for use in the Config
 ///    builder.
 ///
@@ -18,14 +19,14 @@ use std::{
 const GEOTEST_URL: &str = "https://geotest.lbkrs.com";
 const GEOTEST_TIMEOUT_SECS: u64 = 2;
 
-/// Timeout for one access-point health request.
+/// Timeout for one access-point probe request.
 pub const CONNECT_TIMEOUT_SECS: u64 = 5;
 
 /// How long the background probe holds off before its first request, so the
 /// command's own startup has the network and the runtime to itself.
 const PROBE_START_DELAY: Duration = Duration::from_secs(3);
 
-/// Health requests per access point, averaged after dropping the fastest and
+/// Probe requests per access point, averaged after dropping the fastest and
 /// slowest. Enough samples that one stalled request cannot decide a repin.
 pub const PROBE_COUNT: usize = 10;
 
@@ -70,6 +71,11 @@ fn repin_from_latency(is_cn: bool, global: &ProbeStats, cn: &ProbeStats) -> Opti
 /// Measures HTTPS warm-connection latency with `PROBE_COUNT` requests.
 /// Sends one warm-up request first to establish the connection, then
 /// drops the fastest and slowest sample from the measured runs and averages the rest.
+///
+/// A reply — any reply the server itself wrote — is what proves the access point
+/// reachable and times the path to it. The quote host answers a plain GET with a
+/// 400 and a WebSocket handshake complaint, and that is a healthy answer from
+/// it; only a transport failure or a timeout means unreachable.
 async fn probe(url: &str) -> ProbeStats {
     let Ok(client) = reqwest::Client::builder()
         .timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
@@ -86,10 +92,9 @@ async fn probe(url: &str) -> ProbeStats {
         let start = Instant::now();
         match client.get(url).send().await {
             Ok(resp) => {
-                let body = resp.text().await.unwrap_or_default();
-                if body.trim() != "success" {
-                    return ProbeStats { ok: false, ms: 0 };
-                }
+                // Drain the body so the timing covers the whole exchange and the
+                // connection stays reusable for the next sample.
+                let _ = resp.bytes().await;
             }
             Err(_) => return ProbeStats { ok: false, ms: 0 },
         }
@@ -103,12 +108,28 @@ async fn probe(url: &str) -> ProbeStats {
 
 /// Measure both access points at once. The pair is what a repin decision needs:
 /// either one alone says nothing about which is better.
+///
+/// The quote host is what gets measured, not `openapi.<tld>/health`, because it
+/// is the host the reader waits on: every price, chart and trade list crosses
+/// it, one request at a time. The two are not interchangeable, and on a
+/// connection where they disagree the health endpoint is the one that is wrong —
+/// measured from Shanghai, `openapi.longbridge.cn/health` answers in 58ms
+/// against 120ms for `.com` while the quote host it is standing in for is the
+/// other way round, 370ms against 215ms, and a `kline` command takes 2.5s on the
+/// access point the health check preferred against 0.85s on the other.
 pub async fn probe_access_points() -> (ProbeStats, ProbeStats) {
-    let (global, cn) = (
-        format!("{HTTP_URL_GLOBAL}/health"),
-        format!("{HTTP_URL_CN}/health"),
-    );
+    let (global, cn) = (probe_url(QUOTE_WS_URL_GLOBAL), probe_url(QUOTE_WS_URL_CN));
     tokio::join!(probe(&global), probe(&cn))
+}
+
+/// The quote endpoint as something `reqwest` can GET: same host, same port,
+/// plain HTTP scheme.
+fn probe_url(ws_url: &str) -> String {
+    match ws_url.split_once("://") {
+        Some(("wss", rest)) => format!("https://{rest}"),
+        Some(("ws", rest)) => format!("http://{rest}"),
+        _ => ws_url.to_string(),
+    }
 }
 
 /// How long a probed verdict is trusted before it is re-checked. Long enough
@@ -503,6 +524,39 @@ fn parse_geotest_country(body: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The probe has to reach the same host the quotes come from, so it takes
+    /// the endpoint the SDK uses and only swaps the scheme.
+    #[test]
+    fn the_probe_url_keeps_the_quote_host_and_path() {
+        assert_eq!(
+            probe_url("wss://openapi-quote.longbridge.com/v2"),
+            "https://openapi-quote.longbridge.com/v2"
+        );
+        assert_eq!(
+            probe_url("ws://127.0.0.1:8080/v2"),
+            "http://127.0.0.1:8080/v2"
+        );
+        // Already plain, or an unrecognised scheme: left alone rather than mangled.
+        assert_eq!(
+            probe_url("https://example.test/v2"),
+            "https://example.test/v2"
+        );
+    }
+
+    /// Both constants must stay reachable by the probe; a scheme change that
+    /// slipped past `probe_url` would make both access points look unreachable
+    /// and freeze the verdict wherever it happened to be.
+    #[test]
+    fn both_access_points_produce_http_probe_urls() {
+        for url in [QUOTE_WS_URL_GLOBAL, QUOTE_WS_URL_CN] {
+            let probed = probe_url(url);
+            assert!(
+                probed.starts_with("http://") || probed.starts_with("https://"),
+                "{url} probes as {probed}"
+            );
+        }
+    }
 
     #[test]
     fn parses_country_code_from_geotest_body() {

--- a/src/tui/kline.rs
+++ b/src/tui/kline.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::RwLock};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Mutex, RwLock},
+};
 
 use crate::data::{AdjustType, Counter, Kline, KlineType, Klines};
 use rust_decimal::Decimal;
@@ -10,13 +13,54 @@ type StoreKey = (Counter, KlineType, AdjustType);
 #[derive(Debug)]
 pub struct KlineStore {
     inner: RwLock<HashMap<StoreKey, (bool /* no more history */, Klines)>>,
+    /// Series with a request already on the wire.
+    ///
+    /// `by_pagination` is called from inside the render closure, so a series
+    /// that is not in the store yet is asked for again on every frame — thirty
+    /// times a second for as long as the fetch takes. The quote SDK runs one
+    /// command at a time and awaits each round trip, so those duplicates do not
+    /// merely waste quota: they take the single request slot away from the
+    /// quote, trades and static-info calls the same stock switch is waiting on.
+    /// One request per series at a time; the next frame re-asks if it is still
+    /// missing when the first one lands.
+    inflight: Mutex<HashSet<StoreKey>>,
+}
+
+/// Clears the in-flight mark when the request task ends, including when the
+/// task is dropped part-way through.
+struct InflightGuard(StoreKey);
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        KLINES.inflight.lock().expect("poison").remove(&self.0);
+    }
 }
 
 impl KlineStore {
     fn new() -> Self {
         Self {
             inner: RwLock::default(),
+            inflight: Mutex::default(),
         }
+    }
+
+    /// The key a series is stored under: below the daily period every adjust
+    /// type shares one entry, because the adjustment is applied on read.
+    fn key(counter: &Counter, kline_type: KlineType, adjust_type: AdjustType) -> StoreKey {
+        (
+            counter.clone(),
+            kline_type,
+            Self::normalize(kline_type).unwrap_or(adjust_type),
+        )
+    }
+
+    /// Marks a series as being fetched, or reports that it already is.
+    fn begin_request(&self, key: &StoreKey) -> Option<InflightGuard> {
+        self.inflight
+            .lock()
+            .expect("poison")
+            .insert(key.clone())
+            .then(|| InflightGuard(key.clone()))
     }
 
     pub fn by_pagination(
@@ -27,19 +71,16 @@ impl KlineStore {
         page: usize,
         page_size: usize,
     ) -> Klines {
+        let key = Self::key(&counter, kline_type, adjust_type);
         let store = self.inner.read().expect("poison");
-        let Some((has_more, entries)) = store.get(&(
-            counter.clone(),
-            kline_type,
-            Self::normalize(kline_type).unwrap_or(adjust_type),
-        )) else {
-            crate::tui::app::RT.get().unwrap().spawn(Self::request(
+        let Some((has_more, entries)) = store.get(&key) else {
+            self.spawn_request(
+                key,
                 counter,
                 kline_type,
                 adjust_type,
-                0,
                 (page + 1) * page_size,
-            ));
+            );
             return Klines::default();
         };
 
@@ -52,13 +93,7 @@ impl KlineStore {
         };
 
         if *has_more && results.len() < page_size {
-            crate::tui::app::RT.get().unwrap().spawn(Self::request(
-                counter,
-                kline_type,
-                adjust_type,
-                entries.first().map(|e| e.timestamp).unwrap_or_default(),
-                page_size,
-            ));
+            self.spawn_request(key, counter, kline_type, adjust_type, page_size);
         }
 
         // Fix forward adjust
@@ -84,6 +119,53 @@ impl KlineStore {
         } else {
             results.to_vec()
         }
+    }
+
+    /// Fetch a series the caller is waiting on, unless it is already stored or
+    /// already on the wire.
+    ///
+    /// The difference from [`spawn_request`] is that this one is awaited, so a
+    /// caller can put the chart ahead of its own later requests. The quote SDK
+    /// runs one command at a time, and the chart is by far the largest thing on
+    /// the screen that is blank until its answer arrives, so it goes first.
+    pub async fn ensure(
+        &self,
+        counter: &Counter,
+        kline_type: KlineType,
+        adjust_type: AdjustType,
+        count: usize,
+    ) {
+        let key = Self::key(counter, kline_type, adjust_type);
+        if self.inner.read().expect("poison").contains_key(&key) {
+            return;
+        }
+        let Some(guard) = self.begin_request(&key) else {
+            return;
+        };
+        Self::request(counter.clone(), kline_type, adjust_type, count).await;
+        drop(guard);
+    }
+
+    /// Fetch a series, unless a request for it is already on the wire or the
+    /// reader has already moved off the stock it belongs to.
+    fn spawn_request(
+        &self,
+        key: StoreKey,
+        counter: Counter,
+        kline_type: KlineType,
+        adjust_type: AdjustType,
+        count: usize,
+    ) {
+        if !crate::tui::systems::settled_on(&counter) {
+            return;
+        }
+        let Some(guard) = self.begin_request(&key) else {
+            return;
+        };
+        crate::tui::app::RT.get().unwrap().spawn(async move {
+            Self::request(counter, kline_type, adjust_type, count).await;
+            drop(guard);
+        });
     }
 
     /// Update candlestick data
@@ -131,7 +213,6 @@ impl KlineStore {
         counter: Counter,
         kline_type: KlineType,
         adjust_type: AdjustType,
-        _before: i64,
         count: usize,
     ) {
         // Use Longbridge SDK to request candlestick data

--- a/src/tui/systems/mod.rs
+++ b/src/tui/systems/mod.rs
@@ -37,13 +37,47 @@ pub use watchlist_stock::*;
 // Compatibility type alias
 pub type Component = ();
 
-// WebSocket subscription management (simplified implementation)
-pub struct WsManager;
+/// Which symbols each named mount asked the server to stream.
+///
+/// The split between the two feeds is deliberate. `QUOTE` belongs to the
+/// watchlist and to the index carousel: it is subscribed once and never given
+/// back, which is what keeps a price on screen without a request per screen.
+/// `DEPTH` and `TRADE` belong to whichever single stock the detail view is
+/// showing, and they are the expensive half — an order book pushes many times
+/// a second, and every push deep-copies the stock it lands on. Leaving them
+/// subscribed for every stock ever opened is what made a session get slower
+/// the longer it was used.
+pub struct WsManager {
+    detail: std::sync::Mutex<HashMap<String, Vec<Counter>>>,
+}
+
+/// The feeds only the stock the reader is looking at needs.
+const DETAIL_FLAGS: longbridge::quote::SubFlags =
+    longbridge::quote::SubFlags::DEPTH.union(longbridge::quote::SubFlags::TRADE);
 
 impl WsManager {
-    #[allow(clippy::unused_async, clippy::unused_async_trait_impl)]
-    pub async fn unmount(&self, _name: &str) -> anyhow::Result<()> {
-        // TODO: Use Longbridge SDK to unsubscribe
+    fn new() -> Self {
+        Self {
+            detail: std::sync::Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Release the per-stock feeds this mount holds. `QUOTE` is never released:
+    /// the watchlist behind the detail view is still showing those prices.
+    pub async fn unmount(&self, name: &str) -> anyhow::Result<()> {
+        let symbols = self
+            .detail
+            .lock()
+            .expect("poison")
+            .remove(name)
+            .unwrap_or_default();
+        if symbols.is_empty() {
+            return Ok(());
+        }
+        let symbols: Vec<String> = symbols.iter().map(ToString::to_string).collect();
+        let _ = crate::openapi::quote()
+            .unsubscribe(&symbols, DETAIL_FLAGS)
+            .await;
         Ok(())
     }
 
@@ -53,7 +87,6 @@ impl WsManager {
         symbols: &[Counter],
         _sub_type: SubTypes,
     ) -> anyhow::Result<()> {
-        // TODO: Use Longbridge SDK to resubscribe
         let ctx = crate::openapi::quote();
         let symbol_strings: Vec<String> = symbols
             .iter()
@@ -65,35 +98,74 @@ impl WsManager {
         Ok(())
     }
 
-    pub async fn quote_detail(&self, _name: &str, symbols: &[Counter]) -> anyhow::Result<()> {
-        let ctx = crate::openapi::quote();
+    /// Stream everything the detail view draws for `symbols`.
+    ///
+    /// One `subscribe` for all three feeds rather than one per feed: the quote
+    /// SDK runs a single command at a time and awaits its whole round trip, so
+    /// each extra call is another full network wait in front of the data the
+    /// reader is waiting for. Whatever this mount was streaming before is left
+    /// running and handed to [`release_stale`], which the caller sends once the
+    /// panel is filled — a release is never what the reader is waiting on.
+    pub async fn quote_detail(&self, name: &str, symbols: &[Counter]) -> anyhow::Result<()> {
         let symbol_strings: Vec<String> = symbols
             .iter()
             .map(std::string::ToString::to_string)
             .collect();
-        let _ = ctx
+        {
+            let mut detail = self.detail.lock().expect("poison");
+            let mount = detail.entry(name.to_string()).or_default();
+            for counter in symbols {
+                if !mount.contains(counter) {
+                    mount.push(counter.clone());
+                }
+            }
+        }
+
+        let _ = crate::openapi::quote()
             .subscribe(
                 &symbol_strings,
-                longbridge::quote::SubFlags::QUOTE | longbridge::quote::SubFlags::DEPTH,
+                longbridge::quote::SubFlags::QUOTE | DETAIL_FLAGS,
             )
             .await;
         Ok(())
     }
 
-    pub async fn quote_trade(&self, _name: &str, symbols: &[Counter]) -> anyhow::Result<()> {
-        let ctx = crate::openapi::quote();
-        let symbol_strings: Vec<String> = symbols
-            .iter()
-            .map(std::string::ToString::to_string)
-            .collect();
-        let _ = ctx
-            .subscribe(&symbol_strings, longbridge::quote::SubFlags::TRADE)
-            .await;
+    /// Stop streaming the order book and ticks of everything this mount holds
+    /// except `keep`.
+    ///
+    /// Called off the critical path, after the panel the reader is waiting for
+    /// is filled. Until it runs, a walk down a watchlist leaves a trail of open
+    /// order books, and every one of them pushes several times a second into a
+    /// panel nobody is looking at.
+    pub async fn release_stale(&self, name: &str, keep: &[Counter]) -> anyhow::Result<()> {
+        let stale: Vec<String> = {
+            let detail = self.detail.lock().expect("poison");
+            let Some(mount) = detail.get(name) else {
+                return Ok(());
+            };
+            mount
+                .iter()
+                .filter(|counter| !keep.contains(counter))
+                .map(ToString::to_string)
+                .collect()
+        };
+        if stale.is_empty() {
+            return Ok(());
+        }
+        crate::openapi::quote()
+            .unsubscribe(&stale, DETAIL_FLAGS)
+            .await?;
+        // Forgotten only once the server has been told, so a task cancelled
+        // part-way through leaves them on the books for the next release to
+        // pick up rather than stranding them subscribed for the session.
+        if let Some(mount) = self.detail.lock().expect("poison").get_mut(name) {
+            mount.retain(|counter| keep.contains(counter));
+        }
         Ok(())
     }
 }
 
-pub static WS: std::sync::LazyLock<WsManager> = std::sync::LazyLock::new(|| WsManager);
+pub static WS: std::sync::LazyLock<WsManager> = std::sync::LazyLock::new(WsManager::new);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RiskLevel {

--- a/src/tui/systems/portfolio.rs
+++ b/src/tui/systems/portfolio.rs
@@ -737,10 +737,15 @@ mod tests {
 }
 
 pub async fn fetch_holdings() -> anyhow::Result<Vec<Counter>> {
-    let ctx = crate::openapi::trade();
-
-    // Get holdings list
-    match ctx.stock_positions(None).await {
+    // Paced, unlike the rest of the terminal's calls, because this one does not
+    // have the quote socket's one-at-a-time discipline behind it: startup fires
+    // it against the trade connection at the same instant as the watchlist load
+    // on the quote connection, and the server's minimum interval between two
+    // calls is account-wide, not per connection. Racing them returned 429003 on
+    // 14 of 51 launches, and the error was swallowed into an empty holdings
+    // list, so the watchlist silently lost its position markers. The limiter
+    // spaces the two and retries the rejection.
+    match crate::openapi::helpers::get_stock_positions().await {
         Ok(response) => {
             // StockPositionsResponse contains positions from multiple channels
             let mut counters = Vec::new();

--- a/src/tui/systems/stock_detail.rs
+++ b/src/tui/systems/stock_detail.rs
@@ -29,7 +29,13 @@ const EMPTY_PLACEHOLDER: &str = "--";
 
 /// How long a stock must stay selected before it is fetched, so that holding a
 /// cursor down a watchlist does not fetch every row it passes.
-const REFRESH_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(150);
+///
+/// Sized against key auto-repeat rather than against the network: a held arrow
+/// repeats every 25-50ms on the usual settings, so this swallows a held key
+/// while costing a deliberate press as little as possible. It used to be 150ms,
+/// which was most of what a switch cost once the requests behind it were down to
+/// a few hundred milliseconds — dead time in front of every one of them.
+const REFRESH_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(80);
 
 /// Bumped by every refresh; a task whose number is no longer the latest has
 /// been superseded and stops.

--- a/src/tui/systems/stock_detail.rs
+++ b/src/tui/systems/stock_detail.rs
@@ -27,31 +27,61 @@ use super::{Key, NavFooter, PopUp, StockDetail, KLINE_INDEX, KLINE_TYPE};
 
 const EMPTY_PLACEHOLDER: &str = "--";
 
-// Debounce state for stock refresh
-static REFRESH_STOCK_TASK: std::sync::LazyLock<Mutex<Option<JoinHandle<()>>>> =
+/// How long a stock must stay selected before it is fetched, so that holding a
+/// cursor down a watchlist does not fetch every row it passes.
+const REFRESH_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// Bumped by every refresh; a task whose number is no longer the latest has
+/// been superseded and stops.
+///
+/// This replaces an "is a refresh running" flag that turned a refresh away
+/// while another was in flight. A turned-away refresh was never retried, so the
+/// stock the reader had settled on could simply never load. A generation
+/// instead lets the newest selection always win, and makes a superseded task
+/// discard its own late answers rather than write them over the current
+/// stock's.
+static REFRESH_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+/// The task serving the current selection, so a superseded one can be stopped
+/// before it issues another request rather than merely before it stores an
+/// answer. The quote SDK runs one command at a time, so a request a stale task
+/// still manages to send is a full round trip the current stock waits behind.
+static REFRESH_TASK: std::sync::LazyLock<Mutex<Option<JoinHandle<()>>>> =
     std::sync::LazyLock::new(|| Mutex::new(None));
-// Flag to track if a refresh is currently executing
-static REFRESH_EXECUTING: Atomic<bool> = Atomic::new(false);
+/// How many candles the chart last asked for, which depends on how wide it was
+/// drawn. Zero until the first frame that draws a chart.
+static CHART_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+/// The stock the reader has actually stopped on, as opposed to the ones the
+/// cursor passed over on the way. Set once the debounce elapses.
+static SETTLED: std::sync::LazyLock<Mutex<Option<Counter>>> =
+    std::sync::LazyLock::new(|| Mutex::new(None));
 // Flag set when the API returns no data for the current symbol
 static STOCK_NOT_FOUND: Atomic<bool> = Atomic::new(false);
 
-// RAII guard to ensure REFRESH_EXECUTING is always cleared
-struct RefreshGuard;
+/// Whether this task still speaks for the stock on screen.
+fn is_current(generation: u64) -> bool {
+    REFRESH_GENERATION.load(Ordering::Relaxed) == generation
+}
 
-impl RefreshGuard {
-    fn try_acquire() -> Option<Self> {
-        if REFRESH_EXECUTING.swap(true, Ordering::Relaxed) {
-            None
-        } else {
-            Some(RefreshGuard)
-        }
+/// Ask for a frame.
+///
+/// Renders only happen when something is marked dirty, so a task that has just
+/// changed what is on screen has to say so; otherwise the change waits for
+/// whatever push or keystroke comes next.
+fn request_redraw() {
+    if let Some(tx) = crate::tui::app::UPDATE_TX.get() {
+        let _ = tx.send(bevy_ecs::system::CommandQueue::default());
     }
 }
 
-impl Drop for RefreshGuard {
-    fn drop(&mut self) {
-        REFRESH_EXECUTING.store(false, Ordering::Relaxed);
-    }
+/// Whether `counter` is the stock the detail view has settled on.
+///
+/// The candlestick store asks this before sending a request. Its reads happen
+/// inside the render closure, which runs while the cursor is still moving, so
+/// without this a walk down a watchlist queues a chart request for every row it
+/// passes — and each one delays the chart of the row the reader actually stops
+/// on, because they all queue behind each other on one connection.
+pub fn settled_on(counter: &Counter) -> bool {
+    SETTLED.lock().expect("poison").as_ref() == Some(counter)
 }
 
 pub fn render_stock(
@@ -706,6 +736,9 @@ pub(crate) fn stock_detail(
                 (width, selected / width, selected % width)
             })
             .unwrap_or_default();
+        // Remembered so the refresh task can ask for the chart itself, ahead of
+        // its own requests, instead of waiting for a frame to ask for it.
+        CHART_COUNT.store((page + 1) * width, Ordering::Relaxed);
         let samples = KLINES.by_pagination(
             counter.clone(),
             kline_type,
@@ -921,88 +954,233 @@ pub(crate) fn stock_detail(
     }
 }
 
-/// Debounced version of `refresh_stock` with 50ms delay
-/// Cancels previous pending requests if a new one arrives within the debounce window
-/// Also prevents multiple concurrent executions
-pub fn refresh_stock_debounced(counter: Counter) {
-    // Cancel previous pending task if it exists
-    if let Ok(mut task_guard) = REFRESH_STOCK_TASK.lock() {
-        if let Some(task) = task_guard.take() {
-            task.abort();
+/// The rows either side of `counter` in the watchlist, nearest-below first.
+///
+/// Empty when the stock is not in the watchlist at all — a symbol opened from
+/// search has no neighbours to read ahead of.
+fn watchlist_neighbours(counter: &Counter) -> Vec<Counter> {
+    let watchlist = crate::tui::app::WATCHLIST.read().expect("poison");
+    let counters = watchlist.counters();
+    let Some(index) = counters.iter().position(|c| c == counter) else {
+        return Vec::new();
+    };
+    [
+        Some(index + 1).filter(|i| *i < counters.len()),
+        index.checked_sub(1),
+    ]
+    .into_iter()
+    .flatten()
+    .map(|i| counters[i].clone())
+    .collect()
+}
+
+/// How long the selection must hold still, after its own stock is fully loaded,
+/// before the rows around it are fetched too.
+///
+/// A reader moving through the list is not reading it, and work started on
+/// their behalf would only sit in front of the stock they are moving towards.
+const READ_AHEAD_IDLE: std::time::Duration = std::time::Duration::from_millis(600);
+
+/// Fill the chart and trade list of the neighbouring rows while the connection
+/// would otherwise be idle.
+///
+/// This is what a stock switch costs: the quote SDK serves one request at a
+/// time, so a stock nobody has opened yet needs a chart and a trade list
+/// fetched one after the other before its panel is whole — about a second, and
+/// no amount of reordering removes it. What removes it is not needing the
+/// requests: a reader who stops on a row is, by then, several hundred
+/// milliseconds from moving to the one above or below it, and the connection is
+/// doing nothing. Every check below hands the connection straight back the
+/// moment the selection moves.
+async fn read_ahead(counter: &Counter, generation: u64, chart_count: usize) {
+    if chart_count == 0 {
+        return;
+    }
+    tokio::time::sleep(READ_AHEAD_IDLE).await;
+    let kline_type = KLINE_TYPE.load(Ordering::Relaxed);
+    for neighbour in watchlist_neighbours(counter) {
+        if !is_current(generation) {
+            return;
         }
+        KLINES
+            .ensure(
+                &neighbour,
+                kline_type,
+                crate::data::AdjustType::ForwardAdjust,
+                chart_count,
+            )
+            .await;
 
-        // Reset not-found flag whenever a new refresh starts
-        STOCK_NOT_FOUND.store(false, Ordering::Relaxed);
-
-        // Spawn a new debounced task
-        let handle = RT.get().unwrap().spawn(async move {
-            // Wait 150ms before executing to avoid firing on every stock passed during navigation
-            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-
-            // Try to acquire the execution lock (RAII guard)
-            let Some(_guard) = RefreshGuard::try_acquire() else {
-                tracing::debug!(
-                    "Skipping refresh for {} - another refresh is in progress",
-                    counter
-                );
-                return;
-            };
-
-            tracing::debug!("Starting refresh for {}", counter);
-
-            // Execute the actual refresh
-            let _ = WS
-                .quote_detail("stock_detail", std::slice::from_ref(&counter))
-                .await;
-            let _ = WS
-                .quote_trade("stock_detail", std::slice::from_ref(&counter))
-                .await;
-
-            // Get full quote data (including prev_close and trade_status)
-            let ctx = crate::openapi::quote();
-            if let Ok(quotes) = ctx.quote(&[counter.to_string()]).await {
-                if let Some(quote) = quotes.first() {
-                    STOCKS.modify(counter.clone(), |stock| {
-                        stock.update_from_security_quote(quote);
-                    });
-                } else {
-                    // API returned no data — symbol does not exist
-                    STOCK_NOT_FOUND.store(true, Ordering::Relaxed);
-                    if let Some(tx) = crate::tui::app::UPDATE_TX.get() {
-                        let _ = tx.send(bevy_ecs::system::CommandQueue::default());
-                    }
+        if !is_current(generation) {
+            return;
+        }
+        let has_trades = STOCKS.get(&neighbour).is_some_and(|s| !s.trades.is_empty());
+        if !has_trades {
+            if let Ok(trades) = openapi::quote::fetch_trades(&neighbour.to_string(), 50).await {
+                if !is_current(generation) {
+                    return;
                 }
-            }
-
-            // Get static info (if not already fetched)
-            let should_fetch = STOCKS
-                .get(&counter)
-                .is_some_and(|s| s.static_info.is_none());
-
-            if should_fetch {
-                // Async fetch static info
-                if let Ok(infos) = openapi::quote::fetch_static_info(&[counter.to_string()]).await {
-                    if let Some(info) = infos.into_iter().next() {
-                        STOCKS.modify(counter.clone(), |stock| {
-                            stock.update_from_static_info(info);
-                        });
-                    }
-                }
-            }
-
-            // Get trade records
-            if let Ok(trades) = openapi::quote::fetch_trades(&counter.to_string(), 50).await {
-                STOCKS.modify(counter.clone(), |stock| {
+                STOCKS.modify(neighbour.clone(), |stock| {
                     stock.update_from_trades(&trades);
                 });
             }
+        }
+    }
+}
 
-            tracing::debug!("Completed refresh for {}", counter);
+/// Fetch the full quote for `counter` and store it, reporting whether the stock
+/// is worth drawing at all.
+///
+/// Returns `false` when the symbol does not exist or the refresh was superseded
+/// while the request was out — in both cases there is nothing more for this
+/// task to do.
+async fn fetch_snapshot(counter: &Counter, symbol: &str, generation: u64) -> bool {
+    match crate::openapi::quote().quote([symbol]).await {
+        Ok(quotes) => {
+            if !is_current(generation) {
+                return false;
+            }
+            if let Some(quote) = quotes.first() {
+                STOCKS.modify(counter.clone(), |stock| {
+                    stock.update_from_security_quote(quote);
+                });
+                true
+            } else {
+                // API returned no data — symbol does not exist
+                STOCK_NOT_FOUND.store(true, Ordering::Relaxed);
+                request_redraw();
+                false
+            }
+        }
+        Err(err) => {
+            tracing::warn!("fail to fetch quote for {counter}: {err}");
+            false
+        }
+    }
+}
 
-            // The _guard will be dropped here, automatically clearing REFRESH_EXECUTING
-        });
+/// Load everything the detail view draws for `counter`, after a short settling
+/// delay, discarding the work as soon as another stock is selected.
+///
+/// The requests are ordered by what the reader is waiting for, and the ones
+/// that are already answered are not sent at all. That ordering is the whole
+/// point: the quote SDK runs one command at a time and awaits each round trip
+/// before starting the next, so every request here sits in front of all the
+/// ones after it. The old sequence spent its first two round trips subscribing
+/// before it asked for a single number, and measured four to seven seconds
+/// from keypress to a filled panel.
+pub fn refresh_stock_debounced(counter: Counter) {
+    let generation = REFRESH_GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
+    // Reset not-found flag whenever a new refresh starts
+    STOCK_NOT_FOUND.store(false, Ordering::Relaxed);
 
-        *task_guard = Some(handle);
+    let handle = RT.get().unwrap().spawn(async move {
+        tokio::time::sleep(REFRESH_DEBOUNCE).await;
+        if !is_current(generation) {
+            return;
+        }
+        *SETTLED.lock().expect("poison") = Some(counter.clone());
+        request_redraw();
+
+        tracing::debug!("Starting refresh for {}", counter);
+        let symbol = counter.to_string();
+
+        // A stock the watchlist has already snapshotted has a price and a
+        // previous close on screen the moment it is selected, so its snapshot
+        // is a correction rather than something the reader is waiting for, and
+        // it is sent last. Only a stock with nothing cached — one reached
+        // through search — has to wait for it, and for that one it goes first,
+        // because until it lands the panel has nothing to draw at all.
+        let has_snapshot = STOCKS
+            .get(&counter)
+            .is_some_and(|s| s.quote.prev_close.is_some() && s.quote.last_done.is_some());
+
+        if !has_snapshot && !fetch_snapshot(&counter, &symbol, generation).await {
+            return;
+        }
+
+        if !is_current(generation) {
+            return;
+        }
+        // The chart, first, because it is the largest area of the panel that is
+        // blank until its answer comes back. Asking for it here rather than
+        // leaving it to the next frame is what keeps it in front of everything
+        // below on a connection that serves one request at a time. A stock
+        // whose chart is already cached costs nothing here.
+        let count = CHART_COUNT.load(Ordering::Relaxed);
+        if count > 0 {
+            KLINES
+                .ensure(
+                    &counter,
+                    KLINE_TYPE.load(Ordering::Relaxed),
+                    crate::data::AdjustType::ForwardAdjust,
+                    count,
+                )
+                .await;
+            if !is_current(generation) {
+                return;
+            }
+            request_redraw();
+        }
+
+        if let Ok(trades) = openapi::quote::fetch_trades(&symbol, 50).await {
+            if !is_current(generation) {
+                return;
+            }
+            STOCKS.modify(counter.clone(), |stock| {
+                stock.update_from_trades(&trades);
+            });
+            request_redraw();
+        }
+
+        if !is_current(generation) {
+            return;
+        }
+        // The order book and the tick feed last of the three: it is three lines
+        // of the panel, against a chart and a trade list that are the rest of
+        // it, and the price above them is already live from the watchlist's own
+        // subscription.
+        let _ = WS
+            .quote_detail("stock_detail", std::slice::from_ref(&counter))
+            .await;
+
+        // The correction for a stock that already had a cached snapshot. Its
+        // previous close is the one field no push ever carries, so a session
+        // left running across a trading day would otherwise keep showing
+        // yesterday's change.
+        if has_snapshot && is_current(generation) {
+            fetch_snapshot(&counter, &symbol, generation).await;
+        }
+
+        // Last, because it is the only panel that never changes once fetched.
+        let needs_static_info = STOCKS
+            .get(&counter)
+            .is_some_and(|s| s.static_info.is_none());
+        if needs_static_info && is_current(generation) {
+            if let Ok(infos) = openapi::quote::fetch_static_info(&[symbol]).await {
+                if let Some(info) = infos.into_iter().next() {
+                    STOCKS.modify(counter.clone(), |stock| {
+                        stock.update_from_static_info(info);
+                    });
+                }
+            }
+        }
+
+        tracing::debug!("Completed refresh for {}", counter);
+
+        // Only now, with nothing left on screen waiting for the connection, are
+        // the stocks the cursor passed over told to stop streaming.
+        if is_current(generation) {
+            let _ = WS
+                .release_stale("stock_detail", std::slice::from_ref(&counter))
+                .await;
+        }
+
+        read_ahead(&counter, generation, count).await;
+    });
+
+    if let Some(previous) = REFRESH_TASK.lock().expect("poison").replace(handle) {
+        previous.abort();
     }
 }
 
@@ -1012,6 +1190,7 @@ pub fn enter_stock(counter: Res<StockDetail>) {
 
 pub fn exit_stock() {
     STOCK_NOT_FOUND.store(false, Ordering::Relaxed);
+    *SETTLED.lock().expect("poison") = None;
     crate::tui::systems::stock_news::reset_news_view();
     RT.get().unwrap().spawn(async move {
         _ = WS.unmount("stock_detail").await;

--- a/src/tui/systems/stock_news.rs
+++ b/src/tui/systems/stock_news.rs
@@ -104,6 +104,19 @@ pub static NEWS_DETAIL_CONTENT: std::sync::LazyLock<Mutex<String>> =
 pub static NEWS_SYMBOL: std::sync::LazyLock<Mutex<String>> =
     std::sync::LazyLock::new(|| Mutex::new(String::new()));
 
+/// Bumped by every news load; a task whose number is no longer the latest is
+/// answering for a stock, or an article, the reader has already left.
+///
+/// Without it the panes are last-writer-wins across the network: walking a
+/// watchlist with the dock open starts a fetch per row, and the one that
+/// happens to answer last fills the pane — which is not the one being shown.
+static NEWS_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Whether this task still speaks for what is on screen.
+fn news_is_current(generation: u64) -> bool {
+    NEWS_GENERATION.load(Ordering::Relaxed) == generation
+}
+
 pub static NEWS_LOADING: Atomic<bool> = Atomic::new(false);
 pub static NEWS_DETAIL_LOADING: Atomic<bool> = Atomic::new(false);
 pub static NEWS_DETAIL_SCROLL: Atomic<u16> = Atomic::new(0);
@@ -171,6 +184,7 @@ pub fn ensure_news(counter: Counter, tx: mpsc::UnboundedSender<CommandQueue>) {
 }
 
 pub fn fetch_news(counter: Counter, tx: mpsc::UnboundedSender<CommandQueue>) {
+    let generation = NEWS_GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
     *NEWS_SYMBOL.lock().expect("poison") = counter.to_string();
     NEWS_LOADING.store(true, Ordering::Relaxed);
     if let Ok(mut items) = NEWS_ITEMS.lock() {
@@ -200,6 +214,9 @@ pub fn fetch_news(counter: Counter, tx: mpsc::UnboundedSender<CommandQueue>) {
                     })
                     .collect();
 
+                if !news_is_current(generation) {
+                    return;
+                }
                 if let Ok(mut stored) = NEWS_ITEMS.lock() {
                     *stored = news_items;
                 }
@@ -211,12 +228,16 @@ pub fn fetch_news(counter: Counter, tx: mpsc::UnboundedSender<CommandQueue>) {
                 tracing::error!("Failed to fetch news: {}", e);
             }
         }
+        if !news_is_current(generation) {
+            return;
+        }
         NEWS_LOADING.store(false, Ordering::Relaxed);
         let _ = tx.send(CommandQueue::default());
     });
 }
 
 pub fn fetch_news_detail(id: String, tx: mpsc::UnboundedSender<CommandQueue>) {
+    let generation = NEWS_GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
     NEWS_DETAIL_LOADING.store(true, Ordering::Relaxed);
     NEWS_DETAIL_SCROLL.store(0, Ordering::Relaxed);
     if let Ok(mut content) = NEWS_DETAIL_CONTENT.lock() {
@@ -251,12 +272,18 @@ pub fn fetch_news_detail(id: String, tx: mpsc::UnboundedSender<CommandQueue>) {
                     item.title.clone()
                 };
                 let text = format!("# {title}\n\n{}\n\n{body}", meta.join(" · "));
+                if !news_is_current(generation) {
+                    return;
+                }
                 if let Ok(mut content) = NEWS_DETAIL_CONTENT.lock() {
                     *content = prepare_article(&text);
                 }
             }
             Err(e) => {
                 tracing::error!("Failed to fetch news detail: {e}");
+                if !news_is_current(generation) {
+                    return;
+                }
                 if let Ok(mut content) = NEWS_DETAIL_CONTENT.lock() {
                     *content = t!("News.ErrorFetch", error = e.to_string()).to_string();
                 }


### PR DESCRIPTION
Switching stocks in the TUI left the chart and trade list blank for
seconds, and walking a watchlist could leave the row you stopped on blank
indefinitely. Longbridge Lite has none of this, which turned out to be two
separate reasons.

## The access point (the bigger half)

The latency repin measured `openapi.<tld>/health` and used the verdict for
`openapi-quote.<tld>`, a different host. Measured from Shanghai the two
disagree, and the health endpoint is the one that is wrong:

| host | `.cn` | `.com` |
|---|---|---|
| `openapi.<tld>/health` (what was probed) | **58ms** | 120ms |
| `openapi-quote.<tld>` (what is used) | 370ms | **215ms** |

So the probe kept pinning to `.cn`. What that costs, same command, three
runs each:

- `longbridge kline AAPL.US` — `.cn` 2.54 / 2.56 / 2.79s, `.com` 1.22 / 0.84 / 0.85s
- one candlestick round trip in the TUI — `.cn` 0.43s, `.com` 0.11s

The probe now measures the quote host. Reachability is judged differently
there, because it answers a plain GET with a 400 and a WebSocket handshake
complaint and that is its healthy answer. The repin margins are unchanged,
and an unreachable access point is still never chosen, so a China Mainland
client that cannot reach `.com` stays put. Lite, for what it is worth,
hardcodes `wss://openapi-quote.longbridge.com`.

`check` was printing the URL it did not measure; it now names the one it did.

## The TUI (the other half)

The quote SDK serves one command at a time and awaits each round trip, so
request count and order are the only levers. Four things worked against both:

- `by_pagination` runs inside the render closure, so a chart not yet in the
  store was re-requested every frame — 29 candlestick requests for 9 stocks.
  Now one request per series at a time.
- A global "refresh already running" flag turned away refreshes and never
  retried them, so the stock you settled on could never load. Replaced with
  a generation counter.
- The chain subscribed twice before asking for a single number. The chart is
  now first, then the trade list, then the feeds.
- `WsManager::unmount` was a TODO that unsubscribed nothing, so every stock
  ever opened kept pushing its order book at a panel nobody was looking at.

Plus read-ahead of the rows either side of the cursor while the connection
is idle, which removes the wait rather than shortening it, and a settle
delay cut from 150ms to 80ms once it had become the largest remaining piece
of dead time.

## Two more found while auditing cancellation

Every spawn site in `src/tui` was checked for what happens when the
selection moves on. Two were unguarded:

- **News filled the pane for the wrong stock.** `fetch_news` cleared the
  pane and spawned with nothing tying the answer to the request, so walking
  the list with the dock open let whichever fetch answered last win. Same
  shape in `fetch_news_detail` between articles. Both now carry a
  generation. News rides HTTP, so this was never part of the delay.
- **Holdings were lost on a quarter of launches.** `refresh_watchlist`
  fires the watchlist and holdings loads with `tokio::join!`; the server's
  0.02s minimum interval between calls is account-wide, so the loser came
  back 429003, and the handler swallowed it into an empty list — no
  position markers for that session, silently. 14 of 51 launches in one
  day's logs. Holdings now goes through the rate-limited helper; 6 of 6
  launches loaded after the change. The quote path deliberately stays
  unpaced, since the SDK cannot fan out and the limiter's gap would land in
  front of every switch.

Worth stating: `abort()` cannot cancel a request already handed to the SDK,
because its actor awaits the round trip inline. Cancellation can only stop
requests not yet issued — which is why the count and the order mattered as
much as they did. Verified empirically: 0 of 49 refreshes wrote data for a
stock that was no longer selected.

## Measured

Panels still blank after a fast 8-row walk, then stopping:

| | t+0.2s | t+1s | t+2s | t+4s | t+6s |
|---|---|---|---|---|---|
| before | 2 | 2 | 2 | 2 | 2 |
| after (TUI only, still on `.cn`) | 2 | 2 | 0 | 0 | 0 |
| after (both, repinned) | **0** | 0 | 0 | 0 | 0 |

Back and forth with `j`/`k`: no blank panel at any sample, in ten switches.
Keypress-to-repaint was never the problem and is unchanged at 9–39ms.

## Notes

- The first commit is only `Cargo.lock`: `Cargo.toml` had gone to 0.28.3
  without the lockfile following, so every build dirtied the tree.
- `cargo clippy` still reports one error in `src/cli/agent/client.rs:319`.
  It is present on `main` unchanged and is left alone rather than folded
  into this PR.
- 826 tests pass; `cargo fmt` clean; no new build warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2gcviuqWGGyMxDsjjctbu
