### PR TITLE
fix(quote): stop dividing option theta by 252 (API now returns per-day value)

### DIFF
--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -124,14 +124,6 @@ pub fn fmt_decimal_div100(v: &Option<rust_decimal::Decimal>) -> String {
     )
 }
 
-/// Format optional decimal divided by 252 with 3 decimal places (convert annualized greek to per-trading-day, e.g. theta, vega)
-pub fn fmt_decimal_div252(v: &Option<rust_decimal::Decimal>) -> String {
-    v.map_or_else(
-        || "-".to_string(),
-        |d| format!("{:.3}", d / rust_decimal::Decimal::from(252u32)),
-    )
-}
-
 /// Format decimal
 pub fn fmt_dec(v: rust_decimal::Decimal) -> String {
     v.to_string()

--- a/src/cli/quote.rs
+++ b/src/cli/quote.rs
@@ -9,10 +9,7 @@ use serde_json::Value;
 
 use super::{
     api::{http_get, http_get_dc, http_post, LbQuoteApi, QuoteApi},
-    output::{
-        fmt_date, fmt_dec, fmt_decimal, fmt_decimal_div100, fmt_decimal_div252, parse_date,
-        print_table,
-    },
+    output::{fmt_date, fmt_dec, fmt_decimal, fmt_decimal_div100, parse_date, print_table},
     OutputFormat,
 };
 use crate::utils::counter::symbol_to_counter_id;
@@ -165,7 +162,7 @@ fn calc_index_column(key: &str) -> Option<(&'static str, CalcIndexExtractor)> {
         })),
         "delta" => Some(("Delta", |r| fmt_decimal(&r.delta))),
         "gamma" => Some(("Gamma", |r| fmt_decimal(&r.gamma))),
-        "theta" => Some(("Theta", |r| fmt_decimal_div252(&r.theta))),
+        "theta" => Some(("Theta", |r| fmt_decimal(&r.theta))),
         "vega" => Some(("Vega", |r| fmt_decimal_div100(&r.vega))),
         "rho" => Some(("Rho", |r| fmt_decimal_div100(&r.rho))),
         "open_interest" | "oi" => Some(("Open Interest", |r| {


### PR DESCRIPTION
The Calc Index API's theta was fixed server-side to return a per-day value (the raw annualized value is now divided by 365 on the server), so the CLI must no longer divide it by 252 — doing so under-reported theta. Format theta with `fmt_decimal` like the other raw Greeks; vega/rho keep their /100 normalization. Removed the now-unused `fmt_decimal_div252` helper.

Matches longbridge/openapi#586 and the MCP change. build + clippy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)