### PR TITLE
cli: Export legacy statements and report download failures in `statement export`

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ longbridge statement export --file-key <KEY> --section equity_holdings  # Export
 longbridge statement export --file-key <KEY> --all                     # Export all non-empty sections
 ```
 
-JSON statements exist from 2024-08 onward and export as sections. Earlier statements were delivered as password-protected PDFs: `statement list` fills those periods in from the PDF list (`format` column `pdf`, `file_key` ending in `.pdf`), and `statement export` with such a key saves the PDF and prints its password.
+JSON statements exist from 2024-08 onward and export as sections. Earlier statements were delivered as password-protected PDFs: `statement list` fills those periods in from the PDF list (`format` column `pdf`, `file_key` ending in `.pdf`), and `statement export` with such a key saves the PDF and prints the password rule (last 4 digits of the mobile number + last 4 characters of the account-opening ID, e.g. mobile 12345678 and ID 123456(X) give `5678456X`).
 
 ### Insider Trades
 

--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ longbridge statement export --file-key <KEY> --section equity_holdings  # Export
 longbridge statement export --file-key <KEY> --all                     # Export all non-empty sections
 ```
 
+JSON statements exist only from 2024-08 onward. Earlier statements were delivered as password-protected PDFs: download them from the Longbridge app or use the PDF attached to the statement email (the email explains the password format). An entry with an empty `file_key` in `statement list` has no exportable file.
+
 ### Insider Trades
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ longbridge statement export --file-key <KEY> --section equity_holdings  # Export
 longbridge statement export --file-key <KEY> --all                     # Export all non-empty sections
 ```
 
-JSON statements exist only from 2024-08 onward. Earlier statements were delivered as password-protected PDFs: download them from the Longbridge app or use the PDF attached to the statement email (the email explains the password format). An entry with an empty `file_key` in `statement list` has no exportable file.
+JSON statements exist from 2024-08 onward and export as sections. Earlier statements were delivered as password-protected PDFs: `statement list` fills those periods in from the PDF list (`format` column `pdf`, `file_key` ending in `.pdf`), and `statement export` with such a key saves the PDF and prints its password.
 
 ### Insider Trades
 

--- a/src/cli/agent/client.rs
+++ b/src/cli/agent/client.rs
@@ -316,10 +316,7 @@ fn map_event(ev: ConversationStreamEvent) -> Option<AgentEvent> {
         // The SDK has no typed variant for `token_usage`, so it arrives here as
         // a raw event carrying the cumulative counts for the round.
         ConversationStreamEvent::Other { event, data } if event == "token_usage" => {
-            match crate::openapi::chats::TokenUsage::from_data(&data) {
-                Some(usage) => AgentEvent::TokenUsage(usage),
-                None => return None,
-            }
+            AgentEvent::TokenUsage(crate::openapi::chats::TokenUsage::from_data(&data)?)
         }
         ConversationStreamEvent::Other { event, .. } => AgentEvent::Unknown { event },
         // Progress-only events the CLI does not display.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -871,6 +871,12 @@ pub enum Commands {
     /// Download and export account statements (daily/monthly)
     ///
     /// Without a subcommand, lists available statements (equivalent to `statement list`).
+    ///
+    /// Only statements issued from 2024-08 onward are available as JSON here.
+    /// Earlier statements were delivered as password-protected PDFs: get them
+    /// from the Longbridge app or the statement email (which explains the
+    /// password format).
+    ///
     /// Example: longbridge statement
     /// Example: longbridge statement --type monthly
     /// Example: longbridge statement export --file-key KEY --section `equity_holdings`
@@ -3203,7 +3209,11 @@ impl ConstituentOrder {
 pub enum StatementCmd {
     /// List available statements for an account
     ///
-    /// Returns: date (dt), `file_key` for each statement.
+    /// Returns: date (dt), `file_key` for each statement. An empty `file_key`
+    /// means no JSON statement exists for that period: statements issued before
+    /// 2024-08 were delivered only as password-protected PDFs, available from
+    /// the Longbridge app or the statement email (which explains the password
+    /// format).
     /// Example: longbridge statement list --aaid 12345
     /// Example: longbridge statement list --aaid 12345 --type monthly
     List {
@@ -3226,9 +3236,13 @@ pub enum StatementCmd {
     /// When `-o` is provided, defaults to CSV format and saves to file(s).
     /// When `-o` is omitted, defaults to markdown format and prints to stdout.
     ///
-    /// Statements issued before 2022-03 use a legacy layout: `--section` is
-    /// ignored, every populated table is exported, and `--format json` prints
-    /// the raw statement document.
+    /// Only statements issued from 2024-08 onward are available as JSON.
+    /// Earlier periods were delivered as password-protected PDFs (Longbridge
+    /// app, or the statement email, which explains the password format); an
+    /// entry with an empty `file_key` cannot be exported here. Where an older
+    /// JSON file does exist it uses a legacy layout: `--section` is ignored,
+    /// every populated table is exported, and `--format json` prints the raw
+    /// statement document.
     ///
     /// Example: longbridge statement export --file-key KEY --section `equity_holdings`
     /// Example: longbridge statement export --file-key KEY --section `equity_holdings` -o holdings.csv

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -875,7 +875,8 @@ pub enum Commands {
     /// Statements issued from 2024-08 onward are JSON and export as sections.
     /// Earlier statements exist only as password-protected PDFs; `statement list`
     /// fills those periods in from the PDF list and `statement export` saves the
-    /// PDF together with its password.
+    /// PDF and prints the password rule (last 4 digits of the mobile number +
+    /// last 4 characters of the account-opening ID).
     ///
     /// Example: longbridge statement
     /// Example: longbridge statement --type monthly
@@ -3237,7 +3238,8 @@ pub enum StatementCmd {
     ///
     /// A `.pdf` file key (statements issued before 2024-08, listed by
     /// `statement list` for periods without JSON) is saved as a PDF file and
-    /// its password is printed; `--section` does not apply. Older JSON files
+    /// the password rule is printed (last 4 digits of the mobile number + last
+    /// 4 characters of the account-opening ID); `--section` does not apply. Older JSON files
     /// use a legacy layout: `--section` is ignored, every populated table is
     /// exported, and `--format json` prints the raw statement document.
     ///

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3226,6 +3226,10 @@ pub enum StatementCmd {
     /// When `-o` is provided, defaults to CSV format and saves to file(s).
     /// When `-o` is omitted, defaults to markdown format and prints to stdout.
     ///
+    /// Statements issued before 2022-03 use a legacy layout: `--section` is
+    /// ignored, every populated table is exported, and `--format json` prints
+    /// the raw statement document.
+    ///
     /// Example: longbridge statement export --file-key KEY --section `equity_holdings`
     /// Example: longbridge statement export --file-key KEY --section `equity_holdings` -o holdings.csv
     Export {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -872,10 +872,10 @@ pub enum Commands {
     ///
     /// Without a subcommand, lists available statements (equivalent to `statement list`).
     ///
-    /// Only statements issued from 2024-08 onward are available as JSON here.
-    /// Earlier statements were delivered as password-protected PDFs: get them
-    /// from the Longbridge app or the statement email (which explains the
-    /// password format).
+    /// Statements issued from 2024-08 onward are JSON and export as sections.
+    /// Earlier statements exist only as password-protected PDFs; `statement list`
+    /// fills those periods in from the PDF list and `statement export` saves the
+    /// PDF together with its password.
     ///
     /// Example: longbridge statement
     /// Example: longbridge statement --type monthly
@@ -3209,11 +3209,10 @@ impl ConstituentOrder {
 pub enum StatementCmd {
     /// List available statements for an account
     ///
-    /// Returns: date (dt), `file_key` for each statement. An empty `file_key`
-    /// means no JSON statement exists for that period: statements issued before
-    /// 2024-08 were delivered only as password-protected PDFs, available from
-    /// the Longbridge app or the statement email (which explains the password
-    /// format).
+    /// Returns: date (dt), `file_key` and `format` (`json` or `pdf`) for each
+    /// statement. Periods without a JSON file (statements issued before 2024-08
+    /// were delivered as password-protected PDFs) are filled in from the PDF
+    /// list, so their `file_key` ends in `.pdf`.
     /// Example: longbridge statement list --aaid 12345
     /// Example: longbridge statement list --aaid 12345 --type monthly
     List {
@@ -3236,13 +3235,11 @@ pub enum StatementCmd {
     /// When `-o` is provided, defaults to CSV format and saves to file(s).
     /// When `-o` is omitted, defaults to markdown format and prints to stdout.
     ///
-    /// Only statements issued from 2024-08 onward are available as JSON.
-    /// Earlier periods were delivered as password-protected PDFs (Longbridge
-    /// app, or the statement email, which explains the password format); an
-    /// entry with an empty `file_key` cannot be exported here. Where an older
-    /// JSON file does exist it uses a legacy layout: `--section` is ignored,
-    /// every populated table is exported, and `--format json` prints the raw
-    /// statement document.
+    /// A `.pdf` file key (statements issued before 2024-08, listed by
+    /// `statement list` for periods without JSON) is saved as a PDF file and
+    /// its password is printed; `--section` does not apply. Older JSON files
+    /// use a legacy layout: `--section` is ignored, every populated table is
+    /// exported, and `--format json` prints the raw statement document.
     ///
     /// Example: longbridge statement export --file-key KEY --section `equity_holdings`
     /// Example: longbridge statement export --file-key KEY --section `equity_holdings` -o holdings.csv

--- a/src/cli/statement.rs
+++ b/src/cli/statement.rs
@@ -157,6 +157,7 @@ async fn cmd_export(
     output_path: Option<&str>,
     output_format: &OutputFormat,
 ) -> Result<()> {
+    let explicit_sections = !sections.is_empty();
     let sections = resolve_sections(all, sections)?;
 
     if file_key.trim().is_empty() {
@@ -185,7 +186,7 @@ async fn cmd_export(
     if is_legacy_statement(&value) {
         return export_legacy(
             &value,
-            sections,
+            explicit_sections,
             explicit_format,
             output_path,
             output_format,
@@ -327,12 +328,12 @@ fn is_legacy_statement(value: &Value) -> bool {
 /// not exist in that layout, so every populated table is exported.
 fn export_legacy(
     value: &Value,
-    sections: &[StatementSection],
+    explicit_sections: bool,
     explicit_format: Option<ExportFormat>,
     output_path: Option<&str>,
     output_format: &OutputFormat,
 ) -> Result<()> {
-    if !sections.is_empty() {
+    if explicit_sections {
         eprintln!(
             "Note: this statement uses the legacy layout (issued before 2022-03); \
              --section is ignored and all populated tables are exported."

--- a/src/cli/statement.rs
+++ b/src/cli/statement.rs
@@ -278,8 +278,8 @@ const ALL_SECTIONS: &[StatementSection] = &[
 /// PDFs, so there is usually no JSON file behind the API for those periods.
 const PDF_STATEMENT_HINT: &str = "Statements issued before 2024-08 were delivered as \
     password-protected PDFs. Run `longbridge statement list`: periods without a JSON file \
-    are listed with a PDF file_key, and `statement export` downloads that PDF together with \
-    its password.";
+    are listed with a PDF file_key, and `statement export` downloads that PDF and explains \
+    how to unlock it.";
 
 /// Explicit `--section` values win; `--all` (the default) selects every
 /// section. `--all` defaults to true, so an explicit `--section` must be
@@ -426,6 +426,8 @@ async fn cmd_export(
     Ok(())
 }
 
+use crate::openapi::statement::PDF_PASSWORD_RULE;
+
 /// PDF statements are listed with keys ending in `.pdf`.
 fn is_pdf_key(file_key: &str) -> bool {
     file_key.trim().to_ascii_lowercase().ends_with(".pdf")
@@ -462,7 +464,7 @@ fn pdf_output_path(output: Option<&str>, file_name: &str) -> std::path::PathBuf 
     }
 }
 
-/// Download a PDF statement and save it, printing the password that opens it.
+/// Download a PDF statement and save it, printing how to unlock it.
 async fn export_pdf(
     file_key: &str,
     explicit_sections: bool,
@@ -493,13 +495,13 @@ async fn export_pdf(
     if matches!(output_format, OutputFormat::Json) {
         let out = serde_json::json!({
             "file": path.display().to_string(),
-            "password": dl.pass,
             "cache_key": dl.cache_key,
+            "password_rule": PDF_PASSWORD_RULE,
         });
         println!("{}", serde_json::to_string_pretty(&out)?);
     } else {
         println!("Saved PDF statement to {}", path.display());
-        println!("Password: {}", dl.pass);
+        println!("{PDF_PASSWORD_RULE}");
     }
     Ok(())
 }

--- a/src/cli/statement.rs
+++ b/src/cli/statement.rs
@@ -136,6 +136,19 @@ const ALL_SECTIONS: &[StatementSection] = &[
     StatementSection::GstDetails,
 ];
 
+/// Explicit `--section` values win; `--all` (the default) selects every
+/// section. `--all` defaults to true, so an explicit `--section` must be
+/// checked first or it would never take effect.
+fn resolve_sections(all: bool, sections: &[StatementSection]) -> Result<&[StatementSection]> {
+    if !sections.is_empty() {
+        Ok(sections)
+    } else if all {
+        Ok(ALL_SECTIONS)
+    } else {
+        anyhow::bail!("Specify --section or --all")
+    }
+}
+
 async fn cmd_export(
     file_key: &str,
     sections: &[StatementSection],
@@ -144,13 +157,14 @@ async fn cmd_export(
     output_path: Option<&str>,
     output_format: &OutputFormat,
 ) -> Result<()> {
-    let sections = if all {
-        ALL_SECTIONS
-    } else if sections.is_empty() {
-        anyhow::bail!("Specify --section or --all");
-    } else {
-        sections
-    };
+    let sections = resolve_sections(all, sections)?;
+
+    if file_key.trim().is_empty() {
+        anyhow::bail!(
+            "Empty --file-key: this statement has no downloadable file. \
+             Use `longbridge statement list` and pick an entry with a non-empty file_key."
+        );
+    }
 
     let ctx = crate::openapi::statement();
     let options = GetStatementOptions::new(file_key);
@@ -158,8 +172,25 @@ async fn cmd_export(
 
     // Fetch the statement JSON
     let client = reqwest::Client::new();
-    let body = client.get(&resp.url).send().await?.text().await?;
-    let value: Value = serde_json::from_str(&body)?;
+    let http = client.get(&resp.url).send().await?;
+    let status = http.status().as_u16();
+    let content_type = http
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(ToString::to_string);
+    let body = http.text().await?;
+    let value = parse_statement_body(status, content_type.as_deref(), &body)?;
+
+    if is_legacy_statement(&value) {
+        return export_legacy(
+            &value,
+            sections,
+            explicit_format,
+            output_path,
+            output_format,
+        );
+    }
     let content: CommonStatementContent = serde_json::from_value(value)?;
 
     // --format json: output all sections as a single JSON object keyed by section name.
@@ -204,7 +235,7 @@ async fn cmd_export(
 
     match output_path {
         Some(path) => {
-            if sections.len() == 1 && !all {
+            if sections.len() == 1 {
                 let data = section_to_format(&content, &sections[0], &format)?;
                 std::fs::write(path, data)?;
                 println!("Saved {:?} to {path}", sections[0]);
@@ -244,9 +275,121 @@ async fn cmd_export(
     Ok(())
 }
 
+/// Parse the downloaded statement body, reporting HTTP status, content type
+/// and a body excerpt when it is not the expected JSON document.
+///
+/// Statements issued before the current storage format (older `file_key`
+/// prefixes) resolve to a download URL whose body is an XML/HTML error page
+/// rather than JSON; surfacing that body is the only way to tell why.
+fn parse_statement_body(status: u16, content_type: Option<&str>, body: &str) -> Result<Value> {
+    let describe = || {
+        let content_type = content_type.unwrap_or("unknown");
+        let excerpt: String = body.trim().chars().take(300).collect();
+        let excerpt = if excerpt.is_empty() {
+            "(empty body)".to_string()
+        } else {
+            excerpt
+        };
+        format!("HTTP {status}, content-type: {content_type}\n{excerpt}")
+    };
+
+    if body.trim().is_empty() {
+        anyhow::bail!(
+            "Statement download returned an empty body ({}). \
+             The file behind this file_key is not available for download.",
+            describe()
+        );
+    }
+    let mut value: Value = serde_json::from_str(body).map_err(|e| {
+        anyhow::anyhow!(
+            "Statement download did not return JSON ({e}).\n{}\n\
+             No statement file exists behind this file_key (the list may show an empty \
+             file_key for that period); request it from Longbridge support.",
+            describe()
+        )
+    })?;
+    // Statements issued before 2022-12 serialize empty sections as `null`.
+    crate::utils::json::strip_nulls(&mut value);
+    Ok(value)
+}
+
+/// Statements issued before 2022-03 use a different document layout
+/// (`AssetDetail`, `CashDetails`, `StockHoldingDetails`, ...) that the
+/// section mapping in this module does not know about.
+fn is_legacy_statement(value: &Value) -> bool {
+    value
+        .as_object()
+        .is_some_and(|o| !o.contains_key("Asset") && o.contains_key("AssetDetail"))
+}
+
+/// Export a legacy-layout statement by flattening the raw document into
+/// generic tables. `--section` cannot be honored because the section names do
+/// not exist in that layout, so every populated table is exported.
+fn export_legacy(
+    value: &Value,
+    sections: &[StatementSection],
+    explicit_format: Option<ExportFormat>,
+    output_path: Option<&str>,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    if !sections.is_empty() {
+        eprintln!(
+            "Note: this statement uses the legacy layout (issued before 2022-03); \
+             --section is ignored and all populated tables are exported."
+        );
+    }
+
+    if matches!(output_format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(value)?);
+        return Ok(());
+    }
+
+    let tables = crate::utils::json::flatten_tables(value);
+    let format = explicit_format.unwrap_or(if output_path.is_some() {
+        ExportFormat::Csv
+    } else {
+        ExportFormat::Md
+    });
+    let ext = match format {
+        ExportFormat::Csv => "csv",
+        ExportFormat::Md => "md",
+    };
+
+    let dir = output_path.map(std::path::Path::new);
+    if let Some(dir) = dir {
+        std::fs::create_dir_all(dir)?;
+    }
+    for table in &tables {
+        let headers: Vec<&str> = table.headers.iter().map(String::as_str).collect();
+        let rows: Vec<Vec<&str>> = table
+            .rows
+            .iter()
+            .map(|r| r.iter().map(String::as_str).collect())
+            .collect();
+        let data = SectionData {
+            title: &table.title,
+            headers: &headers,
+            rows,
+        };
+        let formatted = match format {
+            ExportFormat::Csv => data.to_csv()?,
+            ExportFormat::Md => data.to_markdown(),
+        };
+        match dir {
+            Some(dir) => {
+                let file_path = dir.join(format!("{}.{ext}", table.name));
+                std::fs::write(&file_path, formatted)?;
+                println!("Saved {} to {}", table.title, file_path.display());
+            }
+            None => print!("{formatted}"),
+        }
+    }
+    Ok(())
+}
+
 struct SectionData<'a> {
-    title: &'static str,
-    headers: &'static [&'static str],
+    title: &'a str,
+    headers: &'a [&'a str],
     rows: Vec<Vec<&'a str>>,
 }
 
@@ -320,7 +463,8 @@ fn section_data<'a>(
                     .iter()
                     .map(|b| {
                         vec![
-                            b.currency_code.as_str(), // In fact, only this one has a value, so it shows "currency" above, but this uses "currency code"
+                            // Files issued before 2024-08 carry only `Currency`.
+                            first_non_empty(&[&b.currency_code, &b.currency]),
                             b.begin_amount.as_str(),
                             b.begin_amount_as_hkd.as_str(),
                             b.change_amount.as_str(),
@@ -1260,6 +1404,70 @@ fn markdown_cell_width(cell: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn explicit_sections_override_default_all() {
+        let picked = [StatementSection::Asset];
+        assert_eq!(resolve_sections(true, &picked).unwrap().len(), 1);
+        assert_eq!(
+            resolve_sections(true, &[]).unwrap().len(),
+            ALL_SECTIONS.len()
+        );
+        assert!(resolve_sections(false, &[]).is_err());
+    }
+
+    #[test]
+    fn account_balances_fall_back_to_currency_name() {
+        let content: CommonStatementContent = serde_json::from_str(
+            r#"{"AccountBalanceSum":{"AccountBalances":[{"Currency":"美元","BeginAmount":"1"}]}}"#,
+        )
+        .unwrap();
+        let data = section_data(&content, &StatementSection::AccountBalanceSum);
+        assert_eq!(data.rows[0][0], "美元");
+    }
+
+    #[test]
+    fn parse_statement_body_rejects_non_json_with_context() {
+        let body = r#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>"#;
+        let err = parse_statement_body(404, Some("application/xml"), body).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("HTTP 404"), "{msg}");
+        assert!(msg.contains("application/xml"), "{msg}");
+        assert!(msg.contains("NoSuchKey"), "{msg}");
+    }
+
+    #[test]
+    fn parse_statement_body_reports_empty_body() {
+        let err = parse_statement_body(200, None, "").unwrap_err();
+        assert!(err.to_string().contains("empty"), "{err}");
+    }
+
+    #[test]
+    fn parse_statement_body_accepts_json() {
+        let value =
+            parse_statement_body(200, Some("application/json"), r#"{"Date":"202411"}"#).unwrap();
+        assert_eq!(value["Date"], "202411");
+    }
+
+    #[test]
+    fn parse_statement_body_tolerates_null_sections() {
+        let value = parse_statement_body(
+            200,
+            None,
+            r#"{"Asset":{"Currency":"HKD"},"Interests":null,"FundTradeSums":null}"#,
+        )
+        .unwrap();
+        let content: CommonStatementContent = serde_json::from_value(value).unwrap();
+        assert_eq!(content.asset.currency, "HKD");
+        assert!(content.interests.is_empty());
+    }
+
+    #[test]
+    fn legacy_layout_is_detected_by_asset_detail() {
+        assert!(is_legacy_statement(&serde_json::json!({"AssetDetail": {}})));
+        assert!(!is_legacy_statement(&serde_json::json!({"Asset": {}})));
+        assert!(!is_legacy_statement(&serde_json::json!({})));
+    }
 
     fn csv_record(data: &str) -> Vec<String> {
         let mut reader = csv::Reader::from_reader(data.as_bytes());

--- a/src/cli/statement.rs
+++ b/src/cli/statement.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use crate::data::statement::CommonStatementContent;
+use crate::openapi::statement::{PdfStatementItem, PdfStatementKind};
 use anyhow::Result;
 use longbridge::asset::{GetStatementListOptions, GetStatementOptions, StatementType};
 use serde_json::Value;
@@ -83,8 +84,8 @@ pub async fn cmd_statement(cmd: StatementCmd, format: &OutputFormat) -> Result<(
 
 async fn cmd_list(
     statement_type: &str,
-    page: i32,
-    page_size: i32,
+    start_date: i32,
+    limit: i32,
     format: &OutputFormat,
 ) -> Result<()> {
     let st = match statement_type.to_lowercase().as_str() {
@@ -95,18 +96,153 @@ async fn cmd_list(
 
     let ctx = crate::openapi::statement();
     let options = GetStatementListOptions::new(st)
-        .page(page)
-        .page_size(page_size);
+        .page(start_date)
+        .page_size(limit);
     let resp = ctx.statements(options).await?;
-
-    let headers = &["Date", "File Key"];
-    let rows: Vec<Vec<String>> = resp
+    let json: Vec<(i32, String)> = resp
         .list
-        .iter()
-        .map(|item| vec![item.dt.to_string(), item.file_key.clone()])
+        .into_iter()
+        .map(|item| (item.dt, item.file_key))
+        .collect();
+
+    // PDFs only fill in what the JSON list cannot provide, and only for
+    // periods that predate the JSON statement service.
+    let now = OffsetDateTime::now_utc();
+    let now_month = format!("{}{:02}", now.year(), now.month() as u8);
+    let pdf = match pdf_fill_window(start_date, &json, limit, &now_month) {
+        Some((from, to)) => {
+            let kind = match st {
+                StatementType::Daily => PdfStatementKind::Daily,
+                StatementType::Monthly => PdfStatementKind::Monthly,
+            };
+            crate::openapi::statement::pdf_statements(kind, &from, &to).await?
+        }
+        None => Vec::new(),
+    };
+    let rows = merge_statement_rows(&json, &pdf, limit);
+
+    let headers = &["Date", "File Key", "Format"];
+    let rows: Vec<Vec<String>> = rows
+        .into_iter()
+        .map(|r| vec![r.date, r.file_key, r.format.to_string()])
         .collect();
     print_table(headers, rows, format);
     Ok(())
+}
+
+/// Last month for which a statement may exist only as a PDF. From 2025-01 on
+/// every statement has a JSON file, so the PDF list is never consulted there.
+const LAST_PDF_ONLY_MONTH: &str = "202412";
+
+/// The `yyyyMM` range to ask the PDF list for, or `None` when the JSON list
+/// already covers the request.
+///
+/// The PDF endpoint is consulted only when the window starts on or before
+/// [`LAST_PDF_ONLY_MONTH`] and the JSON list is short of the request: an
+/// entry without a file, fewer entries than asked for, or (monthly) a month
+/// missing from the middle of the window.
+fn pdf_fill_window(
+    start_date: i32,
+    json: &[(i32, String)],
+    limit: i32,
+    now_month: &str,
+) -> Option<(String, String)> {
+    let from = yyyymm(start_date);
+    if from.as_str() > LAST_PDF_ONLY_MONTH {
+        return None;
+    }
+    let short = json.len() < usize::try_from(limit).unwrap_or(usize::MAX);
+    let to = if short {
+        now_month.to_string()
+    } else {
+        json.iter().map(|(dt, _)| yyyymm(*dt)).max()?
+    };
+    let to = if to.as_str() > LAST_PDF_ONLY_MONTH {
+        LAST_PDF_ONLY_MONTH.to_string()
+    } else {
+        to
+    };
+    if to < from {
+        return None;
+    }
+    let has_gap = json.iter().any(|(_, key)| key.is_empty()) || short || {
+        // Monthly dates are exactly `yyyyMM`; a missing month in the window is a gap.
+        let monthly = json.iter().all(|(dt, _)| *dt < 1_000_000);
+        monthly && {
+            let months: std::collections::BTreeSet<String> =
+                json.iter().map(|(dt, _)| dt.to_string()).collect();
+            months_between(&from, &to).any(|m| !months.contains(&m))
+        }
+    };
+    has_gap.then_some((from, to))
+}
+
+/// `yyyyMMdd` or `yyyyMM` -> `yyyyMM`.
+fn yyyymm(date: i32) -> String {
+    if date >= 1_000_000 {
+        format!("{:06}", date / 100)
+    } else {
+        format!("{date:06}")
+    }
+}
+
+fn months_between(from: &str, to: &str) -> impl Iterator<Item = String> {
+    let parse = |m: &str| -> Option<i32> {
+        let y: i32 = m.get(..4)?.parse().ok()?;
+        let mo: i32 = m.get(4..6)?.parse().ok()?;
+        Some(y * 12 + mo - 1)
+    };
+    let (a, b) = (parse(from).unwrap_or(0), parse(to).unwrap_or(-1));
+    (a..=b).map(|n| format!("{}{:02}", n / 12, n % 12 + 1))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StatementRow {
+    date: String,
+    file_key: String,
+    /// `json`, `pdf`, or empty when no file exists in either form.
+    format: &'static str,
+}
+
+/// Merge the JSON list with PDF entries: a PDF only fills a date whose JSON
+/// entry is missing or has no file. Sorted by date, at most `limit` rows.
+fn merge_statement_rows(
+    json: &[(i32, String)],
+    pdf: &[PdfStatementItem],
+    limit: i32,
+) -> Vec<StatementRow> {
+    let mut rows: std::collections::BTreeMap<String, StatementRow> = json
+        .iter()
+        .map(|(dt, key)| {
+            let date = dt.to_string();
+            let format = if key.is_empty() { "" } else { "json" };
+            (
+                date.clone(),
+                StatementRow {
+                    date,
+                    file_key: key.clone(),
+                    format,
+                },
+            )
+        })
+        .collect();
+    for item in pdf {
+        let date = item.display_name.replace('.', "");
+        let filled = rows.get(&date).is_some_and(|r| !r.file_key.is_empty());
+        if !filled {
+            rows.insert(
+                date.clone(),
+                StatementRow {
+                    date,
+                    file_key: item.key.clone(),
+                    format: "pdf",
+                },
+            );
+        }
+    }
+    rows.into_values()
+        .take(usize::try_from(limit).unwrap_or(usize::MAX))
+        .collect()
 }
 
 const ALL_SECTIONS: &[StatementSection] = &[
@@ -138,11 +274,12 @@ const ALL_SECTIONS: &[StatementSection] = &[
 
 /// Where to find statements that predate the JSON statement service.
 ///
-/// Statements issued before 2024-08 were delivered only as password-protected
+/// Statements issued before 2024-08 were delivered as password-protected
 /// PDFs, so there is usually no JSON file behind the API for those periods.
-const PDF_STATEMENT_HINT: &str = "Statements issued before 2024-08 were delivered only as \
-    password-protected PDFs: download them from the Longbridge app or use the PDF attached \
-    to the statement email (the email explains the password format).";
+const PDF_STATEMENT_HINT: &str = "Statements issued before 2024-08 were delivered as \
+    password-protected PDFs. Run `longbridge statement list`: periods without a JSON file \
+    are listed with a PDF file_key, and `statement export` downloads that PDF together with \
+    its password.";
 
 /// Explicit `--section` values win; `--all` (the default) selects every
 /// section. `--all` defaults to true, so an explicit `--section` must be
@@ -174,6 +311,10 @@ async fn cmd_export(
              Use `longbridge statement list` and pick an entry with a non-empty file_key.\n\
              {PDF_STATEMENT_HINT}"
         );
+    }
+
+    if is_pdf_key(file_key) {
+        return export_pdf(file_key, explicit_sections, output_path, output_format).await;
     }
 
     let ctx = crate::openapi::statement();
@@ -285,6 +426,84 @@ async fn cmd_export(
     Ok(())
 }
 
+/// PDF statements are listed with keys ending in `.pdf`.
+fn is_pdf_key(file_key: &str) -> bool {
+    file_key.trim().to_ascii_lowercase().ends_with(".pdf")
+}
+
+/// File name for a PDF key such as
+/// `*lb-statement*lb*1*202403*statement-monthly-202403-H10062184.pdf`.
+fn pdf_file_name(file_key: &str) -> String {
+    let last = file_key
+        .trim()
+        .rsplit(['*', '/'])
+        .next()
+        .unwrap_or("")
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+        .collect::<String>();
+    if last.is_empty() || last == ".pdf" {
+        "statement.pdf".to_string()
+    } else {
+        last
+    }
+}
+
+/// Where to write the PDF: `-o` names a directory (existing, or ending in
+/// `/`) to drop the file into, or the file path itself; without `-o` the file
+/// lands in the current directory under its own name.
+fn pdf_output_path(output: Option<&str>, file_name: &str) -> std::path::PathBuf {
+    match output {
+        None => std::path::PathBuf::from(file_name),
+        Some(dir) if dir.ends_with('/') || std::path::Path::new(dir).is_dir() => {
+            std::path::Path::new(dir).join(file_name)
+        }
+        Some(path) => std::path::PathBuf::from(path),
+    }
+}
+
+/// Download a PDF statement and save it, printing the password that opens it.
+async fn export_pdf(
+    file_key: &str,
+    explicit_sections: bool,
+    output_path: Option<&str>,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    if explicit_sections {
+        eprintln!(
+            "Note: this statement is a PDF; --section does not apply and the whole file is saved."
+        );
+    }
+    let dl = crate::openapi::statement::pdf_download(file_key).await?;
+
+    let http = reqwest::Client::new().get(&dl.url).send().await?;
+    let status = http.status().as_u16();
+    let bytes = http.bytes().await?;
+    if !(200..300).contains(&status) || !bytes.starts_with(b"%PDF") {
+        let excerpt: String = String::from_utf8_lossy(&bytes[..bytes.len().min(300)]).into();
+        anyhow::bail!("PDF statement download failed (HTTP {status}):\n{excerpt}");
+    }
+
+    let path = pdf_output_path(output_path, &pdf_file_name(file_key));
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, &bytes)?;
+
+    if matches!(output_format, OutputFormat::Json) {
+        let out = serde_json::json!({
+            "file": path.display().to_string(),
+            "password": dl.pass,
+            "cache_key": dl.cache_key,
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        println!("Saved PDF statement to {}", path.display());
+        println!("Password: {}", dl.pass);
+    }
+    Ok(())
+}
+
 /// Parse the downloaded statement body, reporting HTTP status, content type
 /// and a body excerpt when it is not the expected JSON document.
 ///
@@ -313,8 +532,7 @@ fn parse_statement_body(status: u16, content_type: Option<&str>, body: &str) -> 
     let mut value: Value = serde_json::from_str(body).map_err(|e| {
         anyhow::anyhow!(
             "Statement download did not return JSON ({e}).\n{}\n\
-             No statement file exists behind this file_key (the list may show an empty \
-             file_key for that period).\n{PDF_STATEMENT_HINT}",
+             No JSON statement exists behind this file_key.\n{PDF_STATEMENT_HINT}",
             describe()
         )
     })?;
@@ -1305,7 +1523,9 @@ pub(crate) fn schema_for_path(path: &[String]) -> Option<super::schema::Response
 
     let command = path.join(" ");
     let schema = match command.as_str() {
-        "statement" | "statement list" => array("Available statements", &["date", "file_key"]),
+        "statement" | "statement list" => {
+            array("Available statements", &["date", "file_key", "format"])
+        }
         "statement export" => object("Exported statement sections", statement_section_fields()),
         _ => return None,
     };
@@ -1414,6 +1634,99 @@ fn markdown_cell_width(cell: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pdf(display_name: &str, key: &str) -> PdfStatementItem {
+        PdfStatementItem {
+            display_name: display_name.to_string(),
+            key: key.to_string(),
+            cache_key: String::new(),
+        }
+    }
+
+    #[test]
+    fn pdf_fills_only_dates_without_a_json_file() {
+        let json = vec![
+            (202403, String::new()),
+            (202408, "/statement_data/x/202408.json".to_string()),
+        ];
+        let pdf = vec![
+            pdf("2024.03", "*a*202403.pdf"),
+            pdf("2024.05", "*a*202405.pdf"),
+            pdf("2024.08", "*a*202408.pdf"),
+        ];
+        let rows = merge_statement_rows(&json, &pdf, 10);
+        let got: Vec<(&str, &str, &str)> = rows
+            .iter()
+            .map(|r| (r.date.as_str(), r.file_key.as_str(), r.format))
+            .collect();
+        assert_eq!(
+            got,
+            [
+                ("202403", "*a*202403.pdf", "pdf"),
+                ("202405", "*a*202405.pdf", "pdf"),
+                ("202408", "/statement_data/x/202408.json", "json"),
+            ]
+        );
+        assert_eq!(merge_statement_rows(&json, &pdf, 2).len(), 2);
+    }
+
+    #[test]
+    fn pdf_window_skips_periods_that_always_have_json() {
+        let full = vec![(202501, "k".to_string()), (202502, "k".to_string())];
+        assert_eq!(pdf_fill_window(20250101, &full, 2, "202609"), None);
+        // Complete JSON coverage inside 2024 needs no PDF lookup either.
+        let complete = vec![(202411, "k".to_string()), (202412, "k".to_string())];
+        assert_eq!(pdf_fill_window(20241101, &complete, 2, "202609"), None);
+    }
+
+    #[test]
+    fn pdf_window_covers_gaps_and_caps_at_last_pdf_month() {
+        // Empty key -> gap; JSON window runs into 2025 but PDFs stop at 2024-12.
+        let json = vec![(202403, String::new()), (202501, "k".to_string())];
+        assert_eq!(
+            pdf_fill_window(20240301, &json, 2, "202609"),
+            Some(("202403".to_string(), "202412".to_string()))
+        );
+        // A month missing from the middle of a full-length list is a gap.
+        let holes = vec![(202404, "k".to_string()), (202407, "k".to_string())];
+        assert_eq!(
+            pdf_fill_window(20240401, &holes, 2, "202609"),
+            Some(("202404".to_string(), "202407".to_string()))
+        );
+        // Fewer rows than asked for: window extends to now, capped at 2024-12.
+        let short = vec![(20240319, "k".to_string())];
+        assert_eq!(
+            pdf_fill_window(20240301, &short, 30, "202609"),
+            Some(("202403".to_string(), "202412".to_string()))
+        );
+    }
+
+    #[test]
+    fn pdf_key_detection_and_file_name() {
+        let key = "*lb-statement*lb*1*202403*statement-monthly-202403-H10062184.pdf";
+        assert!(is_pdf_key(key));
+        assert!(!is_pdf_key(
+            "/statement_data/data/lb/1/202411/10000104.json"
+        ));
+        assert_eq!(pdf_file_name(key), "statement-monthly-202403-H10062184.pdf");
+        assert_eq!(pdf_file_name("*.pdf"), "statement.pdf");
+    }
+
+    #[test]
+    fn pdf_output_path_treats_trailing_slash_as_directory() {
+        assert_eq!(
+            pdf_output_path(None, "a.pdf"),
+            std::path::PathBuf::from("a.pdf")
+        );
+        assert_eq!(
+            pdf_output_path(Some("out/"), "a.pdf"),
+            std::path::PathBuf::from("out/a.pdf")
+        );
+        assert_eq!(
+            pdf_output_path(Some("out/x.pdf"), "a.pdf"),
+            std::path::PathBuf::from("out/x.pdf")
+        );
+    }
 
     #[test]
     fn explicit_sections_override_default_all() {

--- a/src/cli/statement.rs
+++ b/src/cli/statement.rs
@@ -136,6 +136,14 @@ const ALL_SECTIONS: &[StatementSection] = &[
     StatementSection::GstDetails,
 ];
 
+/// Where to find statements that predate the JSON statement service.
+///
+/// Statements issued before 2024-08 were delivered only as password-protected
+/// PDFs, so there is usually no JSON file behind the API for those periods.
+const PDF_STATEMENT_HINT: &str = "Statements issued before 2024-08 were delivered only as \
+    password-protected PDFs: download them from the Longbridge app or use the PDF attached \
+    to the statement email (the email explains the password format).";
+
 /// Explicit `--section` values win; `--all` (the default) selects every
 /// section. `--all` defaults to true, so an explicit `--section` must be
 /// checked first or it would never take effect.
@@ -163,7 +171,8 @@ async fn cmd_export(
     if file_key.trim().is_empty() {
         anyhow::bail!(
             "Empty --file-key: this statement has no downloadable file. \
-             Use `longbridge statement list` and pick an entry with a non-empty file_key."
+             Use `longbridge statement list` and pick an entry with a non-empty file_key.\n\
+             {PDF_STATEMENT_HINT}"
         );
     }
 
@@ -297,7 +306,7 @@ fn parse_statement_body(status: u16, content_type: Option<&str>, body: &str) -> 
     if body.trim().is_empty() {
         anyhow::bail!(
             "Statement download returned an empty body ({}). \
-             The file behind this file_key is not available for download.",
+             The file behind this file_key is not available for download.\n{PDF_STATEMENT_HINT}",
             describe()
         );
     }
@@ -305,7 +314,7 @@ fn parse_statement_body(status: u16, content_type: Option<&str>, body: &str) -> 
         anyhow::anyhow!(
             "Statement download did not return JSON ({e}).\n{}\n\
              No statement file exists behind this file_key (the list may show an empty \
-             file_key for that period); request it from Longbridge support.",
+             file_key for that period).\n{PDF_STATEMENT_HINT}",
             describe()
         )
     })?;

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -8,6 +8,7 @@ pub mod news;
 pub mod quote;
 pub mod rate_limiter;
 pub mod search;
+pub mod statement;
 pub mod wrapper;
 
 pub use agent::{AuthenticationRequiredAgent, OpenApiAgent};

--- a/src/openapi/statement.rs
+++ b/src/openapi/statement.rs
@@ -27,16 +27,22 @@ struct PdfStatementList {
 }
 
 /// Response of `GET /v1/statement/pdf/download`.
+///
+/// The PDF is password-protected; the password is not part of the response
+/// but follows a fixed rule, see [`PDF_PASSWORD_RULE`].
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct PdfDownload {
     /// Presigned URL of the PDF file.
     pub url: String,
-    /// Password that unlocks the PDF.
-    #[serde(default)]
-    pub pass: String,
     #[serde(default)]
     pub cache_key: String,
 }
+
+/// How to unlock a downloaded PDF statement, shown after every download.
+pub const PDF_PASSWORD_RULE: &str = "The PDF is password-protected. Password: the last 4 digits \
+    of the mobile number used for the account + the last 4 characters of the ID used for account \
+    opening, uppercase letters and digits only (drop brackets and other symbols). Example: mobile \
+    12345678 and ID 123456(X) give 5678456X.";
 
 /// Statement kind as the PDF endpoints encode it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/openapi/statement.rs
+++ b/src/openapi/statement.rs
@@ -1,0 +1,135 @@
+//! PDF statement endpoints (`/v1/statement/pdf/*`).
+//!
+//! Statements issued before the JSON statement service exist only as
+//! password-protected PDFs. These endpoints list them and return a presigned
+//! download URL together with the PDF password. The SDK has no wrapper for
+//! them yet, so they are called through the shared authenticated HTTP client.
+
+use anyhow::{Context, Result};
+use longbridge::httpclient::{Json, Method};
+use serde::{Deserialize, Serialize};
+
+/// One PDF statement as listed by `GET /v1/statement/pdf/list`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PdfStatementItem {
+    /// Display label, e.g. `2024.03` (monthly) or `2024.03.19` (daily).
+    pub display_name: String,
+    /// Opaque file key for `pdf_download`, ends with `.pdf`.
+    pub key: String,
+    #[serde(default)]
+    pub cache_key: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct PdfStatementList {
+    #[serde(default)]
+    items: Vec<PdfStatementItem>,
+}
+
+/// Response of `GET /v1/statement/pdf/download`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PdfDownload {
+    /// Presigned URL of the PDF file.
+    pub url: String,
+    /// Password that unlocks the PDF.
+    #[serde(default)]
+    pub pass: String,
+    #[serde(default)]
+    pub cache_key: String,
+}
+
+/// Statement kind as the PDF endpoints encode it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PdfStatementKind {
+    Daily = 0,
+    Monthly = 1,
+}
+
+/// Largest page the endpoint accepts.
+const PAGE_SIZE: u32 = 100;
+
+/// `GET /v1/statement/pdf/list` — every PDF statement of `kind` whose month
+/// falls in `start_month..=end_month` (both `yyyyMM`), following pagination.
+pub async fn pdf_statements(
+    kind: PdfStatementKind,
+    start_month: &str,
+    end_month: &str,
+) -> Result<Vec<PdfStatementItem>> {
+    let mut all = Vec::new();
+    let mut page = 1u32;
+    loop {
+        let items = pdf_statements_page(kind, start_month, end_month, page).await?;
+        let last = items.len() < PAGE_SIZE as usize;
+        all.extend(items);
+        if last {
+            return Ok(all);
+        }
+        page += 1;
+    }
+}
+
+async fn pdf_statements_page(
+    kind: PdfStatementKind,
+    start_month: &str,
+    end_month: &str,
+    page: u32,
+) -> Result<Vec<PdfStatementItem>> {
+    #[derive(Serialize)]
+    struct Query<'a> {
+        kind: i32,
+        start_dt: &'a str,
+        end_dt: &'a str,
+        page: u32,
+        size: u32,
+    }
+    let start_month = start_month.to_string();
+    let end_month = end_month.to_string();
+    let resp = crate::openapi::global_rate_limiter()
+        .execute("statement_pdf_list", || {
+            let start_month = start_month.clone();
+            let end_month = end_month.clone();
+            Box::pin(async move {
+                crate::openapi::http_client()
+                    .request(Method::GET, "/v1/statement/pdf/list")
+                    .query_params(Query {
+                        kind: kind as i32,
+                        start_dt: &start_month,
+                        end_dt: &end_month,
+                        page,
+                        size: PAGE_SIZE,
+                    })
+                    .response::<Json<PdfStatementList>>()
+                    .send()
+                    .await
+                    .map(|json| json.0)
+            })
+        })
+        .await
+        .context("Failed to list PDF statements")?;
+    Ok(resp.items)
+}
+
+/// `GET /v1/statement/pdf/download` — presigned URL and password for `key`.
+pub async fn pdf_download(key: &str) -> Result<PdfDownload> {
+    #[derive(Serialize)]
+    struct Query<'a> {
+        key: &'a str,
+    }
+    let key = key.to_string();
+    let resp = crate::openapi::global_rate_limiter()
+        .execute("statement_pdf_download", || {
+            let key = key.clone();
+            Box::pin(async move {
+                crate::openapi::http_client()
+                    .request(Method::GET, "/v1/statement/pdf/download")
+                    .query_params(Query { key: &key })
+                    .response::<Json<PdfDownload>>()
+                    .send()
+                    .await
+                    .map(|json| json.0)
+            })
+        })
+        .await
+        .context("Failed to get PDF statement download URL")?;
+    Ok(resp)
+}

--- a/src/utils/json.rs
+++ b/src/utils/json.rs
@@ -1,0 +1,392 @@
+//! Generic JSON helpers: null stripping and flattening arbitrary documents
+//! into tables for export.
+
+use serde_json::{Map, Value};
+
+/// Recursively remove object entries whose value is `null`, and drop `null`
+/// elements from arrays.
+///
+/// Older statement files serialize empty sections as `null` instead of `[]`,
+/// which `#[serde(default)]` does not tolerate (it only fills *missing* keys).
+/// Stripping nulls first makes those files deserialize like current ones.
+pub fn strip_nulls(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            map.retain(|_, v| !v.is_null());
+            for v in map.values_mut() {
+                strip_nulls(v);
+            }
+        }
+        Value::Array(items) => {
+            items.retain(|v| !v.is_null());
+            for v in items {
+                strip_nulls(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// A table derived from one node of a JSON document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlatTable {
+    /// File-name-friendly identifier, e.g. `stock_holding_details_stock_holding`.
+    pub name: String,
+    /// Human-readable title, e.g. `StockHoldingDetails / StockHolding`.
+    pub title: String,
+    pub headers: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+}
+
+/// Flatten an arbitrary JSON document into tables, one per object or array
+/// node, so a document with an unknown schema can still be exported.
+///
+/// Rules:
+/// - Scalar fields of an object become one row; nested objects are flattened
+///   into dotted columns (`Fee.Amount`).
+/// - An array of objects becomes one table; array-valued fields of its
+///   elements become sub-tables whose rows carry the parent's scalar fields
+///   as leading context columns (e.g. `Market` on each holding row).
+/// - Tables with no rows are omitted.
+pub fn flatten_tables(value: &Value) -> Vec<FlatTable> {
+    let mut out = Vec::new();
+    walk(&mut out, &[], value, &[]);
+    out
+}
+
+type Context = Vec<(String, String)>;
+
+fn walk(out: &mut Vec<FlatTable>, path: &[String], value: &Value, context: &[(String, String)]) {
+    match value {
+        Value::Object(map) => walk_object(out, path, map, context),
+        Value::Array(items) => walk_array(out, path, items, context),
+        _ => {}
+    }
+}
+
+fn walk_object(
+    out: &mut Vec<FlatTable>,
+    path: &[String],
+    map: &Map<String, Value>,
+    context: &[(String, String)],
+) {
+    let scalars = scalar_columns(map, "");
+    if !scalars.is_empty() {
+        let (headers, row) = with_context(context, scalars);
+        push_table(out, path, headers, vec![row]);
+    }
+    for (key, child) in map {
+        if child.is_object() && !is_flat_object(child) || child.is_array() {
+            let child_path = join_path(path, key);
+            walk(out, &child_path, child, context);
+        }
+    }
+}
+
+fn walk_array(
+    out: &mut Vec<FlatTable>,
+    path: &[String],
+    items: &[Value],
+    context: &[(String, String)],
+) {
+    let objects: Vec<&Map<String, Value>> = items.iter().filter_map(Value::as_object).collect();
+    if objects.is_empty() {
+        let rows: Vec<Vec<String>> = items
+            .iter()
+            .filter(|v| !v.is_object() && !v.is_array())
+            .map(|v| {
+                let (_, row) = with_context(context, vec![("Value".to_string(), scalar_text(v))]);
+                row
+            })
+            .collect();
+        let (headers, _) = with_context(context, vec![("Value".to_string(), String::new())]);
+        push_table(out, path, headers, rows);
+        return;
+    }
+
+    // Union of scalar column names across elements, in first-seen order.
+    let mut columns: Vec<String> = Vec::new();
+    let per_row: Vec<Vec<(String, String)>> = objects
+        .iter()
+        .map(|obj| {
+            let cols = scalar_columns(obj, "");
+            for (k, _) in &cols {
+                if !columns.contains(k) {
+                    columns.push(k.clone());
+                }
+            }
+            cols
+        })
+        .collect();
+
+    let mut headers: Vec<String> = context.iter().map(|(k, _)| k.clone()).collect();
+    headers.extend(columns.iter().cloned());
+    let rows: Vec<Vec<String>> = per_row
+        .iter()
+        .map(|cols| {
+            let mut row: Vec<String> = context.iter().map(|(_, v)| v.clone()).collect();
+            for col in &columns {
+                row.push(
+                    cols.iter()
+                        .find(|(k, _)| k == col)
+                        .map(|(_, v)| v.clone())
+                        .unwrap_or_default(),
+                );
+            }
+            row
+        })
+        .collect();
+    push_table(out, path, headers, rows);
+
+    // Array-valued fields inside elements become sub-tables with the element's
+    // scalars as context, merged across all elements.
+    let mut sub_keys: Vec<String> = Vec::new();
+    for obj in &objects {
+        for (k, v) in *obj {
+            if v.is_array() && !sub_keys.contains(k) {
+                sub_keys.push(k.clone());
+            }
+        }
+    }
+    for key in sub_keys {
+        let sub_path = join_path(path, &key);
+        let mut merged = FlatTableBuilder::default();
+        for (obj, cols) in objects.iter().zip(&per_row) {
+            let Some(Value::Array(children)) = obj.get(&key) else {
+                continue;
+            };
+            let mut ctx: Context = context.to_vec();
+            ctx.extend(cols.iter().cloned());
+            let mut tmp = Vec::new();
+            walk_array(&mut tmp, &sub_path, children, &ctx);
+            for t in tmp {
+                merged.absorb(t);
+            }
+        }
+        out.extend(merged.finish());
+    }
+}
+
+/// Accumulates tables produced per element into one table per name, so a
+/// sub-array spread across many parent elements yields a single table.
+#[derive(Default)]
+struct FlatTableBuilder {
+    tables: Vec<FlatTable>,
+}
+
+impl FlatTableBuilder {
+    fn absorb(&mut self, table: FlatTable) {
+        if let Some(existing) = self.tables.iter_mut().find(|t| t.name == table.name) {
+            if existing.headers == table.headers {
+                existing.rows.extend(table.rows);
+            } else {
+                // Column sets differ between parents: re-align rows by header name.
+                for h in &table.headers {
+                    if !existing.headers.contains(h) {
+                        existing.headers.push(h.clone());
+                        for row in &mut existing.rows {
+                            row.push(String::new());
+                        }
+                    }
+                }
+                for row in table.rows {
+                    let mut aligned = vec![String::new(); existing.headers.len()];
+                    for (h, v) in table.headers.iter().zip(row) {
+                        if let Some(i) = existing.headers.iter().position(|x| x == h) {
+                            aligned[i] = v;
+                        }
+                    }
+                    existing.rows.push(aligned);
+                }
+            }
+        } else {
+            self.tables.push(table);
+        }
+    }
+
+    fn finish(self) -> Vec<FlatTable> {
+        self.tables
+    }
+}
+
+fn with_context(
+    context: &[(String, String)],
+    cols: Vec<(String, String)>,
+) -> (Vec<String>, Vec<String>) {
+    let mut headers: Vec<String> = context.iter().map(|(k, _)| k.clone()).collect();
+    let mut row: Vec<String> = context.iter().map(|(_, v)| v.clone()).collect();
+    for (k, v) in cols {
+        headers.push(k);
+        row.push(v);
+    }
+    (headers, row)
+}
+
+/// Scalar fields of `map`, with nested flat objects flattened into dotted keys.
+fn scalar_columns(map: &Map<String, Value>, prefix: &str) -> Vec<(String, String)> {
+    let mut cols = Vec::new();
+    for (k, v) in map {
+        let name = if prefix.is_empty() {
+            k.clone()
+        } else {
+            format!("{prefix}.{k}")
+        };
+        match v {
+            Value::Object(inner) if is_flat_object(v) => cols.extend(scalar_columns(inner, &name)),
+            Value::Object(_) | Value::Array(_) | Value::Null => {}
+            other => cols.push((name, scalar_text(other))),
+        }
+    }
+    cols
+}
+
+/// An object whose values are all scalars (or nested flat objects) is
+/// flattened into its parent's row rather than becoming its own table.
+fn is_flat_object(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => map.values().all(|v| match v {
+            Value::Array(_) => false,
+            Value::Object(_) => is_flat_object(v),
+            _ => true,
+        }),
+        _ => false,
+    }
+}
+
+fn scalar_text(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+fn join_path(path: &[String], key: &str) -> Vec<String> {
+    let mut p = path.to_vec();
+    p.push(key.to_string());
+    p
+}
+
+fn push_table(
+    out: &mut Vec<FlatTable>,
+    path: &[String],
+    headers: Vec<String>,
+    rows: Vec<Vec<String>>,
+) {
+    if rows.is_empty() {
+        return;
+    }
+    let name = if path.is_empty() {
+        "document".to_string()
+    } else {
+        path.iter()
+            .map(|s| to_snake_case(s))
+            .collect::<Vec<_>>()
+            .join("_")
+    };
+    let title = if path.is_empty() {
+        "Document".to_string()
+    } else {
+        path.join(" / ")
+    };
+    out.push(FlatTable {
+        name,
+        title,
+        headers,
+        rows,
+    });
+}
+
+/// `StockHoldingDetails` -> `stock_holding_details`.
+pub fn to_snake_case(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    let chars: Vec<char> = s.chars().collect();
+    for (i, c) in chars.iter().enumerate() {
+        if c.is_uppercase() {
+            let prev_lower =
+                i > 0 && (chars[i - 1].is_lowercase() || chars[i - 1].is_ascii_digit());
+            let next_lower = chars.get(i + 1).is_some_and(|n| n.is_lowercase());
+            if i > 0 && (prev_lower || next_lower) && !out.ends_with('_') {
+                out.push('_');
+            }
+            out.extend(c.to_lowercase());
+        } else if c.is_alphanumeric() {
+            out.push(*c);
+        } else if !out.ends_with('_') {
+            out.push('_');
+        }
+    }
+    out.trim_matches('_').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn strip_nulls_removes_null_entries_recursively() {
+        let mut v = json!({"a": null, "b": {"c": null, "d": 1}, "e": [null, {"f": null}]});
+        strip_nulls(&mut v);
+        assert_eq!(v, json!({"b": {"d": 1}, "e": [{}]}));
+    }
+
+    #[test]
+    fn snake_case_handles_acronyms_and_digits() {
+        assert_eq!(
+            to_snake_case("StockHoldingDetails"),
+            "stock_holding_details"
+        );
+        assert_eq!(to_snake_case("Fee0Name"), "fee0_name");
+        assert_eq!(to_snake_case("IPOSub"), "ipo_sub");
+    }
+
+    #[test]
+    fn flattens_legacy_statement_shape() {
+        let doc = json!({
+            "Date": "2021.11.30",
+            "AssetDetail": {"Cash": "1", "Total": "2"},
+            "CashDetails": {
+                "Currency": "HKD",
+                "CashDetail": [{"Currency": "HKD", "Amount": "1"}, {"Currency": "USD", "Amount": "2"}]
+            },
+            "StockHoldingDetails": [
+                {"Market": "US", "StockHolding": [{"StName": "DAL", "Total": "199"}]},
+                {"Market": "HK", "StockHolding": [{"StName": "00175", "Total": "1000"}]}
+            ],
+            "Empty": null,
+            "Nothing": []
+        });
+        let tables = flatten_tables(&doc);
+        let names: Vec<&str> = tables.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(
+            names,
+            [
+                "document",
+                "cash_details",
+                "cash_details_cash_detail",
+                "stock_holding_details",
+                "stock_holding_details_stock_holding",
+            ]
+        );
+
+        let doc_table = &tables[0];
+        assert_eq!(
+            doc_table.headers,
+            ["Date", "AssetDetail.Cash", "AssetDetail.Total"]
+        );
+        assert_eq!(doc_table.rows, [["2021.11.30", "1", "2"]]);
+
+        let holdings = &tables[4];
+        assert_eq!(holdings.title, "StockHoldingDetails / StockHolding");
+        assert_eq!(holdings.headers, ["Market", "StName", "Total"]);
+        assert_eq!(
+            holdings.rows,
+            [["US", "DAL", "199"], ["HK", "00175", "1000"]]
+        );
+
+        let cash = &tables[2];
+        assert_eq!(cash.headers, ["Currency", "Amount"]);
+        assert_eq!(cash.rows.len(), 2);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod cycle;
 pub mod datetime;
 pub mod decimal_ext;
 pub mod dry_run;
+pub mod json;
 pub mod number;
 pub mod text;
 


### PR DESCRIPTION
## Summary

`longbridge statement export` only worked for statements issued from 2024-08 onward. Investigating a user report ("can export 202411 but nothing earlier, `Error: expected value at line 1 column 1`") showed three distinct eras of statement files behind `/v1/statement/download`:

| Issued | Server-side file | Before | After |
|---|---|---|---|
| 2021-11 – 2022-02 | JSON in a legacy layout (`AssetDetail`, `CashDetails`, `StockHoldingDetails`, …) | silently exported empty tables | exported as generic tables; `--format json` prints the raw document |
| 2022-03 – 2022-11 | current layout, empty sections serialized as `null` | `invalid type: null, expected a sequence` | exports normally |
| 2022-12 – 2024-07 | no file at all (`file_key` is empty in `statement list`; a guessed key gets an S3 404 XML) | `expected value at line 1 column 1` | error shows HTTP status, content type and body excerpt, and says no file exists for that period |
| 2024-08 – now | current layout | works | unchanged (JSON output verified byte-identical) |

## User-visible changes

- Legacy statements are exported by flattening the document: one table per section, with parent fields such as `Market` carried as leading columns. `--section` does not apply to that layout and is ignored with a note.
- Statements with `null` sections no longer fail to parse.
- A download that does not return JSON reports what came back instead of a bare serde error; an empty `--file-key` is rejected with a hint to pick an entry from `statement list`.
- An explicit `--section` now takes effect. `--all` defaults to true and previously always won, so `--section asset -o asset.csv` created a directory named `asset.csv` instead of a file.
- Account balances in pre-2024-08 files show the currency (they only carry `Currency`, not `CurrencyCode`).
- Also fixes the pre-existing clippy `question_mark` error in `src/cli/agent/client.rs` so `cargo clippy` is clean.

## PDF statements for periods without JSON

Statements issued before 2024-08 were delivered only as password-protected PDFs. The backend now exposes them through `GET /v1/statement/pdf/list` and `GET /v1/statement/pdf/download` (same parameters as the app's `/v1/portfolio/statement/list` and `/url`), so the CLI fills them in where JSON is missing:

- `statement list` keeps the JSON list as the source of truth. Only when the request reaches into 2024-12 or earlier and the JSON list falls short (an entry without a file, fewer entries than asked for, or a month missing from the window) does it consult the PDF list, and PDF entries fill those dates only. A new `format` column (`json` / `pdf`) says which kind each row is; requests from 2025-01 on never touch the PDF endpoint.
- `statement export` with a `.pdf` file key downloads the PDF, saves it (into `-o` as a directory or file path, else the current directory under its own name) and prints how to unlock it: the password is rule-based (last 4 digits of the mobile number + last 4 characters of the account-opening ID, uppercase letters and digits only, e.g. mobile 12345678 and ID 123456(X) give `5678456X`). `--format json` returns `file`, `cache_key` and `password_rule`. `--section` does not apply and is noted.
- The `statement` help text, the errors for a missing JSON file, and the README describe the PDF fill-in.

Verified live on a real account: `statement list --type monthly --start-date 2024-01-01` now lists 2024-01..07 as PDF rows and 2024-08..12 as JSON rows; the 2024-03 monthly PDF downloads as a 3-page PDF 1.4 file followed by the password rule; 2025 requests list `json` only.

## Test plan

- [x] `cargo fmt && cargo clippy` clean
- [x] `cargo test` (842 passed)
- [x] Live: exported 202111 and 202202 (legacy), 202203 (null sections), 202411 (current) from a real account; 202411 `--format json` identical to the released 0.28.4 binary
- [x] Live: missing key now reports `HTTP 404, content-type: application/xml` with the S3 error body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvQduY84wqvhc2MYkR44pq



