### PR TITLE
cli: Give a clear error when a statement is no longer available

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3204,8 +3204,8 @@ pub enum StatementCmd {
     /// List available statements for an account
     ///
     /// Returns: date (dt), `file_key` for each statement.
-    /// Example: longbridge statement list --aaid 12345
-    /// Example: longbridge statement list --aaid 12345 --type monthly
+    /// Example: longbridge statement list
+    /// Example: longbridge statement list --type monthly
     List {
         /// Statement type: daily (default) | monthly
         #[arg(long = "type", default_value = "daily")]

--- a/src/cli/statement.rs
+++ b/src/cli/statement.rs
@@ -158,7 +158,12 @@ async fn cmd_export(
 
     // Fetch the statement JSON
     let client = reqwest::Client::new();
-    let body = client.get(&resp.url).send().await?.text().await?;
+    let http_resp = client.get(&resp.url).send().await?;
+    let status = http_resp.status();
+    let body = http_resp.text().await?;
+    if !status.is_success() {
+        anyhow::bail!(statement_download_error(status.as_u16(), &body));
+    }
     let value: Value = serde_json::from_str(&body)?;
     let content: CommonStatementContent = serde_json::from_value(value)?;
 
@@ -1257,9 +1262,41 @@ fn markdown_cell_width(cell: &str) -> usize {
     UnicodeWidthStr::width(escape_markdown_cell(cell).as_ref())
 }
 
+/// Turn a failed statement-download HTTP response into an actionable error.
+///
+/// The download URL points at object storage that returns an XML error body
+/// (not JSON) when the object is missing. Parsing that as JSON used to surface
+/// the cryptic `expected value at line 1 column 1`, so map it to a clear
+/// message here instead.
+fn statement_download_error(status: u16, body: &str) -> String {
+    if status == 404 || body.contains("<Code>NoSuchKey</Code>") {
+        return "statement not available for this file key — Longbridge only keeps recent \
+             statements online, so older ones are no longer downloadable via the API. \
+             Get them from the Longbridge app or website (Me → Statements), or contact support."
+            .to_string();
+    }
+    format!("failed to download statement (HTTP {status})")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn download_error_for_missing_object_is_actionable() {
+        let body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>";
+        let msg = statement_download_error(404, body);
+        // Must not leak the misleading JSON-parser error the user reported.
+        assert!(!msg.contains("expected value"));
+        // Must tell the user this statement simply isn't available.
+        assert!(msg.contains("not available"), "got: {msg}");
+    }
+
+    #[test]
+    fn download_error_for_other_status_includes_status_code() {
+        let msg = statement_download_error(403, "<Error><Code>AccessDenied</Code></Error>");
+        assert!(msg.contains("403"), "got: {msg}");
+    }
 
     fn csv_record(data: &str) -> Vec<String> {
         let mut reader = csv::Reader::from_reader(data.as_bytes());


### PR DESCRIPTION
## Problem

`longbridge statement export --file-key ...` failed with the cryptic
`Error: expected value at line 1 column 1` for older statements (e.g. a user
trying to export 2024 monthly statements for tax filing).

## Root cause

`cmd_export` fetches the presigned download URL and runs `serde_json::from_str`
on the body unconditionally. Older statement JSON is only retained on object
storage for a limited window; once purged, the URL returns **HTTP 404 with an
S3 XML error body** (`<Code>NoSuchKey</Code>`). Parsing that XML as JSON is what
produced the confusing `expected value at line 1 column 1`.

Verified end-to-end: an existing month (e.g. 202606) returns `200` + valid JSON
and exports fine; a missing month returns `404` + XML.

## Fix

- Check the HTTP status before parsing. On a missing object, return an
  actionable message telling the user the statement is no longer available via
  the API and to get it from the Longbridge app/website or support.
- Drop the stale `--aaid 12345` example from `statement list --help` — no such
  flag exists on the command.

## Notes

- Older statements past the retention window genuinely cannot be retrieved via
  this API; this PR only makes that situation legible instead of a JSON parse
  error.
- Unit tests cover the error mapping (missing object → actionable message;
  other statuses → include the status code). `cargo fmt` / `cargo clippy` clean.