### PR TITLE
cli: Remove API-key env auth; the CLI is OAuth-only

### DIFF
--- a/src/ai/tui.rs
+++ b/src/ai/tui.rs
@@ -1127,7 +1127,7 @@ pub async fn run(agent_uid: String, quotes: Option<QuoteStream>) -> Result<Optio
                         // different account, usually). The contexts are rebuilt from
                         // the new credentials and this session carries on with them;
                         // only a failure to build them is worth leaving for.
-                        if let Ok((rx, _, _)) = crate::openapi::init_contexts().await {
+                        if let Ok((rx, _)) = crate::openapi::init_contexts().await {
                             quotes = Box::pin(rx);
                             ui.session = super::account::local();
                             ui.notice = Some(t!("Ai.SignedIn").to_string());

--- a/src/cli/agent/client.rs
+++ b/src/cli/agent/client.rs
@@ -179,21 +179,6 @@ impl AgentApi for LbAgentApi {
     }
 }
 
-/// Reject AI conversations when the process authenticated with API-key env
-/// vars. The AI conversation endpoints are only known to accept an OAuth
-/// principal; failing fast with an actionable message beats an opaque 401
-/// mid-stream. (Can be lifted once API-key auth is confirmed to work against
-/// the AI endpoints, now that requests go through the SDK's signing client.)
-fn ensure_oauth_auth(using_api_key: bool) -> Result<()> {
-    if using_api_key {
-        anyhow::bail!(
-            "agent chat requires OAuth login (API-key auth is not supported for AI \
-             conversations); run `longbridge auth login`"
-        );
-    }
-    Ok(())
-}
-
 /// A conversation to stream: either a fresh round or the resumption of an
 /// interrupted one. Mirrors the two SDK entry points
 /// ([`AgentContext::conversation_streamed`](longbridge::agent::AgentContext::conversation_streamed)
@@ -817,7 +802,12 @@ pub async fn stream_conversation(
     verbose: bool,
     on_event: &mut (dyn FnMut(AgentEvent) + Send),
 ) -> Result<()> {
-    ensure_oauth_auth(crate::openapi::using_api_key())?;
+    // No auth-mode gate here: the conversation goes through the SDK's signing
+    // `HttpClient` (`AgentContext` shares `Config::create_http_client()` with the
+    // quote/trade contexts), so an API-key principal signs AI requests the same
+    // way it signs every other endpoint. If the server declines an API-key
+    // principal, that surfaces as a typed API error rather than a client-side
+    // refusal that misreports the cause.
     let ctx = crate::openapi::agent();
     let agent_uid = req.agent_uid().to_string();
     let mut ident = req.ident();
@@ -1121,17 +1111,6 @@ mod tests {
             trace_id: "t".into(),
         });
         assert!(!is_rate_limited(&other));
-    }
-
-    #[test]
-    fn api_key_mode_is_rejected_with_actionable_message() {
-        let err = ensure_oauth_auth(true).unwrap_err().to_string();
-        assert!(err.contains("OAuth"), "unexpected message: {err}");
-        assert!(
-            err.contains("longbridge auth login"),
-            "message must be actionable: {err}"
-        );
-        ensure_oauth_auth(false).expect("OAuth mode must be allowed");
     }
 
     #[test]

--- a/src/cli/agent/skills.rs
+++ b/src/cli/agent/skills.rs
@@ -124,8 +124,7 @@ pub fn skills_doc() -> &'static str {
 
         ## 6. Etiquette
 
-        - Requires OAuth login (`longbridge auth login`). API-key env
-          authentication is not supported for AI conversations.
+        - Requires OAuth login (`longbridge auth login`).
         - Serialize requests; the API rejects bursts with code 429002.
           On 429002, wait a few seconds and retry.
         - Agent runs are slow (up to ~2 min). Do not re-send while running.

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ pub struct Args {
     pub logout: bool,
 }
 
-fn print_cli_error(e: &anyhow::Error, using_api_key: bool) {
+fn print_cli_error(e: &anyhow::Error) {
     use longbridge::{httpclient::HttpClientError, wsclient::WsClientError, Error as LbError};
     // Strip terminal control/escape sequences from server-controlled text
     // before it hits stderr, so a hostile API error cannot repaint the
@@ -52,13 +52,6 @@ fn print_cli_error(e: &anyhow::Error, using_api_key: bool) {
                 );
                 if !trace_id.is_empty() {
                     eprintln!("  trace_id: {}", sanitize_server_text(trace_id));
-                }
-                if using_api_key && *code == 401_003 {
-                    eprintln!(
-                        "\nYou are currently using environment variable authentication.\n\
-                        Please check that LONGBRIDGE_APP_KEY, LONGBRIDGE_APP_SECRET, and LONGBRIDGE_ACCESS_TOKEN are valid.\n\
-                        To switch to OAuth instead, unset these environment variables and restart."
-                    );
                 }
                 return;
             }
@@ -297,7 +290,7 @@ async fn main() {
         Some(cli::Commands::Tui) => {
             tracing::info!("App started");
             analytics::track(analytics::event::TUI_LAUNCH, serde_json::json!({}));
-            let (quote_receiver, using_api_key, _) = match openapi::init_contexts().await {
+            let (quote_receiver, _) = match openapi::init_contexts().await {
                 Ok(r) => r,
                 Err(e) => {
                     eprintln!("OAuth2 authentication failed: {e}");
@@ -305,7 +298,7 @@ async fn main() {
                 }
             };
             if let Err(e) = openapi::quote().member_id().await {
-                print_cli_error(&anyhow::anyhow!(e), using_api_key);
+                print_cli_error(&anyhow::anyhow!(e));
                 return;
             }
             tracing::info!("OpenAPI initialized successfully");
@@ -349,7 +342,7 @@ async fn main() {
             // Refusing to start was the wrong call: signing in is the one thing you
             // would come here to do without a token.
             let quote_receiver: Option<ai::QuoteStream> = match openapi::init_contexts().await {
-                Ok((rx, _, _)) => Some(Box::pin(rx)),
+                Ok((rx, _)) => Some(Box::pin(rx)),
                 Err(_) => None,
             };
 
@@ -400,7 +393,7 @@ async fn main() {
         // `serve` is the only command that keeps the market WebSocket: every
         // other one discards the push stream after `init_contexts`.
         Some(cli::Commands::Serve) => {
-            let (quote_receiver, using_api_key, _) = match openapi::init_contexts().await {
+            let (quote_receiver, _) = match openapi::init_contexts().await {
                 Ok(r) => r,
                 Err(e) => {
                     eprintln!("Authentication failed: {e}");
@@ -409,7 +402,7 @@ async fn main() {
                 }
             };
             if let Err(e) = openapi::quote().member_id().await {
-                print_cli_error(&anyhow::anyhow!(e), using_api_key);
+                print_cli_error(&anyhow::anyhow!(e));
                 analytics::flush().await;
                 std::process::exit(1);
             }
@@ -432,7 +425,7 @@ async fn main() {
 
         Some(cli::Commands::Check) => {
             if let Err(e) = cli::check::cmd_check(&cli.format).await {
-                print_cli_error(&e, false);
+                print_cli_error(&e);
                 analytics::finish_command(analytics::Outcome::Error).await;
                 std::process::exit(1);
             }
@@ -562,7 +555,7 @@ async fn main() {
             )
             .await;
             if let Err(e) = result {
-                print_cli_error(&anyhow::anyhow!(e), false);
+                print_cli_error(&anyhow::anyhow!(e));
                 analytics::flush().await;
                 std::process::exit(1);
             }
@@ -573,8 +566,8 @@ async fn main() {
         Some(cmd) => {
             let start = verbose.then(Instant::now);
             // CLI mode: init contexts (auth), then dispatch
-            let (using_api_key, http_url) = match openapi::init_contexts().await {
-                Ok((_, using_api_key, http_url)) => (using_api_key, http_url),
+            let http_url = match openapi::init_contexts().await {
+                Ok((_, http_url)) => http_url,
                 Err(e) => {
                     eprintln!("Authentication failed: {e}");
                     // Reported before exiting: a failure to authenticate is
@@ -588,7 +581,7 @@ async fn main() {
                 eprintln!("* Host: {http_url}");
             }
             if let Err(e) = cli::dispatch(cmd, &cli.format, cli.verbose).await {
-                print_cli_error(&e, using_api_key);
+                print_cli_error(&e);
                 analytics::finish_command(analytics::Outcome::Error).await;
                 std::process::exit(1);
             }

--- a/src/openapi/agent.rs
+++ b/src/openapi/agent.rs
@@ -179,7 +179,7 @@ impl AuthenticationRequiredAgent {
         let backend = self
             .authenticated
             .get_or_try_init(|| async move {
-                let _ = super::init_oauth_contexts().await?;
+                let _ = super::init_contexts().await?;
                 Ok::<_, BackendError>(OpenApiAgent::new(super::agent().clone(), agent_id))
             })
             .await?;

--- a/src/openapi/context.rs
+++ b/src/openapi/context.rs
@@ -55,9 +55,6 @@ pub(crate) static SIGNAL_CTX: Slot<longbridge::signal::SignalContext> = Slot::ne
 /// Global `AgentContext` for AI agent discovery and conversations
 pub(crate) static AGENT_CTX: Slot<longbridge::agent::AgentContext> = Slot::new();
 
-/// Whether this process authenticated with API-key env vars (vs OAuth).
-static USING_API_KEY: Slot<bool> = Slot::new();
-
 /// Global `HttpClient` for making authenticated requests to the Longbridge `OpenAPI`
 pub(crate) static HTTP_CLIENT: Slot<longbridge::httpclient::HttpClient> = Slot::new();
 
@@ -103,29 +100,6 @@ fn ws_url_from_http(http_url: &str) -> String {
     }
 }
 
-/// Initialize contexts (should be called once at app startup).
-/// If `LONGBRIDGE_APP_KEY`, `LONGBRIDGE_APP_SECRET`, and `LONGBRIDGE_ACCESS_TOKEN`
-/// are all set, uses API key authentication (no browser needed).
-/// Otherwise falls back to OAuth: loads token from disk or runs browser flow.
-/// Returns `(quote_stream, using_api_key, http_url)` where `http_url` is the
-/// effective base URL that was configured (useful for diagnostics/verbose output).
-pub async fn init_contexts() -> Result<(
-    impl tokio_stream::Stream<Item = longbridge::quote::PushEvent> + Send + Unpin,
-    bool,
-    String,
-)> {
-    init_contexts_with_auth(true).await
-}
-
-/// Initialize contexts using only credentials saved by `longbridge auth login`.
-pub async fn init_oauth_contexts() -> Result<(
-    impl tokio_stream::Stream<Item = longbridge::quote::PushEvent> + Send + Unpin,
-    bool,
-    String,
-)> {
-    init_contexts_with_auth(false).await
-}
-
 /// Return whether an OAuth token is available without starting an OAuth flow.
 pub fn oauth_credentials_available() -> Result<bool> {
     let token_path = crate::auth::token_file_path()?;
@@ -144,77 +118,50 @@ pub fn oauth_credentials_available() -> Result<bool> {
     Ok(true)
 }
 
-async fn init_contexts_with_auth(
-    allow_api_key: bool,
-) -> Result<(
+/// Initialize contexts (should be called once at app startup).
+///
+/// Authenticates with OAuth only: loads the token from disk (run
+/// `longbridge auth login` first) and refreshes it if expired. There is no
+/// API-key env-var path — `LONGBRIDGE_APP_KEY` and friends are never read.
+/// Returns `(quote_stream, http_url)` where `http_url` is the effective base
+/// URL that was configured (useful for diagnostics/verbose output).
+pub async fn init_contexts() -> Result<(
     impl tokio_stream::Stream<Item = longbridge::quote::PushEvent> + Send + Unpin,
-    bool,
     String,
 )> {
-    let api_key_configs = if allow_api_key {
-        match (
-            longbridge::Config::from_apikey_env(),
-            longbridge::httpclient::HttpClientConfig::from_apikey_env(),
-        ) {
-            (Ok(config), Ok(http_config)) => Some((config, http_config)),
-            _ => None,
+    // If no token file exists, refuse to start a browser/callback-server flow.
+    // CLI commands require a stored token; users must run `longbridge auth login` first.
+    if !oauth_credentials_available()? {
+        return Err(anyhow::anyhow!(
+            "Not authenticated. Please run `longbridge auth login` first."
+        ));
+    }
+
+    // Refresh the access token ourselves if it has expired, before handing
+    // off to the SDK.  This avoids a 5-minute browser-callback timeout that
+    // the SDK would trigger when its own refresh fallback fires.
+    crate::auth::refresh_if_expired().await?;
+
+    let oauth_result = longbridge::oauth::OAuthBuilder::new(crate::auth::effective_client_id())
+        .callback_port(crate::auth::CALLBACK_PORT)
+        .token_storage(crate::secure_storage::EncryptedFileTokenStorage)
+        .build(|_url| {
+            tracing::warn!("OAuth browser flow triggered unexpectedly");
+        })
+        .await;
+
+    let oauth = match oauth_result {
+        Ok(o) => o,
+        Err(e) => {
+            return Err(anyhow::anyhow!("OAuth initialization failed: {e}"));
         }
-    } else {
-        None
-    };
-    let (config_builder, http_client_config, using_api_key) = if let Some((config, http_config)) =
-        api_key_configs
-    {
-        tracing::info!("Using API key authentication (env vars)");
-        (
-            config
-                .language(get_api_language())
-                .dont_print_quote_packages(),
-            http_config,
-            true,
-        )
-    } else {
-        tracing::info!("No API key env vars found, using OAuth authentication");
-
-        // If no token file exists, refuse to start a browser/callback-server flow.
-        // CLI commands require a stored token; users must run `longbridge auth login` first.
-        if !oauth_credentials_available()? {
-            return Err(anyhow::anyhow!(
-                "Not authenticated. Please run `longbridge auth login` first."
-            ));
-        }
-
-        // Refresh the access token ourselves if it has expired, before handing
-        // off to the SDK.  This avoids a 5-minute browser-callback timeout that
-        // the SDK would trigger when its own refresh fallback fires.
-        crate::auth::refresh_if_expired().await?;
-
-        let oauth_result = longbridge::oauth::OAuthBuilder::new(crate::auth::effective_client_id())
-            .callback_port(crate::auth::CALLBACK_PORT)
-            .token_storage(crate::secure_storage::EncryptedFileTokenStorage)
-            .build(|_url| {
-                tracing::warn!("OAuth browser flow triggered unexpectedly");
-            })
-            .await;
-
-        let oauth = match oauth_result {
-            Ok(o) => o,
-            Err(e) => {
-                return Err(anyhow::anyhow!("OAuth initialization failed: {e}"));
-            }
-        };
-
-        let config_builder = longbridge::Config::from_oauth(oauth.clone())
-            .language(get_api_language())
-            .dont_print_quote_packages();
-
-        let http_client_config =
-            longbridge::httpclient::HttpClientConfig::from_oauth(oauth.clone());
-        (config_builder, http_client_config, false)
     };
 
-    let mut config_builder = config_builder;
-    let mut http_client_config = http_client_config;
+    let mut config_builder = longbridge::Config::from_oauth(oauth.clone())
+        .language(get_api_language())
+        .dont_print_quote_packages();
+
+    let mut http_client_config = longbridge::httpclient::HttpClientConfig::from_oauth(oauth);
 
     // Enable the US overnight market so `quote` returns `overnight_quote`.
     // Pre/post-market quotes are returned without this flag, but the overnight
@@ -320,9 +267,6 @@ async fn init_contexts_with_auth(
 
     let config = Arc::new(config_builder);
 
-    // Published for callers that bypass the SDK client and need to know the
-    // auth mode (e.g. the agent commands reject API-key mode).
-    USING_API_KEY.set(using_api_key);
     // A successful init is what "signed in" means, including the second one after a
     // sign-out in the same process.
     SIGNED_OUT.store(false, Ordering::Relaxed);
@@ -385,7 +329,6 @@ async fn init_contexts_with_auth(
 
     Ok((
         tokio_stream::wrappers::UnboundedReceiverStream::new(quote_receiver),
-        using_api_key,
         effective_http_url,
     ))
 }
@@ -500,12 +443,6 @@ pub fn signal() -> &'static longbridge::signal::SignalContext {
     SIGNAL_CTX
         .get()
         .expect("SignalContext not initialized, please call init_contexts() first")
-}
-
-/// Whether the session authenticated with API-key env vars rather than
-/// OAuth. Defaults to `false` before [`init_contexts`] runs.
-pub fn using_api_key() -> bool {
-    USING_API_KEY.get().copied().unwrap_or(false)
 }
 
 /// Get global `AgentContext` for AI agent discovery and conversations

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -12,8 +12,8 @@ pub mod wrapper;
 
 pub use agent::{AuthenticationRequiredAgent, OpenApiAgent};
 pub use context::{
-    agent, content, fundamental, grid, http_client, init_contexts, init_oauth_contexts, is_ready,
-    is_us_account, mark_signed_out, oauth_credentials_available, quote, quote_cmd, quote_limited,
-    signal, statement, track_quote_cmd, trade, trade_limited, using_api_key,
+    agent, content, fundamental, grid, http_client, init_contexts, is_ready, is_us_account,
+    mark_signed_out, oauth_credentials_available, quote, quote_cmd, quote_limited, signal,
+    statement, track_quote_cmd, trade, trade_limited,
 };
 pub use rate_limiter::global_rate_limiter;


### PR DESCRIPTION
## Problem

`init_contexts` switched to API-key authentication whenever `LONGBRIDGE_APP_KEY`, `LONGBRIDGE_APP_SECRET` and `LONGBRIDGE_ACCESS_TOKEN` were all present. The SDK also **falls back to the `LONGPORT_` prefix** and loads `.env` files (`dotenv::dotenv()`), so a stray credential in the environment silently flipped the auth mode — and `echo $LONGBRIDGE_APP_KEY` never revealed it.

That made `longbridge ai` reject users already logged in with OAuth (API-key mode was refused for AI chat), and signing in from the chat rebuilt the contexts back into API-key mode, so the login prompt looped forever. See longbridge/developers#1247.

## Change

**The CLI is now OAuth-only.** The API-key env-var path is removed entirely; `LONGBRIDGE_APP_KEY`/`LONGPORT_APP_KEY` and friends are never read.

- `init_contexts` authenticates only via the stored OAuth token (`longbridge auth login`).
- Drops the `using_api_key` plumbing, the API-key-specific `401_003` hint in `print_cli_error`, the `--api-key`/env auto-detect, and the agent-chat API-key rejection gate.
- Merges `init_oauth_contexts` into `init_contexts` (they're now identical).
- Net: **7 files, −89 lines.** One auth path, nothing to misconfigure.

## Breaking change

Headless/CI users who relied on env-var API-key credentials must run `longbridge auth login` once. The token persists on disk and the SDK refreshes it automatically, so a single interactive login is enough.

## Verification

- `--help` no longer lists `--api-key`; passing `--api-key` errors as an unknown argument.
- Fake `LONGBRIDGE_APP_KEY/SECRET/ACCESS_TOKEN` in the env are fully ignored — the CLI uses OAuth (fails with the OAuth "refresh token expired" path, never an API-key error).
- 826 unit tests pass; clippy clean.

Fixes longbridge/developers#1247