### PR TITLE
cli: Exit quietly when stdout is a closed pipe

### DIFF
--- a/src/cli/agent/client.rs
+++ b/src/cli/agent/client.rs
@@ -316,10 +316,7 @@ fn map_event(ev: ConversationStreamEvent) -> Option<AgentEvent> {
         // The SDK has no typed variant for `token_usage`, so it arrives here as
         // a raw event carrying the cumulative counts for the round.
         ConversationStreamEvent::Other { event, data } if event == "token_usage" => {
-            match crate::openapi::chats::TokenUsage::from_data(&data) {
-                Some(usage) => AgentEvent::TokenUsage(usage),
-                None => return None,
-            }
+            AgentEvent::TokenUsage(crate::openapi::chats::TokenUsage::from_data(&data)?)
         }
         ConversationStreamEvent::Other { event, .. } => AgentEvent::Unknown { event },
         // Progress-only events the CLI does not display.

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -5,7 +5,14 @@ use crate::cli::Cli;
 
 pub fn cmd_completion(shell: Shell) {
     let mut cmd = Cli::command();
-    generate(shell, &mut cmd, "longbridge", &mut std::io::stdout());
+    // Generated into memory and printed, rather than written straight to
+    // stdout: `clap_complete` unwraps its own write errors, so `longbridge
+    // completion zsh | head -1` aborted inside the generator before the
+    // crate's broken-pipe handling could see it. A completion script is a few
+    // hundred KiB, so buffering it costs nothing.
+    let mut script = Vec::new();
+    generate(shell, &mut cmd, "longbridge", &mut script);
+    print!("{}", String::from_utf8_lossy(&script));
 }
 
 pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::ResponseSchema> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,45 @@ use clap::{CommandFactory, FromArgMatches};
 use std::io::Write;
 use std::time::Instant;
 
+/// `print!`, `println!`, `eprint!` and `eprintln!` that end the run quietly
+/// when the reader has closed the pipe, shadowing the prelude macros for the
+/// whole crate.
+///
+/// Defined before the module declarations below, which is what puts them in
+/// textual scope for every module in the binary — the only way to cover all
+/// ~700 existing call sites without rewriting each one, and the only way for
+/// new ones to be covered by default. See `utils::stdio` for why a closed
+/// stdout must not be a panic here, and why `SIGPIPE` is left ignored.
+macro_rules! print {
+    ($($arg:tt)*) => {
+        $crate::utils::stdio::write_stdout(::std::format_args!($($arg)*), false)
+    };
+}
+
+macro_rules! println {
+    () => {
+        $crate::utils::stdio::write_stdout(::std::format_args!(""), true)
+    };
+    ($($arg:tt)*) => {
+        $crate::utils::stdio::write_stdout(::std::format_args!($($arg)*), true)
+    };
+}
+
+macro_rules! eprint {
+    ($($arg:tt)*) => {
+        $crate::utils::stdio::write_stderr(::std::format_args!($($arg)*), false)
+    };
+}
+
+macro_rules! eprintln {
+    () => {
+        $crate::utils::stdio::write_stderr(::std::format_args!(""), true)
+    };
+    ($($arg:tt)*) => {
+        $crate::utils::stdio::write_stderr(::std::format_args!($($arg)*), true)
+    };
+}
+
 pub mod ai;
 /// Sensors Analytics. `analytics::core` is shared verbatim with the desktop
 /// app; everything terminal-specific lives beside it in `analytics/mod.rs`.
@@ -289,8 +328,11 @@ async fn main() {
 
     match cli.command {
         None => {
-            // No subcommand: print help and exit
-            cli::Cli::command().print_help().unwrap();
+            // No subcommand: print help and exit. Rendered to a string and
+            // printed rather than written straight to stdout by clap, so a
+            // closed reader takes the shared broken-pipe path instead of
+            // clap's `unwrap`.
+            print!("{}", cli::Cli::command().render_help());
             println!();
         }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,7 @@ pub mod datetime;
 pub mod decimal_ext;
 pub mod dry_run;
 pub mod number;
+pub mod stdio;
 pub mod text;
 
 pub use decimal_ext::DecimalExt;

--- a/src/utils/stdio.rs
+++ b/src/utils/stdio.rs
@@ -1,0 +1,80 @@
+//! Printing that survives a reader walking away.
+//!
+//! `longbridge kline 700.HK --count 1000 | head -1` leaves the CLI writing into
+//! a pipe nobody is reading. Rust ignores `SIGPIPE` for the whole process, so
+//! that write fails with `EPIPE` rather than killing us — and `println!` turns
+//! the failure into a panic. Under this crate's `panic = "abort"` release
+//! profile that panic is a `SIGABRT` and a core dump, for what is an ordinary
+//! way to end a pipeline.
+//!
+//! The `print!` / `println!` / `eprint!` / `eprintln!` macros defined at the
+//! crate root shadow the prelude ones and route every call site here, where a
+//! closed reader ends the run quietly instead.
+//!
+//! Restoring `SIGPIPE` to `SIG_DFL` is the other common fix, and was rejected:
+//! this binary holds long-lived WebSocket and HTTP connections, and `std`'s
+//! vectored socket writes go through `writev` without `MSG_NOSIGNAL`, so the
+//! default disposition would trade a stdout panic for the process being killed
+//! mid-session by a peer reset.
+
+use std::io::{self, Write};
+
+/// Exit code for a run whose output was cut short by its reader.
+///
+/// Zero, not the 141 a `SIGPIPE` death would produce: `| head` is a normal way
+/// to look at the front of a long result, and reporting failure there would
+/// break `set -o pipefail` scripts that did nothing wrong.
+const PIPE_CLOSED_EXIT_CODE: i32 = 0;
+
+/// Write `args` to stdout, appending a newline when `newline`.
+///
+/// A closed stdout ends the run: stdout carries the answer the command was
+/// asked for, and there is nowhere left to put the rest of it.
+pub fn write_stdout(args: std::fmt::Arguments<'_>, newline: bool) {
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    let result = write(&mut out, args, newline);
+    // Released before the exit below, so the flush of stdout on the way out is
+    // not re-entering a lock this thread still holds.
+    drop(out);
+
+    match result {
+        Ok(()) => {}
+        Err(e) if is_broken_pipe(&e) => std::process::exit(PIPE_CLOSED_EXIT_CODE),
+        // A genuine fault — a full disk, a bad file descriptor. Panicking is
+        // what the std macros do, and keeps a real I/O failure loud.
+        Err(e) => panic!("failed printing to stdout: {e}"),
+    }
+}
+
+/// Write `args` to stderr, appending a newline when `newline`.
+///
+/// A closed stderr is dropped rather than fatal: stderr carries diagnostics
+/// beside the real output, so losing the reader of the commentary is no reason
+/// to truncate an answer that stdout is still delivering. When both are the
+/// same closed pipe — `longbridge ... 2>&1 | head -1` — the next stdout write
+/// ends the run anyway.
+pub fn write_stderr(args: std::fmt::Arguments<'_>, newline: bool) {
+    let stderr = io::stderr();
+    let mut err = stderr.lock();
+    let result = write(&mut err, args, newline);
+    drop(err);
+
+    match result {
+        Ok(()) => {}
+        Err(e) if is_broken_pipe(&e) => {}
+        Err(e) => panic!("failed printing to stderr: {e}"),
+    }
+}
+
+fn is_broken_pipe(e: &io::Error) -> bool {
+    e.kind() == io::ErrorKind::BrokenPipe
+}
+
+fn write(out: &mut impl Write, args: std::fmt::Arguments<'_>, newline: bool) -> io::Result<()> {
+    out.write_fmt(args)?;
+    if newline {
+        out.write_all(b"\n")?;
+    }
+    Ok(())
+}

--- a/tests/broken_pipe.rs
+++ b/tests/broken_pipe.rs
@@ -1,0 +1,39 @@
+//! A reader that stops early — `longbridge ... | head -1` — must end the run
+//! quietly. Rust ignores `SIGPIPE`, so the failed write surfaces as `EPIPE`,
+//! and the release profile builds with `panic = "abort"`: left unhandled, an
+//! everyday pipeline produced `SIGABRT` and a core dump.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+
+/// `completion zsh` is the subject because it needs no credentials and emits a
+/// few hundred KiB — far past the pipe buffer, so the child is still writing
+/// when the reader goes away, which is what makes the closed pipe observable.
+#[test]
+fn closing_stdout_early_exits_quietly() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_longbridge"))
+        .args(["completion", "zsh"])
+        // Pins the access point, which skips the startup probe and keeps the
+        // run off the network.
+        .env("LONGBRIDGE_REGION", "global")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn longbridge");
+
+    let mut stdout = child.stdout.take().expect("piped stdout");
+    let mut first = [0u8; 1];
+    stdout.read_exact(&mut first).expect("read first byte");
+    // Closing the read end is what `head` does once it has what it asked for.
+    drop(stdout);
+
+    let output = child.wait_with_output().expect("wait for longbridge");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("panicked"),
+        "panicked on a closed stdout: {stderr}"
+    );
+    // `None` here means death by signal — the abort this guards against.
+    assert_eq!(output.status.code(), Some(0), "stderr: {stderr}");
+}


### PR DESCRIPTION
## Problem

`longbridge kline 700.HK --count 1000 --format json | head -1` did not just stop — it aborted with `SIGABRT` and left a core dump:

```
thread 'main' panicked at library/std/src/io/stdio.rs:1166:9:
failed printing to stdout: Broken pipe (os error 32)
```

Rust ignores `SIGPIPE` process-wide, so a reader that walks away turns the next write into `EPIPE` rather than a signal. `println!` turns that error into a panic, and the release profile builds with `panic = "abort"`.

`longbridge completion zsh | head -1` aborted too, by a separate route: `clap_complete` unwraps its own write error.

(The `quote ... | head -c 1` in the original report is not a reliable repro — that output fits in the 64 KiB pipe buffer, so the write never fails.)

## What changes for users

- Piping any command into `head`, `less`, or anything else that stops reading early now ends the run quietly with exit status 0, instead of aborting. No panic message, no core dump.
- A closed **stderr** no longer takes the run down with it: stderr carries diagnostics beside the real output, so losing the reader of the commentary is no reason to truncate an answer stdout is still delivering. When both are the same closed pipe (`2>&1 | head`), the next stdout write ends the run anyway.
- Genuine I/O failures — a full disk, a bad file descriptor — still fail loudly.
- Exit status is 0 rather than the 141 a `SIGPIPE` death produces: `| head` is a normal way to read the front of a long result, and reporting failure there would break `set -o pipefail` scripts that did nothing wrong.

## Notes on the approach

`print!`/`println!`/`eprint!`/`eprintln!` are shadowed at the crate root, which puts them in textual scope for every module in the binary. That covers all ~700 existing call sites without rewriting one of them, and covers new ones by default.

Restoring `SIGPIPE` to `SIG_DFL` — the other common fix — was rejected. This binary holds long-lived WebSocket and HTTP connections (`tui`, `serve`, `ai`), and std's vectored socket writes reach `writev` without `MSG_NOSIGNAL`, so the default disposition would trade a stdout panic for the process being killed mid-session by a peer reset. The reasoning is recorded in `utils::stdio`'s module docs.

## Verification

- Both repros above now exit 0 with no panic.
- New `tests/broken_pipe.rs` closes the read end after one byte and asserts a clean, unsignalled exit. Removing the shadowing macros makes it fail, so it holds the regression shut.
- `cargo test --all`: 841 passed, 0 failed.
- Per CLAUDE.md, compared the installed release binary against this build with `--format json`: `static` and `trades` identical, `completion zsh` byte-identical at 414385 bytes, `kline` differing only in the last candle's live close/volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Bf9r3dNDiZRjjDxXiVVtN


---

**Also in this branch** (separate commit, unrelated to the above): `map_event` in `src/cli/agent/client.rs` had the only `cargo clippy` error on `main` — a `match` whose `None` arm was `?` written out. Replaced with `?`. `cargo clippy` is now clean.

Note that `cargo clippy --all-targets` still reports 8 errors, all in pre-existing `#[cfg(test)]` code and test targets (`tests/schema_cli.rs`, `src/ai/tui.rs`, `src/tui/ui/snapshot.rs`, `src/ai/chart.rs`, `src/openapi/chats.rs`). Left alone here — happy to clean them up in their own PR.
