### PR TITLE
cli: Standardize DC-region wording in command and flag help

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ longbridge warrant issuers                        # Warrant issuer list (HK mark
 
 ```bash
 longbridge financial-report AAPL.US [--kind IS|BS|CF]               # Multi-period financial statements (income / balance sheet / cash flow)
-longbridge financial-report AAPL.US --latest                         # Latest financial report summary
+longbridge financial-report AAPL.US --latest                         # Latest financial report summary (--kind/--latest: AP accounts only)
 longbridge financial-report snapshot AAPL.US --report qf --year N --period N  # Earnings summary + forecast vs actual (revenue/EBIT/EPS beat/miss) + financial ratios
 longbridge financial-statement AAPL.US [--kind IS|BS|CF|ALL] [--report af|saf|qf|cumul]  # Detailed financial statement (v3 endpoint)
 longbridge institution-rating AAPL.US                                # Analyst rating distribution and consensus target price
@@ -217,7 +217,7 @@ longbridge dividend detail AAPL.US                                   # Dividend 
 longbridge forecast-eps AAPL.US                                      # Analyst EPS consensus forecast snapshots
 longbridge consensus AAPL.US                                         # Revenue / profit / EPS multi-period comparison with beat/miss markers
 longbridge valuation AAPL.US [--indicator pe|pb|ps|dvd_yld]         # Current valuation snapshot and peer comparison
-longbridge valuation AAPL.US --history [--indicator pe] [--range 5]  # Historical valuation time series (1 / 3 / 5 / 10 years)
+longbridge valuation AAPL.US --history [--indicator pe] [--range 5]  # Historical valuation time series (1 / 3 / 5 / 10 years) (AP accounts only)
 longbridge valuation-rank AAPL.US [--start 20240101] [--end 20241231] # Industry valuation percentile ranking (default: last 30 days)
 longbridge analyst-estimates AAPL.US                                 # Analyst consensus EPS estimates
 longbridge fund-holder AAPL.US [--count 20]                          # Funds and ETFs holding this stock
@@ -329,7 +329,7 @@ longbridge agent --skill                                            # Print the 
 longbridge order                                           # Today's orders, or historical with --history
 longbridge order --history [--start 2024-01-01]            # Historical orders (use --symbol to filter)
 longbridge order detail <order_id>                         # Full detail for a single order including charges and history
-longbridge order executions                                # Today's trade executions (fills), or historical with --history
+longbridge order executions                                # Today's trade executions (fills) (AP accounts only; US accounts use `order --history`)
 longbridge order buy TSLA.US 100 --price 250.00            # Preview a buy order (dry run); add --execute <CODE> to place it
 longbridge order sell TSLA.US 100 --price 260.00           # Preview a sell order (dry run); add --execute <CODE> to place it
 longbridge order cancel <order_id>                         # Preview cancelling a pending order (dry run); add --execute <CODE> to cancel it
@@ -391,6 +391,8 @@ longbridge investors changes 0001067983 --from 2024-12-31     # Compare latest v
 ```
 
 ### Recurring Investment
+
+_AP accounts only._
 
 ```bash
 longbridge dca                                                # List all recurring investment plans

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -246,7 +246,7 @@ pub enum Commands {
     /// Real-time quotes for one or more symbols
     ///
     /// Returns: symbol, `last_done`, `prev_close`, open, high, low, volume, turnover, `trade_status`.
-    /// Also returns `pre_market_quote`, `post_market_quote`, `overnight_quote` when available (US only).
+    /// Also returns `pre_market_quote`, `post_market_quote`, `overnight_quote` when available (US market only).
     /// In table format an "Extended Hours" section is appended; in JSON these are nested objects.
     /// Example: longbridge quote TSLA.US 700.HK AAPL.US
     /// Example: longbridge quote TSLA.US NVDA.US --format json
@@ -483,6 +483,9 @@ pub enum Commands {
     // ── Fundamentals ────────────────────────────────────────────────────────────
     /// Financial statements (income, balance sheet, cash flow) for a symbol
     ///
+    /// Behavior adapts to your account's region automatically; you never
+    /// pass a region. --kind/--latest apply only to AP accounts.
+    ///
     /// Subcommands: snapshot
     /// Example: longbridge financial-report TSLA.US --kind IS --report af
     /// Example: longbridge financial-report TSLA.US --kind BS --format json
@@ -493,13 +496,16 @@ pub enum Commands {
         /// Symbol in <CODE>.<MARKET> format, e.g. TSLA.US 700.HK (omit when using a subcommand)
         symbol: Option<String>,
         /// Statement type: IS (income), BS (balance sheet), CF (cash flow), ALL.
-        /// US accounts: omit to get financial summary (finn-overview).
+        /// AP accounts only. Ignored for US accounts, which always
+        /// return the finn-overview summary (the region is inferred from your account — do not pass it).
         #[arg(long, value_name = "TYPE", default_value = "")]
         kind: String,
         /// Report period: af (annual), saf (semi-annual), q1 (Q1), 3q (3 quarters), qf (quarterly)
         #[arg(long)]
         report: Option<String>,
-        /// Fetch the latest financial report summary instead of the full statement
+        /// AP accounts only: fetch the latest financial report summary
+        /// instead of the full statement. Not supported for US accounts (the region is
+        /// inferred from your account — do not pass it).
         #[arg(long)]
         latest: bool,
         #[command(subcommand)]
@@ -704,6 +710,9 @@ pub enum Commands {
 
     /// Valuation analysis: P/E, P/B, P/S, dividend yield, and peer comparison
     ///
+    /// Behavior adapts to your account's region automatically; you never
+    /// pass a region. --history/--indicator/--range apply only to AP accounts.
+    ///
     /// Default: current metrics + 5-year range + peer comparison.
     /// With --history: returns historical valuation time series (default indicator: pe).
     /// Example: longbridge valuation TSLA.US
@@ -713,13 +722,17 @@ pub enum Commands {
     Valuation {
         /// Symbol in <CODE>.<MARKET> format
         symbol: String,
-        /// Show historical valuation time series instead of current snapshot
+        /// AP accounts only: show historical valuation time series
+        /// instead of current snapshot. Not supported for US accounts (the region is
+        /// inferred from your account — do not pass it).
         #[arg(long)]
         history: bool,
-        /// Valuation indicator for history mode: `pe` | `pb` | `ps` | `dvd_yld`
+        /// Valuation indicator for history mode (AP accounts only):
+        /// `pe` | `pb` | `ps` | `dvd_yld`. Not supported for US accounts.
         #[arg(long)]
         indicator: Option<String>,
-        /// Historical range in years (history mode, default: 1): 1 | 3 | 5 | 10
+        /// Historical range in years (history mode, AP accounts only,
+        /// default: 1): 1 | 3 | 5 | 10. Not supported for US accounts.
         #[arg(long)]
         range: Option<String>,
     },
@@ -891,6 +904,9 @@ pub enum Commands {
     // ── Trade ───────────────────────────────────────────────────────────────────
     /// Order management: list, detail, buy, sell, cancel, replace, executions
     ///
+    /// Behavior adapts to your account's region automatically; you never
+    /// pass a region. --action/--page/--limit apply only to US accounts.
+    ///
     /// Without a subcommand, lists today's orders (or historical with --history).
     /// Example: longbridge order
     /// Example: longbridge order --history --start 2024-01-01 --symbol TSLA.US
@@ -913,13 +929,13 @@ pub enum Commands {
         /// Filter by symbol (e.g. TSLA.US)
         #[arg(long)]
         symbol: Option<String>,
-        /// US accounts only: filter by direction (buy | sell)
+        /// US accounts only: filter by direction (buy | sell). Ignored for AP accounts (the region is inferred from your account — do not pass it).
         #[arg(long, value_name = "DIRECTION")]
         action: Option<String>,
-        /// US accounts only: page number (default: 1)
+        /// US accounts only: page number (default: 1). Ignored for AP accounts (the region is inferred from your account — do not pass it).
         #[arg(long, default_value = "1")]
         page: u32,
-        /// US accounts only: page size (default: 20)
+        /// US accounts only: page size (default: 20). Ignored for AP accounts (the region is inferred from your account — do not pass it).
         #[arg(long, default_value = "20")]
         limit: u32,
         #[command(subcommand)]
@@ -971,6 +987,9 @@ pub enum Commands {
     },
 
     /// Current stock (equity) positions across all sub-accounts
+    ///
+    /// Behavior adapts to your account's region automatically; you never
+    /// pass a region.
     ///
     /// Returns: symbol, name, quantity, `available_quantity`, `cost_price`, currency, market.
     /// Example: longbridge positions --format json
@@ -1084,7 +1103,7 @@ pub enum Commands {
         cmd: Option<IndustryValuationCmd>,
     },
 
-    /// Operating reviews and financial indicators by report period (HK stocks only)
+    /// AP accounts only: operating reviews and financial indicators by report period (HK-listed stocks)
     ///
     /// Example: longbridge operating 700.HK
     /// Example: longbridge operating 700.HK --report q1
@@ -1149,7 +1168,7 @@ pub enum Commands {
     /// Example: longbridge market-status
     MarketStatus,
 
-    /// Broker holding positions (HK market only)
+    /// AP accounts only: broker holding positions (HK-listed stocks)
     ///
     /// Currently only supports HK-listed stocks. US and other markets are not available.
     /// Example: longbridge broker-holding 700.HK
@@ -1388,7 +1407,7 @@ pub enum Commands {
     },
 
     // ── Recurring Investment ──────────────────────────────────────────────────────
-    /// Recurring Investment: automatically invest a fixed amount at regular intervals
+    /// AP accounts only: Recurring Investment — automatically invest a fixed amount at regular intervals
     ///
     /// Create and manage recurring investment plans that execute stock purchases on a daily, weekly,
     /// fortnightly, or monthly schedule. Track trade history, monitor cumulative profit,
@@ -2640,7 +2659,7 @@ pub enum FinancialReportCmd {
     /// Example: longbridge financial-report key-metrics AAPL.US
     /// Example: longbridge financial-report key-metrics AAPL.US --report annual
     KeyMetrics {
-        /// Symbol in <CODE>.<MARKET> format (US only)
+        /// Symbol in <CODE>.<MARKET> format (US market only)
         symbol: String,
         /// Report period: annual (default) | quarterly
         #[arg(long)]
@@ -3255,19 +3274,23 @@ pub enum StatementCmd {
 pub enum OrderCmd {
     /// Full detail for a single order including charges and history
     ///
+    /// Behavior adapts to your account's region automatically; you never
+    /// pass a region. --attached applies only to US accounts.
+    ///
     /// Returns all fields from `order` plus `charge_detail`, `history_details`, msg.
     /// Example: longbridge order detail 20240101-123456789
     /// Example: longbridge order detail 20240101-123456789 --attached
     Detail {
         /// Order ID (from `longbridge order` or returned by `order buy`/`order sell`)
         order_id: String,
-        /// US accounts only: query the attached child order (take-profit/stop-loss)
+        /// US accounts only: query the attached child order (take-profit/stop-loss). Ignored for AP accounts (the region is inferred from your account — do not pass it).
         #[arg(long)]
         attached: bool,
     },
 
-    /// Today's trade executions (fills), or historical with --history
+    /// AP accounts only: today's trade executions (fills), or historical with --history
     ///
+    /// US accounts: use `order --history` instead.
     /// Returns: `order_id`, `trade_id`, symbol, price, quantity, `trade_done_at`.
     /// Example: longbridge order executions
     /// Example: longbridge order executions --history --start 2024-01-01
@@ -4765,6 +4788,70 @@ mod tests {
             .expect("spawn CLI parser thread")
             .join()
             .expect("CLI parser thread")
+    }
+
+    // ─── DC-region flag hygiene ───────────────────────────────────────────────
+    //
+    // Region-scoped flags must never be `required`. The account's data-center
+    // region is inferred from the credential, never passed by the caller, so a
+    // user in the other region must be able to run the command without them. A
+    // required region flag would force every caller to supply a value that is
+    // meaningless for their region — exactly the confusion this wording fixes.
+
+    #[test]
+    fn region_scoped_flags_are_never_required() {
+        use clap::CommandFactory;
+        // Same deep-recursion caveat as `parse`: build the tree on a roomy stack.
+        std::thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(|| {
+                let cmd = Cli::command();
+                let order = cmd
+                    .get_subcommands()
+                    .find(|c| c.get_name() == "order")
+                    .expect("order command");
+                for id in ["action", "page", "limit"] {
+                    let arg = order
+                        .get_arguments()
+                        .find(|a| a.get_id() == id)
+                        .unwrap_or_else(|| panic!("order --{id} not found"));
+                    assert!(!arg.is_required_set(), "order --{id} must stay optional");
+                }
+                let detail = order
+                    .get_subcommands()
+                    .find(|c| c.get_name() == "detail")
+                    .expect("order detail command");
+                let attached = detail
+                    .get_arguments()
+                    .find(|a| a.get_id() == "attached")
+                    .expect("order detail --attached not found");
+                assert!(
+                    !attached.is_required_set(),
+                    "order detail --attached must stay optional"
+                );
+
+                // Dual-region commands that carry region-scoped flags.
+                let checks = [
+                    ("financial-report", &["kind", "latest"][..]),
+                    ("valuation", &["history", "indicator", "range"][..]),
+                ];
+                for (name, ids) in checks {
+                    let sub = cmd
+                        .get_subcommands()
+                        .find(|c| c.get_name() == name)
+                        .unwrap_or_else(|| panic!("{name} command"));
+                    for id in ids {
+                        let arg = sub
+                            .get_arguments()
+                            .find(|a| a.get_id() == *id)
+                            .unwrap_or_else(|| panic!("{name} --{id} not found"));
+                        assert!(!arg.is_required_set(), "{name} --{id} must stay optional");
+                    }
+                }
+            })
+            .expect("spawn command-introspection thread")
+            .join()
+            .expect("command-introspection thread");
     }
 
     // ─── Format flag ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Aligns the CLI's DC-region help text with the conventions just landed in longbridge-mcp (PR #141 recoverable + PR #143 DC-region wording). **Wording only — no behavior change.** The goal is that a CLI-driving AI never calls a wrong-region command, and never passes a region parameter that does not exist. Region is the account's data center (`DcRegion::from_credential`, `x-dc-region: ap|us`), never an argument — so the wording uses just two names: **US accounts** and **AP accounts**.

## Source

**Region-exclusive commands** — help now leads with an explicit `US accounts only:` / `AP accounts only:` gate:
- `US accounts only:` — `financial-report key-metrics`, `etf-docs`, `profit-analysis realized`
- `AP accounts only:` — `broker-holding` (+ `detail`/`daily`), `operating`, `dca`, `order executions` (also names `order --history` as the US-account alternative)

**Region-branching commands** — `order`, `order detail`, `positions`, `financial-report`, `valuation` now state that behavior adapts to the account's region automatically and no region is ever passed. Their region-scoped flags share one wording — `<US|AP> accounts only: <what>. … the region is inferred from your account — do not pass it`:
- **US accounts only:** `order --action/--page/--limit`, `order detail --attached`
- **AP accounts only:** `financial-report --kind/--latest`, `valuation --history/--indicator/--range`

Every region gate — command headers and flags alike — now uses the same `US accounts only:` / `AP accounts only:` phrasing (no more bracket tags).

**Intentionally left as-is:** `brokers` ("HK market") and `--outside-rth` ("US market only") gate by *market*, not by account data-center region, so they keep market-level wording. No `--region` argument exists (confirmed), and none was added. `static`'s internal US-crypto routing is transparent to the caller and left untouched.

**Out of scope (follow-up PR):** behavior changes — hiding/disabling wrong-region commands by account region, and unifying the currently-inconsistent wrong-region failure paths (client-side bail / SDK-error rewrite / `dc_restrict` / no gate) into one early-fail-with-named-alternative.

## Locales

None. CLI command/flag help is hardcoded English via clap doc-comments (not routed through `rust-i18n`); `locales/{en,zh-CN,zh-HK}.yml` carry no command-help strings (only `watchlist_group.us/hk`). Nothing to sync — unlike longbridge-mcp, which has localized help.

## Testing

- `cargo fmt` + `cargo clippy` clean; `cargo test` — 827 pass.
- New regression test `region_scoped_flags_are_never_required` asserts every region-scoped flag stays optional (never `required`): `order --action/--page/--limit`, `order detail --attached`, `financial-report --kind/--latest`, `valuation --history/--indicator/--range`. Mirrors mcp's `region_scoped_us_params_are_optional`.
- Spot-checked rendered `--help` for every reworded command and flag.
